### PR TITLE
Make Boost.SIMD interoperable with Boost.Dispatch

### DIFF
--- a/include/boost/simd/arch/common/scalar/function/eps.hpp
+++ b/include/boost/simd/arch/common/scalar/function/eps.hpp
@@ -27,13 +27,14 @@ namespace boost { namespace simd { namespace ext
 {
   namespace bd = boost::dispatch;
   namespace bs = boost::simd;
+
   BOOST_DISPATCH_OVERLOAD ( eps_
                           , (typename A0)
                           , bd::cpu_
                           , bd::scalar_< bd::arithmetic_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const &) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE A0 operator()( A0 ) const BOOST_NOEXCEPT
     {
       return One<A0>();
     }

--- a/include/boost/simd/arch/limits.hpp
+++ b/include/boost/simd/arch/limits.hpp
@@ -15,6 +15,7 @@
 #ifndef BOOST_SIMD_ARCH_LIMITS_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_LIMITS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/arch/power/limits.hpp>
 #include <boost/simd/arch/arm/limits.hpp>
 #include <boost/simd/arch/x86/limits.hpp>

--- a/include/boost/simd/arch/tags.hpp
+++ b/include/boost/simd/arch/tags.hpp
@@ -15,6 +15,7 @@
 #ifndef BOOST_SIMD_ARCH_TAGS_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_TAGS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/arch/common/tags.hpp>
 #include <boost/simd/arch/power/tags.hpp>
 #include <boost/simd/arch/arm/tags.hpp>

--- a/include/boost/simd/arch/x86/ssse3/spec.hpp
+++ b/include/boost/simd/arch/x86/ssse3/spec.hpp
@@ -23,7 +23,7 @@
   #define BOOST_SIMD_DEFAULT_FAMILY  ::boost::simd::sse_
 #endif
 
-#define BOOST_SIMD_DEFAULT_SITE       ::boost::simd::sss3e_
+#define BOOST_SIMD_DEFAULT_SITE       ::boost::simd::ssse3_
 
 #include <tmmintrin.h>
 #include <boost/simd/arch/x86/sse2/as_simd.hpp>

--- a/include/boost/simd/as.hpp
+++ b/include/boost/simd/as.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_AS_HPP_INCLUDED
 #define BOOST_SIMD_AS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/as.hpp>
 
 namespace boost { namespace simd

--- a/include/boost/simd/cardinal_of.hpp
+++ b/include/boost/simd/cardinal_of.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_CARDINAL_OF_HPP_INCLUDED
 #define BOOST_SIMD_CARDINAL_OF_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/core/ignore_unused.hpp>
 #include <boost/config.hpp>
 #include <type_traits>

--- a/include/boost/simd/config.hpp
+++ b/include/boost/simd/config.hpp
@@ -2,7 +2,7 @@
 /*!
   @file
 
-  Defines various macro for controlling math functions behavior
+  Defines various macro for controlling Boost.SIMD behavior
 
   @copyright 2015 LRI UMR 8623 CNRS/Univ Paris Sud XI
   @copyright 2015 NumScale SAS
@@ -14,6 +14,13 @@
 //==================================================================================================
 #ifndef BOOST_SIMD_CONFIG_HPP_INCLUDED
 #define BOOST_SIMD_CONFIG_HPP_INCLUDED
+
+// Setup the dispatch default architecture
+#if !defined(BOOST_DISPATCH_DEFAULT_SITE)
+#  include <boost/simd/arch.hpp>
+#  define BOOST_DISPATCH_DEFAULT_SITE BOOST_SIMD_DEFAULT_SITE
+#  include <boost/dispatch/hierarchy/default_site.hpp>
+#endif
 
 #if defined(__FAST_MATH__) && !defined(BOOST_SIMD_FAST_MATH) || defined(DOXYGEN_ONLY)
 

--- a/include/boost/simd/config.hpp
+++ b/include/boost/simd/config.hpp
@@ -17,7 +17,7 @@
 
 // Setup the dispatch default architecture
 #if !defined(BOOST_DISPATCH_DEFAULT_SITE)
-#  include <boost/simd/arch.hpp>
+#  include <boost/simd/arch/spec.hpp>
 #  define BOOST_DISPATCH_DEFAULT_SITE BOOST_SIMD_DEFAULT_SITE
 #  include <boost/dispatch/hierarchy/default_site.hpp>
 #endif

--- a/include/boost/simd/constant/definition/allbits.hpp
+++ b/include/boost/simd/constant/definition/allbits.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_ALLBITS_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_ALLBITS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/bitincrement.hpp
+++ b/include/boost/simd/constant/definition/bitincrement.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_BITINCREMENT_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_BITINCREMENT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/cgold.hpp
+++ b/include/boost/simd/constant/definition/cgold.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_CGOLD_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_CGOLD_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/constant.hpp
+++ b/include/boost/simd/constant/definition/constant.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_CONSTANT_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_CONSTANT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>
 #include <boost/dispatch/function/make_callable.hpp>

--- a/include/boost/simd/constant/definition/eight.hpp
+++ b/include/boost/simd/constant/definition/eight.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_EIGHT_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_EIGHT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/eps.hpp
+++ b/include/boost/simd/constant/definition/eps.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_EPS_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_EPS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/euler.hpp
+++ b/include/boost/simd/constant/definition/euler.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_EULER_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_EULER_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/exp_1.hpp
+++ b/include/boost/simd/constant/definition/exp_1.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_EXP_1_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_EXP_1_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/expnibig.hpp
+++ b/include/boost/simd/constant/definition/expnibig.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_EXPNIBIG_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_EXPNIBIG_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/fact_10.hpp
+++ b/include/boost/simd/constant/definition/fact_10.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_FACT_10_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_FACT_10_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/fact_11.hpp
+++ b/include/boost/simd/constant/definition/fact_11.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_FACT_11_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_FACT_11_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/fact_12.hpp
+++ b/include/boost/simd/constant/definition/fact_12.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_FACT_12_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_FACT_12_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/fact_4.hpp
+++ b/include/boost/simd/constant/definition/fact_4.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_FACT_4_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_FACT_4_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/fact_5.hpp
+++ b/include/boost/simd/constant/definition/fact_5.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_FACT_5_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_FACT_5_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/fact_6.hpp
+++ b/include/boost/simd/constant/definition/fact_6.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_FACT_6_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_FACT_6_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/fact_7.hpp
+++ b/include/boost/simd/constant/definition/fact_7.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_FACT_7_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_FACT_7_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/fact_8.hpp
+++ b/include/boost/simd/constant/definition/fact_8.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_FACT_8_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_FACT_8_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/fact_9.hpp
+++ b/include/boost/simd/constant/definition/fact_9.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_FACT_9_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_FACT_9_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/false.hpp
+++ b/include/boost/simd/constant/definition/false.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_FALSE_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_FALSE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/dispatch/function/make_callable.hpp>

--- a/include/boost/simd/constant/definition/five.hpp
+++ b/include/boost/simd/constant/definition/five.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_FIVE_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_FIVE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/four.hpp
+++ b/include/boost/simd/constant/definition/four.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_FOUR_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_FOUR_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/fourthrooteps.hpp
+++ b/include/boost/simd/constant/definition/fourthrooteps.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_FOURTHROOTEPS_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_FOURTHROOTEPS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/gold.hpp
+++ b/include/boost/simd/constant/definition/gold.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_GOLD_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_GOLD_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/greatestnoninteger.hpp
+++ b/include/boost/simd/constant/definition/greatestnoninteger.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_GREATESTNONINTEGER_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_GREATESTNONINTEGER_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/half.hpp
+++ b/include/boost/simd/constant/definition/half.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_HALF_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_HALF_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/halfeps.hpp
+++ b/include/boost/simd/constant/definition/halfeps.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_HALFEPS_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_HALFEPS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/inf.hpp
+++ b/include/boost/simd/constant/definition/inf.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_INF_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_INF_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/invexp_1.hpp
+++ b/include/boost/simd/constant/definition/invexp_1.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_INVEXP_1_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_INVEXP_1_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/invlog10_2.hpp
+++ b/include/boost/simd/constant/definition/invlog10_2.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_INVLOG10_2_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_INVLOG10_2_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/invlog_10.hpp
+++ b/include/boost/simd/constant/definition/invlog_10.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_INVLOG_10_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_INVLOG_10_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/invlog_2.hpp
+++ b/include/boost/simd/constant/definition/invlog_2.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_INVLOG_2_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_INVLOG_2_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/ldexpmask.hpp
+++ b/include/boost/simd/constant/definition/ldexpmask.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_LDEXPMASK_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_LDEXPMASK_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/limitexponent.hpp
+++ b/include/boost/simd/constant/definition/limitexponent.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_LIMITEXPONENT_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_LIMITEXPONENT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/log10_2hi.hpp
+++ b/include/boost/simd/constant/definition/log10_2hi.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_LOG10_2HI_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_LOG10_2HI_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/log10_2lo.hpp
+++ b/include/boost/simd/constant/definition/log10_2lo.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_LOG10_2LO_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_LOG10_2LO_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/log10_ehi.hpp
+++ b/include/boost/simd/constant/definition/log10_ehi.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_LOG10_EHI_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_LOG10_EHI_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/log10_elo.hpp
+++ b/include/boost/simd/constant/definition/log10_elo.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_LOG10_ELO_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_LOG10_ELO_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/log10_pi.hpp
+++ b/include/boost/simd/constant/definition/log10_pi.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_LOG10_PI_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_LOG10_PI_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/log2_e.hpp
+++ b/include/boost/simd/constant/definition/log2_e.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_LOG2_E_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_LOG2_E_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/log2_em1.hpp
+++ b/include/boost/simd/constant/definition/log2_em1.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_LOG2_EM1_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_LOG2_EM1_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/log_10.hpp
+++ b/include/boost/simd/constant/definition/log_10.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_LOG_10_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_LOG_10_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/log_2.hpp
+++ b/include/boost/simd/constant/definition/log_2.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_LOG_2_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_LOG_2_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/log_2hi.hpp
+++ b/include/boost/simd/constant/definition/log_2hi.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_LOG_2HI_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_LOG_2HI_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/log_2lo.hpp
+++ b/include/boost/simd/constant/definition/log_2lo.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_LOG_2LO_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_LOG_2LO_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/log_2olog_10.hpp
+++ b/include/boost/simd/constant/definition/log_2olog_10.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_LOG_2OLOG_10_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_LOG_2OLOG_10_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/logeps.hpp
+++ b/include/boost/simd/constant/definition/logeps.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_LOGEPS_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_LOGEPS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/logpi.hpp
+++ b/include/boost/simd/constant/definition/logpi.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_LOGPI_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_LOGPI_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/logsqrt2pi.hpp
+++ b/include/boost/simd/constant/definition/logsqrt2pi.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_LOGSQRT2PI_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_LOGSQRT2PI_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/mantissamask.hpp
+++ b/include/boost/simd/constant/definition/mantissamask.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MANTISSAMASK_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MANTISSAMASK_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/mask1frexp.hpp
+++ b/include/boost/simd/constant/definition/mask1frexp.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MASK1FREXP_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MASK1FREXP_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/mask2frexp.hpp
+++ b/include/boost/simd/constant/definition/mask2frexp.hpp
@@ -11,7 +11,8 @@
 //==================================================================================================
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MASK2FREXP_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MASK2FREXP_HPP_INCLUDED
-//TODO
+
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/maxexponent.hpp
+++ b/include/boost/simd/constant/definition/maxexponent.hpp
@@ -12,13 +12,14 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MAXEXPONENT_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MAXEXPONENT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/dispatch/as.hpp>
-//sa
+
 namespace boost { namespace simd
 {
   namespace tag

--- a/include/boost/simd/constant/definition/maxexponentm1.hpp
+++ b/include/boost/simd/constant/definition/maxexponentm1.hpp
@@ -12,13 +12,14 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MAXEXPONENTM1_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MAXEXPONENTM1_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/dispatch/as.hpp>
-//sa
+
 namespace boost { namespace simd
 {
   namespace tag

--- a/include/boost/simd/constant/definition/maxflint.hpp
+++ b/include/boost/simd/constant/definition/maxflint.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MAXFLINT_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MAXFLINT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/maxgammaln.hpp
+++ b/include/boost/simd/constant/definition/maxgammaln.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MAXGAMMALN_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MAXGAMMALN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/maxinit.hpp
+++ b/include/boost/simd/constant/definition/maxinit.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MAXINIT_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MAXINIT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/maxleftshift.hpp
+++ b/include/boost/simd/constant/definition/maxleftshift.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MAXLEFTSHIFT_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MAXLEFTSHIFT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>
@@ -19,7 +20,7 @@
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>
 #include <boost/dispatch/as.hpp>
-//TODO
+
 namespace boost { namespace simd
 {
   namespace tag

--- a/include/boost/simd/constant/definition/maxlog.hpp
+++ b/include/boost/simd/constant/definition/maxlog.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MAXLOG_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MAXLOG_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/maxlog10.hpp
+++ b/include/boost/simd/constant/definition/maxlog10.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MAXLOG10_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MAXLOG10_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/maxlog2.hpp
+++ b/include/boost/simd/constant/definition/maxlog2.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MAXLOG2_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MAXLOG2_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/meight.hpp
+++ b/include/boost/simd/constant/definition/meight.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MEIGHT_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MEIGHT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/mfive.hpp
+++ b/include/boost/simd/constant/definition/mfive.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MFIVE_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MFIVE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/mfour.hpp
+++ b/include/boost/simd/constant/definition/mfour.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MFOUR_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MFOUR_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/mhalf.hpp
+++ b/include/boost/simd/constant/definition/mhalf.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MHALF_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MHALF_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/mindenormal.hpp
+++ b/include/boost/simd/constant/definition/mindenormal.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MINDENORMAL_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MINDENORMAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/minexponent.hpp
+++ b/include/boost/simd/constant/definition/minexponent.hpp
@@ -12,13 +12,14 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MINEXPONENT_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MINEXPONENT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/dispatch/as.hpp>
-//TODO
+
 namespace boost { namespace simd
 {
   namespace tag

--- a/include/boost/simd/constant/definition/minf.hpp
+++ b/include/boost/simd/constant/definition/minf.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MINF_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MINF_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>
@@ -20,7 +21,6 @@
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/dispatch/as.hpp>
 
-//TODO link it to valmin  for integers if possible to avoid duplication
 namespace boost { namespace simd
 {
   namespace tag

--- a/include/boost/simd/constant/definition/minlog.hpp
+++ b/include/boost/simd/constant/definition/minlog.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MINLOG_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MINLOG_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/minlog10.hpp
+++ b/include/boost/simd/constant/definition/minlog10.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MINLOG10_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MINLOG10_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/minlog2.hpp
+++ b/include/boost/simd/constant/definition/minlog2.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MINLOG2_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MINLOG2_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/mlog10two2nmb.hpp
+++ b/include/boost/simd/constant/definition/mlog10two2nmb.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MLOG10TWO2NMB_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MLOG10TWO2NMB_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/mlog2two2nmb.hpp
+++ b/include/boost/simd/constant/definition/mlog2two2nmb.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MLOG2TWO2NMB_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MLOG2TWO2NMB_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/mlogeps2.hpp
+++ b/include/boost/simd/constant/definition/mlogeps2.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MLOGEPS2_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MLOGEPS2_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/mlogtwo2nmb.hpp
+++ b/include/boost/simd/constant/definition/mlogtwo2nmb.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MLOGTWO2NMB_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MLOGTWO2NMB_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/mnine.hpp
+++ b/include/boost/simd/constant/definition/mnine.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MNINE_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MNINE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/mone.hpp
+++ b/include/boost/simd/constant/definition/mone.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MONE_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MONE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/mseven.hpp
+++ b/include/boost/simd/constant/definition/mseven.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MSEVEN_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MSEVEN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/msix.hpp
+++ b/include/boost/simd/constant/definition/msix.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MSIX_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MSIX_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/mten.hpp
+++ b/include/boost/simd/constant/definition/mten.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MTEN_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MTEN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/mthree.hpp
+++ b/include/boost/simd/constant/definition/mthree.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MTHREE_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MTHREE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/mtwo.hpp
+++ b/include/boost/simd/constant/definition/mtwo.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MTWO_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MTWO_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/mzero.hpp
+++ b/include/boost/simd/constant/definition/mzero.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_MZERO_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_MZERO_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/nan.hpp
+++ b/include/boost/simd/constant/definition/nan.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_NAN_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_NAN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/nbdigits.hpp
+++ b/include/boost/simd/constant/definition/nbdigits.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_NBDIGITS_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_NBDIGITS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/nbexponentbits.hpp
+++ b/include/boost/simd/constant/definition/nbexponentbits.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_NBEXPONENTBITS_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_NBEXPONENTBITS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/nbmantissabits.hpp
+++ b/include/boost/simd/constant/definition/nbmantissabits.hpp
@@ -11,7 +11,8 @@
 //==================================================================================================
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_NBMANTISSABITS_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_NBMANTISSABITS_HPP_INCLUDED
-//TODO
+
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/nine.hpp
+++ b/include/boost/simd/constant/definition/nine.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_NINE_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_NINE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/one.hpp
+++ b/include/boost/simd/constant/definition/one.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_ONE_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_ONE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/oneosqrt5.hpp
+++ b/include/boost/simd/constant/definition/oneosqrt5.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_ONEOSQRT5_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_ONEOSQRT5_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/oneosqrteps.hpp
+++ b/include/boost/simd/constant/definition/oneosqrteps.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_ONEOSQRTEPS_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_ONEOSQRTEPS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/oneotwoeps.hpp
+++ b/include/boost/simd/constant/definition/oneotwoeps.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_ONEOTWOEPS_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_ONEOTWOEPS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/pi.hpp
+++ b/include/boost/simd/constant/definition/pi.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_PI_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_PI_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/pio_2.hpp
+++ b/include/boost/simd/constant/definition/pio_2.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_PIO_2_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_PIO_2_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/powlargelim.hpp
+++ b/include/boost/simd/constant/definition/powlargelim.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_POWLARGELIM_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_POWLARGELIM_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/powlowlim.hpp
+++ b/include/boost/simd/constant/definition/powlowlim.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_POWLOWLIM_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_POWLOWLIM_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/quarter.hpp
+++ b/include/boost/simd/constant/definition/quarter.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_QUARTER_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_QUARTER_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/ratio.hpp
+++ b/include/boost/simd/constant/definition/ratio.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_RATIO_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_RATIO_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/constant/constant.hpp>
 #include <boost/simd/detail/constant_traits.hpp>
 #include <cstdint>

--- a/include/boost/simd/constant/definition/real.hpp
+++ b/include/boost/simd/constant/definition/real.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_REAL_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_REAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/constant/constant.hpp>
 #include <boost/simd/detail/constant_traits.hpp>
 #include <cstdint>

--- a/include/boost/simd/constant/definition/seven.hpp
+++ b/include/boost/simd/constant/definition/seven.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_SEVEN_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_SEVEN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/signmask.hpp
+++ b/include/boost/simd/constant/definition/signmask.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_SIGNMASK_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_SIGNMASK_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/six.hpp
+++ b/include/boost/simd/constant/definition/six.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_SIX_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_SIX_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/smallestposval.hpp
+++ b/include/boost/simd/constant/definition/smallestposval.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_SMALLESTPOSVAL_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_SMALLESTPOSVAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/splitfactor.hpp
+++ b/include/boost/simd/constant/definition/splitfactor.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_SPLITFACTOR_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_SPLITFACTOR_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/sqrt_1o_5.hpp
+++ b/include/boost/simd/constant/definition/sqrt_1o_5.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_SQRT_1O_5_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_SQRT_1O_5_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/sqrt_2.hpp
+++ b/include/boost/simd/constant/definition/sqrt_2.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_SQRT_2_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_SQRT_2_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/sqrt_2o_2.hpp
+++ b/include/boost/simd/constant/definition/sqrt_2o_2.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_SQRT_2O_2_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_SQRT_2O_2_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/sqrt_2o_3.hpp
+++ b/include/boost/simd/constant/definition/sqrt_2o_3.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_SQRT_2O_3_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_SQRT_2O_3_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/sqrteps.hpp
+++ b/include/boost/simd/constant/definition/sqrteps.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_SQRTEPS_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_SQRTEPS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/sqrtsmallestposval.hpp
+++ b/include/boost/simd/constant/definition/sqrtsmallestposval.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_SQRTSMALLESTPOSVAL_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_SQRTSMALLESTPOSVAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/sqrtvalmax.hpp
+++ b/include/boost/simd/constant/definition/sqrtvalmax.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_SQRTVALMAX_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_SQRTVALMAX_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/ten.hpp
+++ b/include/boost/simd/constant/definition/ten.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_TEN_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_TEN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/third.hpp
+++ b/include/boost/simd/constant/definition/third.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_THIRD_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_THIRD_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/thirdrooteps.hpp
+++ b/include/boost/simd/constant/definition/thirdrooteps.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_THIRDROOTEPS_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_THIRDROOTEPS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/three.hpp
+++ b/include/boost/simd/constant/definition/three.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_THREE_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_THREE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/threeeps.hpp
+++ b/include/boost/simd/constant/definition/threeeps.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_THREEEPS_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_THREEEPS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/true.hpp
+++ b/include/boost/simd/constant/definition/true.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_TRUE_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_TRUE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/dispatch/function/make_callable.hpp>

--- a/include/boost/simd/constant/definition/two.hpp
+++ b/include/boost/simd/constant/definition/two.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_TWO_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_TWO_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/twoofive.hpp
+++ b/include/boost/simd/constant/definition/twoofive.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_TWOOFIVE_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_TWOOFIVE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/twothird.hpp
+++ b/include/boost/simd/constant/definition/twothird.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_TWOTHIRD_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_TWOTHIRD_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/twoto31.hpp
+++ b/include/boost/simd/constant/definition/twoto31.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_TWOTO31_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_TWOTO31_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/twotom10.hpp
+++ b/include/boost/simd/constant/definition/twotom10.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_TWOTOM10_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_TWOTOM10_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/twotomnmbo_3.hpp
+++ b/include/boost/simd/constant/definition/twotomnmbo_3.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_TWOTOMNMBO_3_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_TWOTOMNMBO_3_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/twotonmb.hpp
+++ b/include/boost/simd/constant/definition/twotonmb.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_TWOTONMB_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_TWOTONMB_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/constant/definition/valmax.hpp
+++ b/include/boost/simd/constant/definition/valmax.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_VALMAX_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_VALMAX_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>

--- a/include/boost/simd/constant/definition/valmin.hpp
+++ b/include/boost/simd/constant/definition/valmin.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_VALMIN_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_VALMIN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>

--- a/include/boost/simd/constant/definition/zero.hpp
+++ b/include/boost/simd/constant/definition/zero.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_CONSTANT_DEFINITION_ZERO_HPP_INCLUDED
 #define BOOST_SIMD_CONSTANT_DEFINITION_ZERO_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/detail/constant_traits.hpp>

--- a/include/boost/simd/function/definition/abs.hpp
+++ b/include/boost/simd/function/definition/abs.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_ABS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_ABS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/abss.hpp
+++ b/include/boost/simd/function/definition/abss.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_ABSS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_ABSS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/adds.hpp
+++ b/include/boost/simd/function/definition/adds.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_ADDS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_ADDS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/all.hpp
+++ b/include/boost/simd/function/definition/all.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_ALL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_ALL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/any.hpp
+++ b/include/boost/simd/function/definition/any.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_ANY_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_ANY_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/arg.hpp
+++ b/include/boost/simd/function/definition/arg.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_ARG_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_ARG_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/average.hpp
+++ b/include/boost/simd/function/definition/average.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_AVERAGE_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_AVERAGE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/bitfloating.hpp
+++ b/include/boost/simd/function/definition/bitfloating.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_BITFLOATING_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_BITFLOATING_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/bitget.hpp
+++ b/include/boost/simd/function/definition/bitget.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_BITGET_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_BITGET_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/bitinteger.hpp
+++ b/include/boost/simd/function/definition/bitinteger.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_BITINTEGER_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_BITINTEGER_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/bitofsign.hpp
+++ b/include/boost/simd/function/definition/bitofsign.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_BITOFSIGN_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_BITOFSIGN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/bits.hpp
+++ b/include/boost/simd/function/definition/bits.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_BITS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_BITS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/bitset.hpp
+++ b/include/boost/simd/function/definition/bitset.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_BITSET_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_BITSET_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/bitwise_and.hpp
+++ b/include/boost/simd/function/definition/bitwise_and.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_BITWISE_AND_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_BITWISE_AND_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/bitwise_andnot.hpp
+++ b/include/boost/simd/function/definition/bitwise_andnot.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_BITWISE_ANDNOT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_BITWISE_ANDNOT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/bitwise_cast.hpp
+++ b/include/boost/simd/function/definition/bitwise_cast.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_BITWISE_CAST_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_BITWISE_CAST_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/dispatch/as.hpp>

--- a/include/boost/simd/function/definition/bitwise_not.hpp
+++ b/include/boost/simd/function/definition/bitwise_not.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_BITWISE_NOT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_BITWISE_NOT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/function/definition/complement.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 

--- a/include/boost/simd/function/definition/bitwise_notand.hpp
+++ b/include/boost/simd/function/definition/bitwise_notand.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_BITWISE_NOTAND_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_BITWISE_NOTAND_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/bitwise_notor.hpp
+++ b/include/boost/simd/function/definition/bitwise_notor.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_BITWISE_NOTOR_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_BITWISE_NOTOR_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/bitwise_or.hpp
+++ b/include/boost/simd/function/definition/bitwise_or.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_BITWISE_OR_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_BITWISE_OR_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/bitwise_ornot.hpp
+++ b/include/boost/simd/function/definition/bitwise_ornot.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_BITWISE_ORNOT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_BITWISE_ORNOT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/bitwise_select.hpp
+++ b/include/boost/simd/function/definition/bitwise_select.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_BITWISE_SELECT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_BITWISE_SELECT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/bitwise_xor.hpp
+++ b/include/boost/simd/function/definition/bitwise_xor.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_BITWISE_XOR_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_BITWISE_XOR_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/broadcast.hpp
+++ b/include/boost/simd/function/definition/broadcast.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_BROADCAST_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_BROADCAST_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/cbrt.hpp
+++ b/include/boost/simd/function/definition/cbrt.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_CBRT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_CBRT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/ceil.hpp
+++ b/include/boost/simd/function/definition/ceil.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_CEIL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_CEIL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/clz.hpp
+++ b/include/boost/simd/function/definition/clz.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_CLZ_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_CLZ_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/comma.hpp
+++ b/include/boost/simd/function/definition/comma.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_COMMA_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_COMMA_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/compare_equal.hpp
+++ b/include/boost/simd/function/definition/compare_equal.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_COMPARE_EQUAL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_COMPARE_EQUAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/compare_greater.hpp
+++ b/include/boost/simd/function/definition/compare_greater.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_COMPARE_GREATER_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_COMPARE_GREATER_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/compare_greater_equal.hpp
+++ b/include/boost/simd/function/definition/compare_greater_equal.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_COMPARE_GREATER_EQUAL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_COMPARE_GREATER_EQUAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/compare_less.hpp
+++ b/include/boost/simd/function/definition/compare_less.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_COMPARE_LESS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_COMPARE_LESS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/compare_less_equal.hpp
+++ b/include/boost/simd/function/definition/compare_less_equal.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_COMPARE_LESS_EQUAL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_COMPARE_LESS_EQUAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/compare_not_equal.hpp
+++ b/include/boost/simd/function/definition/compare_not_equal.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_COMPARE_NOT_EQUAL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_COMPARE_NOT_EQUAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/complement.hpp
+++ b/include/boost/simd/function/definition/complement.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_COMPLEMENT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_COMPLEMENT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/conj.hpp
+++ b/include/boost/simd/function/definition/conj.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_CONJ_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_CONJ_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/copysign.hpp
+++ b/include/boost/simd/function/definition/copysign.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_COPYSIGN_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_COPYSIGN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/correct_fma.hpp
+++ b/include/boost/simd/function/definition/correct_fma.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_CORRECT_FMA_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_CORRECT_FMA_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/ctz.hpp
+++ b/include/boost/simd/function/definition/ctz.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_CTZ_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_CTZ_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/cummax.hpp
+++ b/include/boost/simd/function/definition/cummax.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_CUMMAX_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_CUMMAX_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/cummin.hpp
+++ b/include/boost/simd/function/definition/cummin.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_CUMMIN_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_CUMMIN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/cumprod.hpp
+++ b/include/boost/simd/function/definition/cumprod.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_CUMPROD_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_CUMPROD_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/cumsum.hpp
+++ b/include/boost/simd/function/definition/cumsum.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_CUMSUM_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_CUMSUM_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/dec.hpp
+++ b/include/boost/simd/function/definition/dec.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_DEC_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_DEC_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/deinterleave_first.hpp
+++ b/include/boost/simd/function/definition/deinterleave_first.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_DEINTERLEAVE_FIRST_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_DEINTERLEAVE_FIRST_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/deinterleave_second.hpp
+++ b/include/boost/simd/function/definition/deinterleave_second.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_DEINTERLEAVE_SECOND_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_DEINTERLEAVE_SECOND_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/dist.hpp
+++ b/include/boost/simd/function/definition/dist.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_DIST_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_DIST_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/dists.hpp
+++ b/include/boost/simd/function/definition/dists.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_DISTS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_DISTS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/divceil.hpp
+++ b/include/boost/simd/function/definition/divceil.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_DIVCEIL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_DIVCEIL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/divfix.hpp
+++ b/include/boost/simd/function/definition/divfix.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_DIVFIX_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_DIVFIX_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/divfloor.hpp
+++ b/include/boost/simd/function/definition/divfloor.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_DIVFLOOR_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_DIVFLOOR_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/divides.hpp
+++ b/include/boost/simd/function/definition/divides.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_DIVIDES_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_DIVIDES_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/divround.hpp
+++ b/include/boost/simd/function/definition/divround.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_DIVROUND_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_DIVROUND_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/divround2even.hpp
+++ b/include/boost/simd/function/definition/divround2even.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_DIVROUND2EVEN_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_DIVROUND2EVEN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/divs.hpp
+++ b/include/boost/simd/function/definition/divs.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_DIVS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_DIVS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/dot.hpp
+++ b/include/boost/simd/function/definition/dot.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_DOT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_DOT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/enumerate.hpp
+++ b/include/boost/simd/function/definition/enumerate.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_ENUMERATE_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_ENUMERATE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/eps.hpp
+++ b/include/boost/simd/function/definition/eps.hpp
@@ -14,14 +14,12 @@
 #define BOOST_SIMD_FUNCTION_DEFINITION_EPS_HPP_INCLUDED
 
 #include <boost/simd/constant/definition/eps.hpp>
+#include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
-
 
 namespace boost { namespace simd
 {
-
- BOOST_DISPATCH_FUNCTION_DEFINITION(tag::eps_, eps);
-
+  BOOST_DISPATCH_FUNCTION_DEFINITION(tag::eps_, eps);
 } }
 
 #endif

--- a/include/boost/simd/function/definition/exp.hpp
+++ b/include/boost/simd/function/definition/exp.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_EXP_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_EXP_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/exp10.hpp
+++ b/include/boost/simd/function/definition/exp10.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_EXP10_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_EXP10_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/exp2.hpp
+++ b/include/boost/simd/function/definition/exp2.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_EXP2_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_EXP2_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/expm1.hpp
+++ b/include/boost/simd/function/definition/expm1.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_EXPM1_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_EXPM1_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/exponent.hpp
+++ b/include/boost/simd/function/definition/exponent.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_EXPONENT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_EXPONENT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/exponentbits.hpp
+++ b/include/boost/simd/function/definition/exponentbits.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_EXPONENTBITS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_EXPONENTBITS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/exprecneg.hpp
+++ b/include/boost/simd/function/definition/exprecneg.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_EXPRECNEG_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_EXPRECNEG_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/exprecnegc.hpp
+++ b/include/boost/simd/function/definition/exprecnegc.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_EXPRECNEGC_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_EXPRECNEGC_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/expx2.hpp
+++ b/include/boost/simd/function/definition/expx2.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_EXPX2_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_EXPX2_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/extract.hpp
+++ b/include/boost/simd/function/definition/extract.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_EXTRACT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_EXTRACT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/ffs.hpp
+++ b/include/boost/simd/function/definition/ffs.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_FFS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_FFS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/firstbitset.hpp
+++ b/include/boost/simd/function/definition/firstbitset.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_FIRSTBITSET_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_FIRSTBITSET_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/firstbitunset.hpp
+++ b/include/boost/simd/function/definition/firstbitunset.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_FIRSTBITUNSET_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_FIRSTBITUNSET_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/floor.hpp
+++ b/include/boost/simd/function/definition/floor.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_FLOOR_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_FLOOR_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/fma.hpp
+++ b/include/boost/simd/function/definition/fma.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_FMA_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_FMA_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/fms.hpp
+++ b/include/boost/simd/function/definition/fms.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_FMS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_FMS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/fnma.hpp
+++ b/include/boost/simd/function/definition/fnma.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_FNMA_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_FNMA_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/fnms.hpp
+++ b/include/boost/simd/function/definition/fnms.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_FNMS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_FNMS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/frac.hpp
+++ b/include/boost/simd/function/definition/frac.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_FRAC_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_FRAC_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/frexp.hpp
+++ b/include/boost/simd/function/definition/frexp.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_FREXP_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_FREXP_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/genmask.hpp
+++ b/include/boost/simd/function/definition/genmask.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_GENMASK_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_GENMASK_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/genmaskc.hpp
+++ b/include/boost/simd/function/definition/genmaskc.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_GENMASKC_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_GENMASKC_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/hi.hpp
+++ b/include/boost/simd/function/definition/hi.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_HI_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_HI_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/hmsb.hpp
+++ b/include/boost/simd/function/definition/hmsb.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_HMSB_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_HMSB_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/hypot.hpp
+++ b/include/boost/simd/function/definition/hypot.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_HYPOT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_HYPOT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/iceil.hpp
+++ b/include/boost/simd/function/definition/iceil.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_ICEIL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_ICEIL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/idivceil.hpp
+++ b/include/boost/simd/function/definition/idivceil.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IDIVCEIL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IDIVCEIL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/idivfix.hpp
+++ b/include/boost/simd/function/definition/idivfix.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IDIVFIX_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IDIVFIX_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/idivfloor.hpp
+++ b/include/boost/simd/function/definition/idivfloor.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IDIVFLOOR_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IDIVFLOOR_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/idivround.hpp
+++ b/include/boost/simd/function/definition/idivround.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IDIVROUND_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IDIVROUND_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/idivround2even.hpp
+++ b/include/boost/simd/function/definition/idivround2even.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IDIVROUND2EVEN_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IDIVROUND2EVEN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/if_allbits_else.hpp
+++ b/include/boost/simd/function/definition/if_allbits_else.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IF_ALLBITS_ELSE_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IF_ALLBITS_ELSE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/if_else.hpp
+++ b/include/boost/simd/function/definition/if_else.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IF_ELSE_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IF_ELSE_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/if_else_allbits.hpp
+++ b/include/boost/simd/function/definition/if_else_allbits.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IF_ELSE_ALLBITS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IF_ELSE_ALLBITS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/if_else_zero.hpp
+++ b/include/boost/simd/function/definition/if_else_zero.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IF_ELSE_ZERO_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IF_ELSE_ZERO_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/if_one_else_zero.hpp
+++ b/include/boost/simd/function/definition/if_one_else_zero.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IF_ONE_ELSE_ZERO_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IF_ONE_ELSE_ZERO_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/if_zero_else.hpp
+++ b/include/boost/simd/function/definition/if_zero_else.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IF_ZERO_ELSE_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IF_ZERO_ELSE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/if_zero_else_one.hpp
+++ b/include/boost/simd/function/definition/if_zero_else_one.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IF_ZERO_ELSE_ONE_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IF_ZERO_ELSE_ONE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/ifloor.hpp
+++ b/include/boost/simd/function/definition/ifloor.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IFLOOR_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IFLOOR_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/ifnotadd.hpp
+++ b/include/boost/simd/function/definition/ifnotadd.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IFNOTADD_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IFNOTADD_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/ifnotdec.hpp
+++ b/include/boost/simd/function/definition/ifnotdec.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IFNOTDEC_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IFNOTDEC_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/ifnotinc.hpp
+++ b/include/boost/simd/function/definition/ifnotinc.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IFNOTINC_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IFNOTINC_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/ifnotsub.hpp
+++ b/include/boost/simd/function/definition/ifnotsub.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IFNOTSUB_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IFNOTSUB_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/ilog2.hpp
+++ b/include/boost/simd/function/definition/ilog2.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_ILOG2_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_ILOG2_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/ilogb.hpp
+++ b/include/boost/simd/function/definition/ilogb.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_ILOGB_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_ILOGB_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/inbtrue.hpp
+++ b/include/boost/simd/function/definition/inbtrue.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_INBTRUE_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_INBTRUE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/inc.hpp
+++ b/include/boost/simd/function/definition/inc.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_INC_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_INC_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/iround.hpp
+++ b/include/boost/simd/function/definition/iround.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IROUND_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IROUND_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/iround2even.hpp
+++ b/include/boost/simd/function/definition/iround2even.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IROUND2EVEN_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IROUND2EVEN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_denormal.hpp
+++ b/include/boost/simd/function/definition/is_denormal.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_DENORMAL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_DENORMAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_equal.hpp
+++ b/include/boost/simd/function/definition/is_equal.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_EQUAL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_EQUAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_equal_with_equal_nans.hpp
+++ b/include/boost/simd/function/definition/is_equal_with_equal_nans.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_EQUAL_WITH_EQUAL_NANS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_EQUAL_WITH_EQUAL_NANS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_eqz.hpp
+++ b/include/boost/simd/function/definition/is_eqz.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_EQZ_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_EQZ_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_even.hpp
+++ b/include/boost/simd/function/definition/is_even.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_EVEN_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_EVEN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_finite.hpp
+++ b/include/boost/simd/function/definition/is_finite.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_FINITE_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_FINITE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_flint.hpp
+++ b/include/boost/simd/function/definition/is_flint.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_FLINT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_FLINT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_gez.hpp
+++ b/include/boost/simd/function/definition/is_gez.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_GEZ_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_GEZ_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_greater.hpp
+++ b/include/boost/simd/function/definition/is_greater.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_GREATER_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_GREATER_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_greater_equal.hpp
+++ b/include/boost/simd/function/definition/is_greater_equal.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_GREATER_EQUAL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_GREATER_EQUAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_gtz.hpp
+++ b/include/boost/simd/function/definition/is_gtz.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_GTZ_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_GTZ_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_imag.hpp
+++ b/include/boost/simd/function/definition/is_imag.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_IMAG_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_IMAG_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_included.hpp
+++ b/include/boost/simd/function/definition/is_included.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_INCLUDED_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_INCLUDED_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_included_c.hpp
+++ b/include/boost/simd/function/definition/is_included_c.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_INCLUDED_C_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_INCLUDED_C_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_inf.hpp
+++ b/include/boost/simd/function/definition/is_inf.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_INF_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_INF_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_invalid.hpp
+++ b/include/boost/simd/function/definition/is_invalid.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_INVALID_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_INVALID_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_less.hpp
+++ b/include/boost/simd/function/definition/is_less.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_LESS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_LESS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_less_equal.hpp
+++ b/include/boost/simd/function/definition/is_less_equal.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_LESS_EQUAL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_LESS_EQUAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_lez.hpp
+++ b/include/boost/simd/function/definition/is_lez.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_LEZ_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_LEZ_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_ltz.hpp
+++ b/include/boost/simd/function/definition/is_ltz.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_LTZ_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_LTZ_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_nan.hpp
+++ b/include/boost/simd/function/definition/is_nan.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_NAN_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_NAN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_negative.hpp
+++ b/include/boost/simd/function/definition/is_negative.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_NEGATIVE_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_NEGATIVE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_nez.hpp
+++ b/include/boost/simd/function/definition/is_nez.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_NEZ_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_NEZ_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_ngez.hpp
+++ b/include/boost/simd/function/definition/is_ngez.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_NGEZ_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_NGEZ_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_ngtz.hpp
+++ b/include/boost/simd/function/definition/is_ngtz.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_NGTZ_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_NGTZ_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_nlez.hpp
+++ b/include/boost/simd/function/definition/is_nlez.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_NLEZ_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_NLEZ_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_nltz.hpp
+++ b/include/boost/simd/function/definition/is_nltz.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_NLTZ_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_NLTZ_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_not_denormal.hpp
+++ b/include/boost/simd/function/definition/is_not_denormal.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_DENORMAL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_DENORMAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_not_equal.hpp
+++ b/include/boost/simd/function/definition/is_not_equal.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_EQUAL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_EQUAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_not_equal_with_equal_nans.hpp
+++ b/include/boost/simd/function/definition/is_not_equal_with_equal_nans.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_EQUAL_WITH_EQUAL_NANS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_EQUAL_WITH_EQUAL_NANS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_not_greater.hpp
+++ b/include/boost/simd/function/definition/is_not_greater.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_GREATER_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_GREATER_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_not_greater_equal.hpp
+++ b/include/boost/simd/function/definition/is_not_greater_equal.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_GREATER_EQUAL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_GREATER_EQUAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_not_imag.hpp
+++ b/include/boost/simd/function/definition/is_not_imag.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_IMAG_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_IMAG_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_not_infinite.hpp
+++ b/include/boost/simd/function/definition/is_not_infinite.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_INFINITE_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_INFINITE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_not_less.hpp
+++ b/include/boost/simd/function/definition/is_not_less.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_LESS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_LESS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_not_less_equal.hpp
+++ b/include/boost/simd/function/definition/is_not_less_equal.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_LESS_EQUAL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_LESS_EQUAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_not_nan.hpp
+++ b/include/boost/simd/function/definition/is_not_nan.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_NAN_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_NAN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_not_real.hpp
+++ b/include/boost/simd/function/definition/is_not_real.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_REAL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_NOT_REAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_odd.hpp
+++ b/include/boost/simd/function/definition/is_odd.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_ODD_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_ODD_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_ord.hpp
+++ b/include/boost/simd/function/definition/is_ord.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_ORD_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_ORD_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_positive.hpp
+++ b/include/boost/simd/function/definition/is_positive.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_POSITIVE_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_POSITIVE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_real.hpp
+++ b/include/boost/simd/function/definition/is_real.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_REAL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_REAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_simd_logical.hpp
+++ b/include/boost/simd/function/definition/is_simd_logical.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_SIMD_LOGICAL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_SIMD_LOGICAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/is_unord.hpp
+++ b/include/boost/simd/function/definition/is_unord.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_IS_UNORD_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_IS_UNORD_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/ldexp.hpp
+++ b/include/boost/simd/function/definition/ldexp.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_LDEXP_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_LDEXP_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/lo.hpp
+++ b/include/boost/simd/function/definition/lo.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_LO_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_LO_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/log.hpp
+++ b/include/boost/simd/function/definition/log.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_LOG_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_LOG_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/log10.hpp
+++ b/include/boost/simd/function/definition/log10.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_LOG10_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_LOG10_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/log1p.hpp
+++ b/include/boost/simd/function/definition/log1p.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_LOG1P_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_LOG1P_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/log2.hpp
+++ b/include/boost/simd/function/definition/log2.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_LOG2_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_LOG2_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/logical_and.hpp
+++ b/include/boost/simd/function/definition/logical_and.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_LOGICAL_AND_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_LOGICAL_AND_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/logical_andnot.hpp
+++ b/include/boost/simd/function/definition/logical_andnot.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_LOGICAL_ANDNOT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_LOGICAL_ANDNOT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/logical_not.hpp
+++ b/include/boost/simd/function/definition/logical_not.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_LOGICAL_NOT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_LOGICAL_NOT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/logical_notand.hpp
+++ b/include/boost/simd/function/definition/logical_notand.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_LOGICAL_NOTAND_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_LOGICAL_NOTAND_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/logical_notor.hpp
+++ b/include/boost/simd/function/definition/logical_notor.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_LOGICAL_NOTOR_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_LOGICAL_NOTOR_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/logical_or.hpp
+++ b/include/boost/simd/function/definition/logical_or.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_LOGICAL_OR_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_LOGICAL_OR_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/logical_ornot.hpp
+++ b/include/boost/simd/function/definition/logical_ornot.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_LOGICAL_ORNOT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_LOGICAL_ORNOT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/logical_xor.hpp
+++ b/include/boost/simd/function/definition/logical_xor.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_LOGICAL_XOR_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_LOGICAL_XOR_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/logspace_add.hpp
+++ b/include/boost/simd/function/definition/logspace_add.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_LOGSPACE_ADD_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_LOGSPACE_ADD_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/logspace_sub.hpp
+++ b/include/boost/simd/function/definition/logspace_sub.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_LOGSPACE_SUB_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_LOGSPACE_SUB_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/lookup.hpp
+++ b/include/boost/simd/function/definition/lookup.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_LOOKUP_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_LOOKUP_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/majority.hpp
+++ b/include/boost/simd/function/definition/majority.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MAJORITY_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MAJORITY_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/mantissa.hpp
+++ b/include/boost/simd/function/definition/mantissa.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MANTISSA_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MANTISSA_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/mask2logical.hpp
+++ b/include/boost/simd/function/definition/mask2logical.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MASK2LOGICAL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MASK2LOGICAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/max.hpp
+++ b/include/boost/simd/function/definition/max.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MAX_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MAX_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/maximum.hpp
+++ b/include/boost/simd/function/definition/maximum.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MAXIMUM_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MAXIMUM_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/maxmag.hpp
+++ b/include/boost/simd/function/definition/maxmag.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MAXMAG_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MAXMAG_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/maxnum.hpp
+++ b/include/boost/simd/function/definition/maxnum.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MAXNUM_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MAXNUM_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/maxnummag.hpp
+++ b/include/boost/simd/function/definition/maxnummag.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MAXNUMMAG_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MAXNUMMAG_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/meanof.hpp
+++ b/include/boost/simd/function/definition/meanof.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MEANOF_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MEANOF_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/min.hpp
+++ b/include/boost/simd/function/definition/min.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MIN_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MIN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/minimum.hpp
+++ b/include/boost/simd/function/definition/minimum.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MINIMUM_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MINIMUM_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/minmag.hpp
+++ b/include/boost/simd/function/definition/minmag.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MINMAG_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MINMAG_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/minmod.hpp
+++ b/include/boost/simd/function/definition/minmod.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MINMOD_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MINMOD_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/minnum.hpp
+++ b/include/boost/simd/function/definition/minnum.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MINNUM_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MINNUM_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/minnummag.hpp
+++ b/include/boost/simd/function/definition/minnummag.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MINNUMMAG_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MINNUMMAG_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/minus.hpp
+++ b/include/boost/simd/function/definition/minus.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MINUS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MINUS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/minusone.hpp
+++ b/include/boost/simd/function/definition/minusone.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MINUSONE_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MINUSONE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/mod.hpp
+++ b/include/boost/simd/function/definition/mod.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MOD_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MOD_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/modf.hpp
+++ b/include/boost/simd/function/definition/modf.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MODF_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MODF_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/modulo.hpp
+++ b/include/boost/simd/function/definition/modulo.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MODULO_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MODULO_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/muls.hpp
+++ b/include/boost/simd/function/definition/muls.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MULS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MULS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/multiplies.hpp
+++ b/include/boost/simd/function/definition/multiplies.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_MULTIPLIES_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_MULTIPLIES_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/nbtrue.hpp
+++ b/include/boost/simd/function/definition/nbtrue.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_NBTRUE_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_NBTRUE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/negate.hpp
+++ b/include/boost/simd/function/definition/negate.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_NEGATE_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_NEGATE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/negatenz.hpp
+++ b/include/boost/simd/function/definition/negatenz.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_NEGATENZ_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_NEGATENZ_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/negif.hpp
+++ b/include/boost/simd/function/definition/negif.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_NEGIF_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_NEGIF_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/negifnot.hpp
+++ b/include/boost/simd/function/definition/negifnot.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_NEGIFNOT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_NEGIFNOT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/negs.hpp
+++ b/include/boost/simd/function/definition/negs.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_NEGS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_NEGS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/next.hpp
+++ b/include/boost/simd/function/definition/next.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_NEXT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_NEXT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/nextafter.hpp
+++ b/include/boost/simd/function/definition/nextafter.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_NEXTAFTER_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_NEXTAFTER_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/nextpow2.hpp
+++ b/include/boost/simd/function/definition/nextpow2.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_NEXTPOW2_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_NEXTPOW2_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/none.hpp
+++ b/include/boost/simd/function/definition/none.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_NONE_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_NONE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/nthroot.hpp
+++ b/include/boost/simd/function/definition/nthroot.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_NTHROOT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_NTHROOT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/oneminus.hpp
+++ b/include/boost/simd/function/definition/oneminus.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_ONEMINUS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_ONEMINUS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/oneplus.hpp
+++ b/include/boost/simd/function/definition/oneplus.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_ONEPLUS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_ONEPLUS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/plus.hpp
+++ b/include/boost/simd/function/definition/plus.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_PLUS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_PLUS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/popcnt.hpp
+++ b/include/boost/simd/function/definition/popcnt.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_POPCNT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_POPCNT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/posmax.hpp
+++ b/include/boost/simd/function/definition/posmax.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_POSMAX_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_POSMAX_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/posmin.hpp
+++ b/include/boost/simd/function/definition/posmin.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_POSMIN_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_POSMIN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/pow.hpp
+++ b/include/boost/simd/function/definition/pow.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_POW_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_POW_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/pow2.hpp
+++ b/include/boost/simd/function/definition/pow2.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_POW2_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_POW2_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/pow_abs.hpp
+++ b/include/boost/simd/function/definition/pow_abs.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_POW_ABS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_POW_ABS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/predecessor.hpp
+++ b/include/boost/simd/function/definition/predecessor.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_PREDECESSOR_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_PREDECESSOR_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/prev.hpp
+++ b/include/boost/simd/function/definition/prev.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_PREV_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_PREV_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/prod.hpp
+++ b/include/boost/simd/function/definition/prod.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_PROD_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_PROD_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/rec.hpp
+++ b/include/boost/simd/function/definition/rec.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_REC_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_REC_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/rem.hpp
+++ b/include/boost/simd/function/definition/rem.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_REM_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_REM_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/remainder.hpp
+++ b/include/boost/simd/function/definition/remainder.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_REMAINDER_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_REMAINDER_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/remquo.hpp
+++ b/include/boost/simd/function/definition/remquo.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_REMQUO_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_REMQUO_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/remround.hpp
+++ b/include/boost/simd/function/definition/remround.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_REMROUND_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_REMROUND_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/reverse.hpp
+++ b/include/boost/simd/function/definition/reverse.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_REVERSE_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_REVERSE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/reversebits.hpp
+++ b/include/boost/simd/function/definition/reversebits.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_REVERSEBITS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_REVERSEBITS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/rol.hpp
+++ b/include/boost/simd/function/definition/rol.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_ROL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_ROL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/ror.hpp
+++ b/include/boost/simd/function/definition/ror.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_ROR_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_ROR_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/round.hpp
+++ b/include/boost/simd/function/definition/round.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_ROUND_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_ROUND_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/round2even.hpp
+++ b/include/boost/simd/function/definition/round2even.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_ROUND2EVEN_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_ROUND2EVEN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/rrol.hpp
+++ b/include/boost/simd/function/definition/rrol.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_RROL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_RROL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/rror.hpp
+++ b/include/boost/simd/function/definition/rror.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_RROR_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_RROR_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/rshl.hpp
+++ b/include/boost/simd/function/definition/rshl.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_RSHL_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_RSHL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/rshr.hpp
+++ b/include/boost/simd/function/definition/rshr.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_RSHR_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_RSHR_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/rsqrt.hpp
+++ b/include/boost/simd/function/definition/rsqrt.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_RSQRT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_RSQRT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/safe_max.hpp
+++ b/include/boost/simd/function/definition/safe_max.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SAFE_MAX_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SAFE_MAX_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/safe_min.hpp
+++ b/include/boost/simd/function/definition/safe_min.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SAFE_MIN_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SAFE_MIN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/saturate.hpp
+++ b/include/boost/simd/function/definition/saturate.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SATURATE_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SATURATE_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/as.hpp>
 #include <boost/dispatch/function/make_callable.hpp>

--- a/include/boost/simd/function/definition/sbits.hpp
+++ b/include/boost/simd/function/definition/sbits.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SBITS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SBITS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/seladd.hpp
+++ b/include/boost/simd/function/definition/seladd.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SELADD_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SELADD_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/seldec.hpp
+++ b/include/boost/simd/function/definition/seldec.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SELDEC_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SELDEC_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/selinc.hpp
+++ b/include/boost/simd/function/definition/selinc.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SELINC_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SELINC_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/selsub.hpp
+++ b/include/boost/simd/function/definition/selsub.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SELSUB_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SELSUB_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/shift_left.hpp
+++ b/include/boost/simd/function/definition/shift_left.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SHIFT_LEFT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SHIFT_LEFT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/shift_right.hpp
+++ b/include/boost/simd/function/definition/shift_right.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SHIFT_RIGHT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SHIFT_RIGHT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/shr.hpp
+++ b/include/boost/simd/function/definition/shr.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SHR_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SHR_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/sign.hpp
+++ b/include/boost/simd/function/definition/sign.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SIGN_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SIGN_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/significants.hpp
+++ b/include/boost/simd/function/definition/significants.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SIGNIFICANTS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SIGNIFICANTS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/signnz.hpp
+++ b/include/boost/simd/function/definition/signnz.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SIGNNZ_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SIGNNZ_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/sort.hpp
+++ b/include/boost/simd/function/definition/sort.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SORT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SORT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/splat.hpp
+++ b/include/boost/simd/function/definition/splat.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SPLAT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SPLAT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/as.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/dispatch/function/make_callable.hpp>

--- a/include/boost/simd/function/definition/splatted_maximum.hpp
+++ b/include/boost/simd/function/definition/splatted_maximum.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SPLATTED_MAXIMUM_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SPLATTED_MAXIMUM_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/splatted_minimum.hpp
+++ b/include/boost/simd/function/definition/splatted_minimum.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SPLATTED_MINIMUM_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SPLATTED_MINIMUM_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/splatted_prod.hpp
+++ b/include/boost/simd/function/definition/splatted_prod.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SPLATTED_PROD_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SPLATTED_PROD_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/splatted_sum.hpp
+++ b/include/boost/simd/function/definition/splatted_sum.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SPLATTED_SUM_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SPLATTED_SUM_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/split.hpp
+++ b/include/boost/simd/function/definition/split.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SPLIT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SPLIT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/sqr.hpp
+++ b/include/boost/simd/function/definition/sqr.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SQR_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SQR_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/sqr_abs.hpp
+++ b/include/boost/simd/function/definition/sqr_abs.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SQR_ABS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SQR_ABS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/sqrs.hpp
+++ b/include/boost/simd/function/definition/sqrs.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SQRS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SQRS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/sqrt.hpp
+++ b/include/boost/simd/function/definition/sqrt.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SQRT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SQRT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/sqrt1pm1.hpp
+++ b/include/boost/simd/function/definition/sqrt1pm1.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SQRT1PM1_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SQRT1PM1_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/subs.hpp
+++ b/include/boost/simd/function/definition/subs.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SUBS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SUBS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/successor.hpp
+++ b/include/boost/simd/function/definition/successor.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SUCCESSOR_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SUCCESSOR_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/sum.hpp
+++ b/include/boost/simd/function/definition/sum.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SUM_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SUM_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/swapbytes.hpp
+++ b/include/boost/simd/function/definition/swapbytes.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_SWAPBYTES_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_SWAPBYTES_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/tenpower.hpp
+++ b/include/boost/simd/function/definition/tenpower.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_TENPOWER_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_TENPOWER_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/tofloat.hpp
+++ b/include/boost/simd/function/definition/tofloat.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_TOFLOAT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_TOFLOAT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/toint.hpp
+++ b/include/boost/simd/function/definition/toint.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_TOINT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_TOINT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/toints.hpp
+++ b/include/boost/simd/function/definition/toints.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_TOINTS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_TOINTS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/touint.hpp
+++ b/include/boost/simd/function/definition/touint.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_TOUINT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_TOUINT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/touints.hpp
+++ b/include/boost/simd/function/definition/touints.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_TOUINTS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_TOUINTS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/trunc.hpp
+++ b/include/boost/simd/function/definition/trunc.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_TRUNC_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_TRUNC_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/two_add.hpp
+++ b/include/boost/simd/function/definition/two_add.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_TWO_ADD_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_TWO_ADD_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/two_prod.hpp
+++ b/include/boost/simd/function/definition/two_prod.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_TWO_PROD_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_TWO_PROD_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/two_split.hpp
+++ b/include/boost/simd/function/definition/two_split.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_TWO_SPLIT_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_TWO_SPLIT_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/twopower.hpp
+++ b/include/boost/simd/function/definition/twopower.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_TWOPOWER_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_TWOPOWER_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/ulp.hpp
+++ b/include/boost/simd/function/definition/ulp.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_ULP_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_ULP_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/ulpdist.hpp
+++ b/include/boost/simd/function/definition/ulpdist.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_ULPDIST_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_ULPDIST_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/unary_minus.hpp
+++ b/include/boost/simd/function/definition/unary_minus.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_UNARY_MINUS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_UNARY_MINUS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/definition/unary_plus.hpp
+++ b/include/boost/simd/function/definition/unary_plus.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_FUNCTION_DEFINITION_UNARY_PLUS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_DEFINITION_UNARY_PLUS_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>

--- a/include/boost/simd/function/eps.hpp
+++ b/include/boost/simd/function/eps.hpp
@@ -51,6 +51,7 @@ namespace boost { namespace simd
 } }
 #endif
 
+#include <boost/simd/function/definition/eps.hpp>
 #include <boost/simd/function/scalar/eps.hpp>
 #include <boost/simd/function/simd/eps.hpp>
 

--- a/include/boost/simd/function/scalar/eps.hpp
+++ b/include/boost/simd/function/scalar/eps.hpp
@@ -13,7 +13,6 @@
 #ifndef BOOST_SIMD_FUNCTION_SCALAR_EPS_HPP_INCLUDED
 #define BOOST_SIMD_FUNCTION_SCALAR_EPS_HPP_INCLUDED
 
-#include <boost/simd/function/definition/eps.hpp>
 #include <boost/simd/arch/common/scalar/function/eps.hpp>
 
 #endif

--- a/include/boost/simd/logical.hpp
+++ b/include/boost/simd/logical.hpp
@@ -13,7 +13,7 @@
 #ifndef BOOST_SIMD_LOGICAL_HPP_INCLUDED
 #define BOOST_SIMD_LOGICAL_HPP_INCLUDED
 
-
+#include <boost/simd/config.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>
 #include <boost/config.hpp>
 #include <iostream>

--- a/include/boost/simd/sdk/as_simd.hpp
+++ b/include/boost/simd/sdk/as_simd.hpp
@@ -15,6 +15,7 @@
 #ifndef BOOST_SIMD_SDK_AS_SIMD_HPP_INCLUDED
 #define BOOST_SIMD_SDK_AS_SIMD_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/arch/spec.hpp>
 
 namespace boost { namespace simd

--- a/include/boost/simd/sdk/expected_cardinal.hpp
+++ b/include/boost/simd/sdk/expected_cardinal.hpp
@@ -15,6 +15,7 @@
 #ifndef BOOST_SIMD_SDK_EXPECTED_CARDINAL_HPP_INCLUDED
 #define BOOST_SIMD_SDK_EXPECTED_CARDINAL_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/arch/limits.hpp>
 #include <boost/simd/detail/brigand.hpp>
 

--- a/include/boost/simd/sdk/is_scalar.hpp
+++ b/include/boost/simd/sdk/is_scalar.hpp
@@ -13,6 +13,7 @@
 #ifndef BOOST_SIMD_SDK_IS_SCALAR_HPP_INCLUDED
 #define BOOST_SIMD_SDK_IS_SCALAR_HPP_INCLUDED
 
+#include <boost/simd/config.hpp>
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/dispatch/hierarchy/unspecified.hpp>
 #include <boost/dispatch/hierarchy/scalar.hpp>

--- a/test/function/scalar/eps.cpp
+++ b/test/function/scalar/eps.cpp
@@ -8,20 +8,17 @@
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 */
 //==================================================================================================
-//#include <boost/simd/function/eps.hpp>
+#include <boost/simd/function/eps.hpp>
 #include <simd_test.hpp>
+
 #include <boost/dispatch/meta/as_integer.hpp>
+#include <boost/simd/constant/mindenormal.hpp>
 #include <boost/simd/constant/inf.hpp>
 #include <boost/simd/constant/minf.hpp>
-#include <boost/simd/constant/mone.hpp>
 #include <boost/simd/constant/nan.hpp>
-#include <boost/simd/constant/one.hpp>
-#include <boost/simd/constant/zero.hpp>
-#include <boost/simd/constant/two.hpp>
-#include <boost/simd/function/eps.hpp>
+#include <boost/simd/constant/eps.hpp>
 
-
-STF_CASE_TPL (" eps real",  STF_IEEE_TYPES)
+STF_CASE_TPL ("eps for IEEE types",  STF_IEEE_TYPES)
 {
   namespace bs = boost::simd;
   using bs::eps;
@@ -31,20 +28,21 @@ STF_CASE_TPL (" eps real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, T);
 
   // specific values tests
-#ifndef STF_NO_INVALIDS
+ #ifndef STF_NO_INVALIDS
   STF_IEEE_EQUAL(eps(bs::Inf<T>()), bs::Nan<r_t>());
   STF_IEEE_EQUAL(eps(bs::Minf<T>()), bs::Nan<r_t>());
   STF_IEEE_EQUAL(eps(bs::Nan<T>()), bs::Nan<r_t>());
-#endif
-  STF_EQUAL(eps(bs::Mone<T>()), bs::Eps<r_t>());
-  STF_EQUAL(eps(bs::One<T>()), bs::Eps<r_t>());
-#if !defined(STF_NO_DENORMALS)
-  STF_EQUAL(eps(bs::Zero<T>()), bs::Mindenormal<r_t>());
-#endif
+ #endif
 
+  STF_EQUAL(eps(T{-1}), bs::Eps<r_t>());
+  STF_EQUAL(eps(T{1}) , bs::Eps<r_t>());
+
+ #if !defined(STF_NO_DENORMALS)
+  STF_EQUAL(eps(T{0}), bs::Mindenormal<r_t>());
+ #endif
 }
 
-STF_CASE_TPL (" eps unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL ("eps on integers",  STF_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
   using bs::eps;
@@ -54,22 +52,8 @@ STF_CASE_TPL (" eps unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
   STF_TYPE_IS(r_t, T);
 
   // specific values tests
-  STF_EQUAL(eps(bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(eps(bs::Zero<T>()), bs::One<r_t>());
-}
-
-STF_CASE_TPL (" eps signed_int",  STF_SIGNED_INTEGRAL_TYPES)
-{
-  namespace bs = boost::simd;
-  using bs::eps;
-  using r_t = decltype(eps(T()));
-
-  // return type conformity test
-  STF_TYPE_IS(r_t, T);
-
-  // specific values tests
-  STF_EQUAL(eps(bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(eps(bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(eps(bs::Zero<T>()), bs::One<r_t>());
-  STF_EQUAL(eps(bs::Two<T>()), bs::One<r_t>());
+  STF_EQUAL(eps(T(-1)), T{1});
+  STF_EQUAL(eps(T(0)) , T{1});
+  STF_EQUAL(eps(T(-1)), T{1});
+  STF_EQUAL(eps(T(42)), T{1});
 }

--- a/test/simd_test.hpp
+++ b/test/simd_test.hpp
@@ -17,6 +17,9 @@
 int main(int argc, const char** argv)
 {
   std::cout << "CTEST_FULL_OUTPUT\n";
+  std::cout << "Compiled for: "
+            << stf::type_id<BOOST_DISPATCH_DEFAULT_SITE>()
+            << "\n";
   return simd_test(argc,argv);
 }
 


### PR DESCRIPTION
- Make config.hpp setup the default site to correct SIMD extension tag
- Make every public file use config.hpp
