### PR TITLE
Divides with options

### DIFF
--- a/include/boost/simd/arch/common/generic/function/div.hpp
+++ b/include/boost/simd/arch/common/generic/function/div.hpp
@@ -1,0 +1,123 @@
+//==================================================================================================
+/*!
+  @file
+
+  @copyright 2015 NumScale SAS
+  @copyright 2015 J.T. Lapreste
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_COMMON_GENERIC_FUNCTION_DIV_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_COMMON_GENERIC_FUNCTION_DIV_HPP_INCLUDED
+
+#include <boost/simd/function/divides.hpp>
+#include <boost/simd/function/definition/ceil.hpp>
+#include <boost/simd/function/divceil.hpp>
+#include <boost/simd/function/definition/floor.hpp>
+#include <boost/simd/function/divfloor.hpp>
+#include <boost/simd/function/definition/round.hpp>
+#include <boost/simd/function/divround.hpp>
+#include <boost/simd/function/definition/round2even.hpp>
+#include <boost/simd/function/divround2even.hpp>
+#include <boost/simd/function/definition/fix.hpp>
+#include <boost/simd/function/divfix.hpp>
+#include <boost/dispatch/function/overload.hpp>
+#include <boost/dispatch/hierarchy.hpp>
+#include <boost/config.hpp>
+
+namespace boost { namespace simd { namespace ext
+{
+
+  namespace bd = boost::dispatch;
+  BOOST_DISPATCH_OVERLOAD ( div_
+                          , (typename T)
+                          , bd::cpu_
+                          , bd::generic_<bd::floating_<T>>
+                          , bd::generic_<bd::floating_<T>>
+                          )
+  {
+    BOOST_FORCEINLINE T operator()(T const& a, T const& b ) const BOOST_NOEXCEPT
+    {
+      return divides(a, b);
+    }
+  };
+
+  BOOST_DISPATCH_OVERLOAD ( div_
+                          , (typename T, typename A0)
+                          , bd::cpu_
+                          , bd::generic_<bd::floating_<T>>
+                          , bd::generic_<bd::floating_<T>>
+                          , bd::unspecified_<A0>
+                          )
+  {
+    BOOST_FORCEINLINE T operator()(T const& a, T const& b
+                                  , bd::functor<bs::tag::ceil_> const& ) const BOOST_NOEXCEPT
+    {
+      return divceil(a, b);
+    }
+  };
+
+  BOOST_DISPATCH_OVERLOAD ( div_
+                          , (typename T)
+                          , bd::cpu_
+                          , bd::generic_<bd::floating_<T>>
+                          , bd::generic_<bd::floating_<T>>
+                          , bs::tag::floor_
+                          )
+  {
+    BOOST_FORCEINLINE T operator()(T const& a, T const& b
+                                  ,  bs::tag::floor_ const& ) const BOOST_NOEXCEPT
+    {
+      return divfloor(a, b);
+    }
+  };
+
+  BOOST_DISPATCH_OVERLOAD ( div_
+                          , (typename T)
+                          , bd::cpu_
+                          , bd::generic_<bd::floating_<T>>
+                          , bd::generic_<bd::floating_<T>>
+                          , bs::tag::fix_
+                          )
+  {
+    BOOST_FORCEINLINE T operator()(T const& a, T const& b
+                                  ,  bs::tag::fix_ const& ) const BOOST_NOEXCEPT
+    {
+      return divfix(a, b);
+    }
+  };
+
+  BOOST_DISPATCH_OVERLOAD ( div_
+                          , (typename T)
+                          , bd::cpu_
+                          , bd::generic_<bd::floating_<T>>
+                          , bd::generic_<bd::floating_<T>>
+                          , bs::tag::round_
+                          )
+  {
+    BOOST_FORCEINLINE T operator()(T const& a, T const& b
+                                  ,  bs::tag::round_ const& ) const BOOST_NOEXCEPT
+    {
+      return divround(a, b);
+    }
+  };
+
+  BOOST_DISPATCH_OVERLOAD ( div_
+                          , (typename T)
+                          , bd::cpu_
+                          , bd::generic_<bd::floating_<T>>
+                          , bd::generic_<bd::floating_<T>>
+                          , bs::tag::round2even_
+                          )
+  {
+    BOOST_FORCEINLINE T operator()(T const& a, T const& b
+                                  ,  bs::tag::round2even_ const& ) const BOOST_NOEXCEPT
+    {
+      return divround2even(a, b);
+    }
+  };
+} } }
+
+#endif

--- a/include/boost/simd/arch/common/generic/function/div.hpp
+++ b/include/boost/simd/arch/common/generic/function/div.hpp
@@ -34,8 +34,8 @@ namespace boost { namespace simd { namespace ext
   BOOST_DISPATCH_OVERLOAD ( div_
                           , (typename T)
                           , bd::cpu_
-                          , bd::generic_<bd::floating_<T>>
-                          , bd::generic_<bd::floating_<T>>
+                          , bd::generic_<bd::arithmetic_<T>>
+                          , bd::generic_<bd::arithmetic_<T>>
                           )
   {
     BOOST_FORCEINLINE T operator()(T const& a, T const& b ) const BOOST_NOEXCEPT
@@ -45,11 +45,11 @@ namespace boost { namespace simd { namespace ext
   };
 
   BOOST_DISPATCH_OVERLOAD ( div_
-                          , (typename T, typename A0)
+                          , (typename T)
                           , bd::cpu_
-                          , bd::generic_<bd::floating_<T>>
-                          , bd::generic_<bd::floating_<T>>
-                          , bd::unspecified_<A0>
+                          , bd::generic_<bd::arithmetic_<T>>
+                          , bd::generic_<bd::arithmetic_<T>>
+                          , bs::tag::ceil_
                           )
   {
     BOOST_FORCEINLINE T operator()(T const& a, T const& b
@@ -62,13 +62,13 @@ namespace boost { namespace simd { namespace ext
   BOOST_DISPATCH_OVERLOAD ( div_
                           , (typename T)
                           , bd::cpu_
-                          , bd::generic_<bd::floating_<T>>
-                          , bd::generic_<bd::floating_<T>>
+                          , bd::generic_<bd::arithmetic_<T>>
+                          , bd::generic_<bd::arithmetic_<T>>
                           , bs::tag::floor_
                           )
   {
     BOOST_FORCEINLINE T operator()(T const& a, T const& b
-                                  ,  bs::tag::floor_ const& ) const BOOST_NOEXCEPT
+                                  ,  bd::functor<bs::tag::floor_> const& ) const BOOST_NOEXCEPT
     {
       return divfloor(a, b);
     }
@@ -77,13 +77,13 @@ namespace boost { namespace simd { namespace ext
   BOOST_DISPATCH_OVERLOAD ( div_
                           , (typename T)
                           , bd::cpu_
-                          , bd::generic_<bd::floating_<T>>
-                          , bd::generic_<bd::floating_<T>>
+                          , bd::generic_<bd::arithmetic_<T>>
+                          , bd::generic_<bd::arithmetic_<T>>
                           , bs::tag::fix_
                           )
   {
     BOOST_FORCEINLINE T operator()(T const& a, T const& b
-                                  ,  bs::tag::fix_ const& ) const BOOST_NOEXCEPT
+                                  ,  bd::functor<bs::tag::fix_> const& ) const BOOST_NOEXCEPT
     {
       return divfix(a, b);
     }
@@ -92,13 +92,13 @@ namespace boost { namespace simd { namespace ext
   BOOST_DISPATCH_OVERLOAD ( div_
                           , (typename T)
                           , bd::cpu_
-                          , bd::generic_<bd::floating_<T>>
-                          , bd::generic_<bd::floating_<T>>
+                          , bd::generic_<bd::arithmetic_<T>>
+                          , bd::generic_<bd::arithmetic_<T>>
                           , bs::tag::round_
                           )
   {
     BOOST_FORCEINLINE T operator()(T const& a, T const& b
-                                  ,  bs::tag::round_ const& ) const BOOST_NOEXCEPT
+                                  ,  bd::functor<bs::tag::round_> const& ) const BOOST_NOEXCEPT
     {
       return divround(a, b);
     }
@@ -107,13 +107,13 @@ namespace boost { namespace simd { namespace ext
   BOOST_DISPATCH_OVERLOAD ( div_
                           , (typename T)
                           , bd::cpu_
-                          , bd::generic_<bd::floating_<T>>
-                          , bd::generic_<bd::floating_<T>>
+                          , bd::generic_<bd::arithmetic_<T>>
+                          , bd::generic_<bd::arithmetic_<T>>
                           , bs::tag::round2even_
                           )
   {
     BOOST_FORCEINLINE T operator()(T const& a, T const& b
-                                  ,  bs::tag::round2even_ const& ) const BOOST_NOEXCEPT
+                                  ,  bd::functor<bs::tag::round2even_> const& ) const BOOST_NOEXCEPT
     {
       return divround2even(a, b);
     }

--- a/include/boost/simd/arch/common/generic/function/idiv.hpp
+++ b/include/boost/simd/arch/common/generic/function/idiv.hpp
@@ -1,0 +1,59 @@
+//==================================================================================================
+/*!
+  @file
+
+  @copyright 2015 NumScale SAS
+  @copyright 2015 J.T. Lapreste
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_COMMON_GENERIC_FUNCTION_IDIV_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_COMMON_GENERIC_FUNCTION_IDIV_HPP_INCLUDED
+
+#include <boost/dispatch/meta/as_integer.hpp>
+#include <boost/simd/function/definition/trunc.hpp>
+#include <boost/simd/function/definition/fix.hpp>
+#include <boost/simd/function/div.hpp>
+#include <boost/dispatch/function/overload.hpp>
+#include <boost/dispatch/hierarchy.hpp>
+#include <boost/config.hpp>
+
+namespace boost { namespace simd { namespace ext
+{
+
+  namespace bd = boost::dispatch;
+  namespace bs = boost::simd;
+  BOOST_DISPATCH_OVERLOAD ( idiv_
+                          , (typename T)
+                          , bd::cpu_
+                          , bd::generic_<bd::arithmetic_<T>>
+                          , bd::generic_<bd::arithmetic_<T>>
+                          )
+  {
+    BOOST_FORCEINLINE  bd::as_integer_t<T>
+    operator()(T const& a, T const& b ) const BOOST_NOEXCEPT
+    {
+      return div(a, b, fix);
+    }
+  };
+//   BOOST_DISPATCH_OVERLOAD ( idiv_
+//                           , (typename T)
+//                           , bd::cpu_
+//                           , bd::generic_<bd::arithmetic_<T>>
+//                           , bd::generic_<bd::arithmetic_<T>>
+//                           , bs::tag::trunc_
+//                           )
+//   {
+//     BOOST_FORCEINLINE bd::as_integer_t<T>
+//     operator()(T const& a, T const& b
+//                , bd::functor<bs::tag::trunc_> ) const BOOST_NOEXCEPT
+//     {
+//       return idiv(a, b, fix);
+//     }
+//   };
+
+} } }
+
+#endif

--- a/include/boost/simd/arch/common/generic/function/mod.hpp
+++ b/include/boost/simd/arch/common/generic/function/mod.hpp
@@ -12,8 +12,8 @@
 #ifndef BOOST_SIMD_ARCH_COMMON_GENERIC_FUNCTION_MOD_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_GENERIC_FUNCTION_MOD_HPP_INCLUDED
 
-#include <boost/simd/function/divfloor.hpp>
-#include <boost/simd/function/idivfloor.hpp>
+#include <boost/simd/function/div.hpp>
+#include <boost/simd/function/idiv.hpp>
 #include <boost/simd/function/is_nez.hpp>
 #include <boost/simd/function/multiplies.hpp>
 #include <boost/simd/function/selsub.hpp>
@@ -32,7 +32,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE A0 operator() ( A0 a0, A0  a1) const BOOST_NOEXCEPT
     {
-      return selsub(is_nez(a1),a0,divfloor(a0,a1)*a1 );
+      return selsub(is_nez(a1),a0,div(a0,a1,floor)*a1 );
     }
   };
 
@@ -45,7 +45,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
-      return selsub(is_nez(a1),a0,simd::multiplies(idivfloor(a0,a1),a1));
+      return selsub(is_nez(a1),a0,simd::multiplies(idiv(a0,a1,floor),a1));
     }
   };
 } } }

--- a/include/boost/simd/arch/common/generic/function/remround.hpp
+++ b/include/boost/simd/arch/common/generic/function/remround.hpp
@@ -12,8 +12,8 @@
 #ifndef BOOST_SIMD_ARCH_COMMON_GENERIC_FUNCTION_REMROUND_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_GENERIC_FUNCTION_REMROUND_HPP_INCLUDED
 
-#include <boost/simd/function/divround.hpp>
-#include <boost/simd/function/idivround.hpp>
+#include <boost/simd/function/div.hpp>
+#include <boost/simd/function/idiv.hpp>
 #include <boost/simd/function/is_nez.hpp>
 #include <boost/simd/function/minus.hpp>
 #include <boost/simd/function/multiplies.hpp>
@@ -42,7 +42,7 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
       return selsub(is_nez(a1),a0,
-                    simd::multiplies(idivround(a0, a1), a1));
+                    simd::multiplies(idiv(a0, a1, round), a1));
     }
   };
 
@@ -55,7 +55,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
-      return a0-divround(a0, a1)*a1;
+      return a0-div(a0, a1, round)*a1;
     }
   };
 } } }

--- a/include/boost/simd/arch/common/scalar/function/rem.hpp
+++ b/include/boost/simd/arch/common/scalar/function/rem.hpp
@@ -15,7 +15,7 @@
 #include <boost/simd/function/fast.hpp>
 
 #include <boost/simd/constant/nan.hpp>
-#include <boost/simd/function/scalar/idivfix.hpp>
+#include <boost/simd/function/scalar/idiv.hpp>
 #include <boost/simd/function/scalar/is_eqz.hpp>
 #include <boost/simd/function/scalar/is_finite.hpp>
 #include <boost/simd/function/scalar/is_inf.hpp>
@@ -49,7 +49,7 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
       if (is_inf(a0) || is_eqz(a1)) return Nan<A0>();
-      return is_finite(a1) ? a0-a1*idivfix(a0,a1) : a0;
+      return is_finite(a1) ? a0-a1*idiv(a0,a1,fix) : a0;
     }
   };
 
@@ -63,7 +63,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1, fast_tag const&) const BOOST_NOEXCEPT
     {
-      return a0-a1*idivfix(a0,a1);
+      return a0-a1*idiv(a0,a1, fix);
     }
   };
   BOOST_DISPATCH_OVERLOAD ( rem_

--- a/include/boost/simd/arch/common/scalar/function/remainder.hpp
+++ b/include/boost/simd/arch/common/scalar/function/remainder.hpp
@@ -12,8 +12,8 @@
 #ifndef BOOST_SIMD_ARCH_COMMON_SCALAR_FUNCTION_REMAINDER_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_SCALAR_FUNCTION_REMAINDER_HPP_INCLUDED
 
-#include <boost/simd/function/divround2even.hpp>
-#include <boost/simd/function/idivround2even.hpp>
+#include <boost/simd/function/div.hpp>
+#include <boost/simd/function/idiv.hpp>
 #include <boost/simd/function/is_nez.hpp>
 #include <boost/simd/function/minus.hpp>
 #include <boost/simd/function/multiplies.hpp>
@@ -43,7 +43,7 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
       return selsub(is_nez(a1),a0,
-                    simd::multiplies(idivround2even(a0, a1), a1));
+                    simd::multiplies(idiv(a0, a1, round2even), a1));
     }
   };
 
@@ -56,7 +56,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
-      return a0-divround2even(a0, a1)*a1;
+      return a0-div(a0, a1, round2even)*a1;
     }
   };
 } } }

--- a/include/boost/simd/arithmetic.hpp
+++ b/include/boost/simd/arithmetic.hpp
@@ -47,13 +47,8 @@ namespace boost { namespace simd
 #include <boost/simd/function/decs.hpp>
 #include <boost/simd/function/dist.hpp>
 #include <boost/simd/function/dists.hpp>
-#include <boost/simd/function/divceil.hpp>
-#include <boost/simd/function/divfix.hpp>
-#include <boost/simd/function/divfloor.hpp>
-#include <boost/simd/function/divround2even.hpp>
-#include <boost/simd/function/divround.hpp>
+#include <boost/simd/function/div.hpp>
 #include <boost/simd/function/divs.hpp>
-#include <boost/simd/function/divtrunc.hpp>
 #include <boost/simd/function/drem.hpp>
 #include <boost/simd/function/extract.hpp>
 #include <boost/simd/function/fabs.hpp>
@@ -66,11 +61,7 @@ namespace boost { namespace simd
 #include <boost/simd/function/fnms.hpp>
 #include <boost/simd/function/hypot.hpp>
 #include <boost/simd/function/iceil.hpp>
-#include <boost/simd/function/idivceil.hpp>
-#include <boost/simd/function/idivfix.hpp>
-#include <boost/simd/function/idivfloor.hpp>
-#include <boost/simd/function/idivround2even.hpp>
-#include <boost/simd/function/idivround.hpp>
+#include <boost/simd/function/idiv.hpp>
 #include <boost/simd/function/ifix.hpp>
 #include <boost/simd/function/ifloor.hpp>
 #include <boost/simd/function/inc.hpp>

--- a/include/boost/simd/function/definition/div.hpp
+++ b/include/boost/simd/function/definition/div.hpp
@@ -17,15 +17,15 @@
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>
 #include <boost/simd/function/divides.hpp>
-#include <boost/simd/function/ceil.hpp>
+#include <boost/simd/function/definition/ceil.hpp>
 #include <boost/simd/function/divceil.hpp>
-#include <boost/simd/function/floor.hpp>
+#include <boost/simd/function/definition/floor.hpp>
 #include <boost/simd/function/divfloor.hpp>
-#include <boost/simd/function/round.hpp>
+#include <boost/simd/function/definition/round.hpp>
 #include <boost/simd/function/divround.hpp>
-#include <boost/simd/function/round2even.hpp>
+#include <boost/simd/function/definition/round2even.hpp>
 #include <boost/simd/function/divround2even.hpp>
-#include <boost/simd/function/fix.hpp>
+#include <boost/simd/function/definition/fix.hpp>
 #include <boost/simd/function/divfix.hpp>
 
 namespace boost { namespace simd
@@ -51,21 +51,21 @@ namespace boost { namespace simd
     return bs::divides(a, b);
   }
 
+  namespace bs = boost::simd;
   template < typename T, typename O>
-  BOOST_FORCEINLINE auto div(T const& a, T const& b, O const& )
-  BOOST_DECL_NOEXCEPT
+  auto div(T const& a, T const& b, O const& )
+    BOOST_NOEXCEPT_DECLTYPE(bs::divides(a, b, O()))
   {
-    namespace bs = boost::simd;
     return bs::divides(a, b, O());
   }
 
 #define BOOST_SIMD_DIV_WITH_OPTION(option)                      \
   template < typename T>                                        \
-  BOOST_FORCEINLINE T div(T const& a, T const& b                \
+  BOOST_FORCEINLINE auto div(T const& a, T const& b             \
                          , boost::simd::tag::option##_ const& ) \
-    BOOST_NOEXCEPT                                              \
+    BOOST_NOEXCEPT_DECLTYPE(bs::div##option(a, b))              \
   {                                                             \
-    return div##option(a, b);                                   \
+    return bs::div##option(a, b);                               \
   }                                                             \
 /**/
 

--- a/include/boost/simd/function/definition/div.hpp
+++ b/include/boost/simd/function/definition/div.hpp
@@ -1,0 +1,80 @@
+//==================================================================================================
+/*!
+  @file
+
+  @copyright 2016 NumScale SAS
+  @copyright 2016 J.T.Lapreste
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#ifndef BOOST_SIMD_FUNCTION_DEFINITION_DIV_INCLUDED
+#define BOOST_SIMD_FUNCTION_DEFINITION_DIV_INCLUDED
+
+#include <boost/simd/config.hpp>
+#include <boost/dispatch/function/make_callable.hpp>
+#include <boost/dispatch/hierarchy/functions.hpp>
+#include <boost/simd/detail/dispatch.hpp>
+#include <boost/simd/function/divides.hpp>
+#include <boost/simd/function/ceil.hpp>
+#include <boost/simd/function/divceil.hpp>
+#include <boost/simd/function/floor.hpp>
+#include <boost/simd/function/divfloor.hpp>
+#include <boost/simd/function/round.hpp>
+#include <boost/simd/function/divround.hpp>
+#include <boost/simd/function/round2even.hpp>
+#include <boost/simd/function/divround2even.hpp>
+#include <boost/simd/function/fix.hpp>
+#include <boost/simd/function/divfix.hpp>
+
+namespace boost { namespace simd
+{
+  namespace tag
+  {
+    BOOST_DISPATCH_MAKE_TAG(ext, div_, boost::dispatch::elementwise_<div_>);
+  }
+  namespace ext
+  {
+    BOOST_DISPATCH_FUNCTION_DECLARATION(tag, div_);
+  }
+  namespace detail
+  {
+    BOOST_DISPATCH_CALLABLE_DEFINITION(tag::div_,div);
+  }
+
+  template < typename T>
+  BOOST_FORCEINLINE T div(T const& a, T const& b )
+  BOOST_NOEXCEPT
+  {
+    namespace bs = boost::simd;
+    return bs::divides(a, b);
+  }
+
+  template < typename T, typename O>
+  BOOST_FORCEINLINE T div(T const& a, T const& b, O const& )
+  BOOST_NOEXCEPT
+  {
+    namespace bs = boost::simd;
+    return bs::divides(a, b, O());
+  }
+
+#define BOOST_SIMD_DIV_WITH_OPTION(option)                      \
+  template < typename T>                                        \
+  BOOST_FORCEINLINE T div(T const& a, T const& b                \
+                         , boost::simd::tag::option##_ const& ) \
+    BOOST_NOEXCEPT                                              \
+  {                                                             \
+    return div##option(a, b);                                   \
+  }                                                             \
+/**/
+
+BOOST_SIMD_DIV_WITH_OPTION(ceil)
+BOOST_SIMD_DIV_WITH_OPTION(fix)
+BOOST_SIMD_DIV_WITH_OPTION(floor)
+BOOST_SIMD_DIV_WITH_OPTION(round)
+BOOST_SIMD_DIV_WITH_OPTION(round2even)
+
+} }
+
+#endif

--- a/include/boost/simd/function/definition/div.hpp
+++ b/include/boost/simd/function/definition/div.hpp
@@ -52,8 +52,8 @@ namespace boost { namespace simd
   }
 
   template < typename T, typename O>
-  BOOST_FORCEINLINE T div(T const& a, T const& b, O const& )
-  BOOST_NOEXCEPT
+  BOOST_FORCEINLINE auto div(T const& a, T const& b, O const& )
+  BOOST_DECL_NOEXCEPT
   {
     namespace bs = boost::simd;
     return bs::divides(a, b, O());

--- a/include/boost/simd/function/definition/div.hpp
+++ b/include/boost/simd/function/definition/div.hpp
@@ -16,17 +16,6 @@
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>
-#include <boost/simd/function/divides.hpp>
-#include <boost/simd/function/definition/ceil.hpp>
-#include <boost/simd/function/divceil.hpp>
-#include <boost/simd/function/definition/floor.hpp>
-#include <boost/simd/function/divfloor.hpp>
-#include <boost/simd/function/definition/round.hpp>
-#include <boost/simd/function/divround.hpp>
-#include <boost/simd/function/definition/round2even.hpp>
-#include <boost/simd/function/divround2even.hpp>
-#include <boost/simd/function/definition/fix.hpp>
-#include <boost/simd/function/divfix.hpp>
 
 namespace boost { namespace simd
 {
@@ -38,42 +27,40 @@ namespace boost { namespace simd
   {
     BOOST_DISPATCH_FUNCTION_DECLARATION(tag, div_);
   }
-  namespace detail
-  {
-    BOOST_DISPATCH_CALLABLE_DEFINITION(tag::div_,div);
-  }
 
-  namespace bs = boost::simd;
-  namespace bd = boost::dispatch;
-  template < typename T>
-  BOOST_FORCEINLINE T div(T const& a, T const& b )
-  BOOST_NOEXCEPT
-  {
-    return bs::divides(a, b);
-  }
+  BOOST_DISPATCH_CALLABLE_DEFINITION(tag::div_,div);
 
-  template < typename T, typename O>
-  auto div(T const& a, T const& b, O const& )
-    BOOST_NOEXCEPT_DECLTYPE(bs::divides(a, b, O()))
-  {
-    return bs::divides(a, b, O());
-  }
+//   namespace bs = boost::simd;
+//   namespace bd = boost::dispatch;
+//   template < typename T>
+//   BOOST_FORCEINLINE T div(T const& a, T const& b )
+//   BOOST_NOEXCEPT
+//   {
+//     return bs::divides(a, b);
+//   }
 
-#define BOOST_SIMD_DIV_WITH_OPTION(option)                      \
-  template < typename T>                                        \
-  BOOST_FORCEINLINE auto div(T const& a, T const& b             \
-                         , bd::functor<bs::tag::option##_> const& ) \
-    BOOST_NOEXCEPT_DECLTYPE(bs::div##option(a, b))              \
-  {                                                             \
-    return bs::div##option(a, b);                               \
-  }                                                             \
-/**/
+//   template < typename T, typename O>
+//   auto div(T const& a, T const& b, O const& )
+//     BOOST_NOEXCEPT_DECLTYPE(bs::divides(a, b, O()))
+//   {
+//     return bs::divides(a, b, O());
+//   }
 
-BOOST_SIMD_DIV_WITH_OPTION(ceil)
-BOOST_SIMD_DIV_WITH_OPTION(fix)
-BOOST_SIMD_DIV_WITH_OPTION(floor)
-BOOST_SIMD_DIV_WITH_OPTION(round)
-BOOST_SIMD_DIV_WITH_OPTION(round2even)
+// #define BOOST_SIMD_DIV_WITH_OPTION(option)                      \
+//   template < typename T>                                        \
+//   BOOST_FORCEINLINE auto div(T const& a, T const& b             \
+//                          , bd::functor<bs::tag::option##_> const& ) \
+//     BOOST_NOEXCEPT_DECLTYPE(bs::div##option(a, b))              \
+//   {                                                             \
+//     return bs::div##option(a, b);                               \
+//   }                                                             \
+// /**/
+
+// BOOST_SIMD_DIV_WITH_OPTION(ceil)
+// BOOST_SIMD_DIV_WITH_OPTION(fix)
+// BOOST_SIMD_DIV_WITH_OPTION(floor)
+// BOOST_SIMD_DIV_WITH_OPTION(round)
+// BOOST_SIMD_DIV_WITH_OPTION(round2even)
 
 } }
 

--- a/include/boost/simd/function/definition/div.hpp
+++ b/include/boost/simd/function/definition/div.hpp
@@ -43,15 +43,15 @@ namespace boost { namespace simd
     BOOST_DISPATCH_CALLABLE_DEFINITION(tag::div_,div);
   }
 
+  namespace bs = boost::simd;
+  namespace bd = boost::dispatch;
   template < typename T>
   BOOST_FORCEINLINE T div(T const& a, T const& b )
   BOOST_NOEXCEPT
   {
-    namespace bs = boost::simd;
     return bs::divides(a, b);
   }
 
-  namespace bs = boost::simd;
   template < typename T, typename O>
   auto div(T const& a, T const& b, O const& )
     BOOST_NOEXCEPT_DECLTYPE(bs::divides(a, b, O()))
@@ -62,7 +62,7 @@ namespace boost { namespace simd
 #define BOOST_SIMD_DIV_WITH_OPTION(option)                      \
   template < typename T>                                        \
   BOOST_FORCEINLINE auto div(T const& a, T const& b             \
-                         , boost::simd::tag::option##_ const& ) \
+                         , bd::functor<bs::tag::option##_> const& ) \
     BOOST_NOEXCEPT_DECLTYPE(bs::div##option(a, b))              \
   {                                                             \
     return bs::div##option(a, b);                               \

--- a/include/boost/simd/function/definition/idiv.hpp
+++ b/include/boost/simd/function/definition/idiv.hpp
@@ -43,6 +43,7 @@ namespace boost { namespace simd
   }
 
   namespace bs = boost::simd;
+  namespace bd = boost::dispatch;
   template < typename T>
   BOOST_FORCEINLINE auto idiv(T const& a, T const& b )
     BOOST_NOEXCEPT_DECLTYPE(bs::idivfix(a, b))
@@ -53,7 +54,7 @@ namespace boost { namespace simd
 #define BOOST_SIMD_IDIV_WITH_OPTION(option)                      \
   template < typename T>                                         \
   BOOST_FORCEINLINE auto idiv(T const& a, T const& b             \
-                         , boost::simd::tag::option##_ const& )  \
+                             , bd::functor<bs::tag::option##_> const& ) \
     BOOST_NOEXCEPT_DECLTYPE(bs::idiv##option(a, b))              \
   {                                                              \
     return idiv##option(a, b);                                   \

--- a/include/boost/simd/function/definition/idiv.hpp
+++ b/include/boost/simd/function/definition/idiv.hpp
@@ -1,0 +1,71 @@
+//==================================================================================================
+/*!
+  @file
+
+  @copyright 2016 NumScale SAS
+  @copyright 2016 J.T.Lapreste
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#ifndef BOOST_SIMD_FUNCTION_DEFINITION_IDIV_INCLUDED
+#define BOOST_SIMD_FUNCTION_DEFINITION_IDIV_INCLUDED
+
+#include <boost/simd/config.hpp>
+#include <boost/dispatch/function/make_callable.hpp>
+#include <boost/dispatch/hierarchy/functions.hpp>
+#include <boost/simd/detail/dispatch.hpp>
+#include <boost/simd/function/ceil.hpp>
+#include <boost/simd/function/idivceil.hpp>
+#include <boost/simd/function/floor.hpp>
+#include <boost/simd/function/idivfloor.hpp>
+#include <boost/simd/function/round.hpp>
+#include <boost/simd/function/idivround.hpp>
+#include <boost/simd/function/round2even.hpp>
+#include <boost/simd/function/idivround2even.hpp>
+#include <boost/simd/function/fix.hpp>
+#include <boost/simd/function/idivfix.hpp>
+
+namespace boost { namespace simd
+{
+  namespace tag
+  {
+    BOOST_DISPATCH_MAKE_TAG(ext, idiv_, boost::dispatch::elementwise_<idiv_>);
+  }
+  namespace ext
+  {
+    BOOST_DISPATCH_FUNCTION_DECLARATION(tag, idiv_);
+  }
+  namespace detail
+  {
+    BOOST_DISPATCH_CALLABLE_DEFINITION(tag::idiv_,idiv);
+  }
+
+  namespace bs = boost::simd;
+  template < typename T>
+  BOOST_FORCEINLINE auto idiv(T const& a, T const& b )
+    BOOST_NOEXCEPT_DECLTYPE(bs::idivfix(a, b))
+  {
+    return bs::idivfix(a, b);
+  }
+
+#define BOOST_SIMD_IDIV_WITH_OPTION(option)                      \
+  template < typename T>                                         \
+  BOOST_FORCEINLINE auto idiv(T const& a, T const& b             \
+                         , boost::simd::tag::option##_ const& )  \
+    BOOST_NOEXCEPT_DECLTYPE(bs::idiv##option(a, b))              \
+  {                                                              \
+    return idiv##option(a, b);                                   \
+  }                                                              \
+/**/
+
+BOOST_SIMD_IDIV_WITH_OPTION(ceil)
+BOOST_SIMD_IDIV_WITH_OPTION(fix)
+BOOST_SIMD_IDIV_WITH_OPTION(floor)
+BOOST_SIMD_IDIV_WITH_OPTION(round)
+BOOST_SIMD_IDIV_WITH_OPTION(round2even)
+
+} }
+
+#endif

--- a/include/boost/simd/function/definition/idiv.hpp
+++ b/include/boost/simd/function/definition/idiv.hpp
@@ -16,15 +16,15 @@
 #include <boost/dispatch/function/make_callable.hpp>
 #include <boost/dispatch/hierarchy/functions.hpp>
 #include <boost/simd/detail/dispatch.hpp>
-#include <boost/simd/function/ceil.hpp>
+#include <boost/simd/function/definition/ceil.hpp>
 #include <boost/simd/function/idivceil.hpp>
-#include <boost/simd/function/floor.hpp>
+#include <boost/simd/function/definition/floor.hpp>
 #include <boost/simd/function/idivfloor.hpp>
-#include <boost/simd/function/round.hpp>
+#include <boost/simd/function/definition/round.hpp>
 #include <boost/simd/function/idivround.hpp>
-#include <boost/simd/function/round2even.hpp>
+#include <boost/simd/function/definition/round2even.hpp>
 #include <boost/simd/function/idivround2even.hpp>
-#include <boost/simd/function/fix.hpp>
+#include <boost/simd/function/definition/fix.hpp>
 #include <boost/simd/function/idivfix.hpp>
 
 namespace boost { namespace simd

--- a/include/boost/simd/function/div.hpp
+++ b/include/boost/simd/function/div.hpp
@@ -1,0 +1,64 @@
+//==================================================================================================
+/*!
+  @file
+
+  @copyright 2016 J.T.Lapreste
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#ifndef BOOST_SIMD_FUNCTION_DIV_INCLUDED
+#define BOOST_SIMD_FUNCTION_DIV_INCLUDED
+
+#if defined(DOXYGEN_ONLY)
+namespace boost { namespace simd
+{
+  /*!
+    @ingroup group-operator
+
+    Perform the quotient of two parameters of the same type with or without options.
+
+    @par Semantic
+
+    For any value @c a and @c b of type @c T,
+
+    @code
+    T r = div(a, b{, option});
+    @endcode
+
+    returns the quotient of @c a by @c b according to the option
+
+    if there is no option the call is equivalent to divides(a, b),  else
+    option can be ceil_(), floor_(), fix_(), round_(), round2even_() and provide the
+    sme result as divceil(a, b), divfloor(a, b), divfix(a, b), divround(a, b)
+
+    @param a First  parameter of the quotient
+    @param b Second parameter of the quotient
+    @param option is the option
+
+    @return The quotient of the two parameters.
+  **/
+  template<typename T> auto div(T const& a, T const& b);
+
+  namespace functional
+  {
+    /*!
+      @ingroup group-callable-operator
+
+      Perform the quotient of two parameters of the same type.
+
+
+      Function object tied to boost::simd::div
+
+      @see boost::simd::div
+    **/
+    const boost::dispatch::functor<tag::div_> div = {};
+  }
+} }
+#endif
+
+#include <boost/simd/function/scalar/div.hpp>
+
+
+#endif

--- a/include/boost/simd/function/div.hpp
+++ b/include/boost/simd/function/div.hpp
@@ -30,8 +30,9 @@ namespace boost { namespace simd
     returns the quotient of @c a by @c b according to the option
 
     if there is no option the call is equivalent to divides(a, b),  else
-    option can be ceil_(), floor_(), fix_(), round_(), round2even_() and provide the
-    sme result as divceil(a, b), divfloor(a, b), divfix(a, b), divround(a, b)
+    option can be ceil, floor, fix, round, round2even (in the namespace booost::simd)
+    and provide the same result as the calls divceil(a, b), divfloor(a, b),
+    divfix(a, b), divround(a, b).
 
     @param a First  parameter of the quotient
     @param b Second parameter of the quotient

--- a/include/boost/simd/function/idiv.hpp
+++ b/include/boost/simd/function/idiv.hpp
@@ -1,0 +1,65 @@
+//==================================================================================================
+/*!
+  @file
+
+  @copyright 2016 J.T.Lapreste
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#ifndef BOOST_SIMD_FUNCTION_IDIV_INCLUDED
+#define BOOST_SIMD_FUNCTION_IDIV_INCLUDED
+
+#if defined(DOXYGEN_ONLY)
+namespace boost { namespace simd
+{
+  /*!
+    @ingroup group-operator
+
+    Perform the quotient of two parameters of the same type with or without options to return
+    an integer result of the type associated to the first parameter.
+
+    @par Semantic
+
+    For any value @c a and @c b of type @c T,
+
+    @code
+    T r = idiv(a, b{, option});
+    @endcode
+
+    returns the quotient of @c a by @c b according to the option
+
+    if there is no option the call is equivalent to divfix(a, b),  else
+    option can be ceil_(), floor_(), fix_(), round_(), round2even_() and provide the
+    same result as idivceil(a, b), idivfloor(a, b), idivfix(a, b), idivround(a, b)
+
+    @param a First  parameter of the quotient
+    @param b Second parameter of the quotient
+    @param option is the option
+
+    @return The quotient of the two parameters.
+  **/
+  template<typename T> auto idiv(T const& a, T const& b);
+
+  namespace functional
+  {
+    /*!
+      @ingroup group-callable-operator
+
+      Perform the quotient of two parameters of the same type.
+
+
+      Function object tied to boost::simd::idiv
+
+      @see boost::simd::idiv
+    **/
+    const boost::dispatch::functor<tag::idiv_> idiv = {};
+  }
+} }
+#endif
+
+#include <boost/simd/function/scalar/idiv.hpp>
+
+
+#endif

--- a/include/boost/simd/function/incs.hpp
+++ b/include/boost/simd/function/incs.hpp
@@ -22,7 +22,7 @@ namespace boost { namespace simd
 
     Returns the entry plus one, saturated in the entry type.
 
-    This is a convenient alias of @ref abs
+    This is a convenient alias of @ref oneplus
   **/
   const boost::dispatch::functor<tag::incs_> incs = {};
 } }

--- a/include/boost/simd/function/mod.hpp
+++ b/include/boost/simd/function/mod.hpp
@@ -35,7 +35,7 @@ namespace boost { namespace simd
     The code is similar to:
 
     @code
-    T r = x-divfloor(x, y)*y;
+    T r = x-div(x, y, floor)*y;
     @endcode
 
     @see remainder, rem,  modulo

--- a/include/boost/simd/function/scalar/div.hpp
+++ b/include/boost/simd/function/scalar/div.hpp
@@ -1,0 +1,16 @@
+//==================================================================================================
+/*!
+  @file
+
+  @copyright 2016 J.T.Lapreste
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#ifndef BOOST_SIMD_FUNCTION_SCALAR_DIV_INCLUDED
+#define BOOST_SIMD_FUNCTION_SCALAR_DIV_INCLUDED
+
+#include <boost/simd/function/definition/div.hpp>
+
+#endif

--- a/include/boost/simd/function/scalar/idiv.hpp
+++ b/include/boost/simd/function/scalar/idiv.hpp
@@ -1,0 +1,16 @@
+//==================================================================================================
+/*!
+  @file
+
+  @copyright 2016 J.T.Lapreste
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#ifndef BOOST_SIMD_FUNCTION_SCALAR_IDIV_INCLUDED
+#define BOOST_SIMD_FUNCTION_SCALAR_IDIV_INCLUDED
+
+#include <boost/simd/function/definition/idiv.hpp>
+
+#endif

--- a/include/boost/simd/function/simd/div.hpp
+++ b/include/boost/simd/function/simd/div.hpp
@@ -2,16 +2,16 @@
 /*!
   @file
 
-  @copyright 2016 J.T.Lapreste
+  Copyright 2016 J.T.Lapreste
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 */
 //==================================================================================================
-#ifndef BOOST_SIMD_FUNCTION_SCALAR_DIV_INCLUDED
-#define BOOST_SIMD_FUNCTION_SCALAR_DIV_INCLUDED
+#ifndef BOOST_SIMD_FUNCTION_SIMD_DIV_INCLUDED
+#define BOOST_SIMD_FUNCTION_SIMD_DIV_INCLUDED
 
-#include <boost/simd/function/definition/div.hpp>
-#include <boost/simd/arch/common/generic/function/div.hpp>
+#include <boost/simd/function/scalar/div.hpp>
 
 #endif
+

--- a/test/function/scalar/CMakeLists.txt
+++ b/test/function/scalar/CMakeLists.txt
@@ -367,7 +367,6 @@ set ( SOURCES
    compare_lt.cpp
    compare_neq.cpp
    bitwise_not.cpp
-   divtrunc.cpp
    rdivide.cpp
    if_zero_else_allbits.cpp
    if_allbits_else_zero.cpp

--- a/test/function/scalar/CMakeLists.txt
+++ b/test/function/scalar/CMakeLists.txt
@@ -43,6 +43,7 @@ set ( SOURCES
    fnms.cpp
    hypot.cpp
    iceil.cpp
+   idiv.cpp
    idivceil.cpp
    idivfix.cpp
    idivfloor.cpp

--- a/test/function/scalar/CMakeLists.txt
+++ b/test/function/scalar/CMakeLists.txt
@@ -31,10 +31,10 @@ set ( SOURCES
    dists.cpp
    div.cpp
    divceil.cpp
-   divfix.cpp
    divfloor.cpp
-   divround2even.cpp
    divround.cpp
+   divround2even.cpp
+   divtrunc.cpp
    divs.cpp
    floor.cpp
    fma.cpp
@@ -47,8 +47,8 @@ set ( SOURCES
    idivceil.cpp
    idivfix.cpp
    idivfloor.cpp
-   idivround2even.cpp
    idivround.cpp
+   idivround2even.cpp
    ifloor.cpp
    inc.cpp
    iround2even.cpp

--- a/test/function/scalar/CMakeLists.txt
+++ b/test/function/scalar/CMakeLists.txt
@@ -29,6 +29,7 @@ set ( SOURCES
    dec.cpp
    dist.cpp
    dists.cpp
+   div.cpp
    divceil.cpp
    divfix.cpp
    divfloor.cpp

--- a/test/function/scalar/div.cpp
+++ b/test/function/scalar/div.cpp
@@ -54,15 +54,9 @@ STF_CASE_TPL( "Check div behavior with options", STF_NUMERIC_TYPES )
   using r_t = decltype(div(T(), T()));
   STF_TYPE_IS(r_t, T);
 
-  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::tag::ceil_()), bs::One<r_t>());
-  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::tag::floor_()), bs::Zero<r_t>());
-  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::tag::round_()), bs::One<r_t>());
-  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::tag::round2even_()), bs::Zero<r_t>());
-  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::tag::fix_()), bs::Zero<r_t>());
-
-//   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::ceil), bs::One<r_t>());
-//   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::floor), bs::Zero<r_t>());
-//   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::round), bs::One<r_t>());
-//   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::round2even), bs::Zero<r_t>());
-//   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::fix), bs::Zero<r_t>());
+  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::ceil), bs::One<r_t>());
+  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::floor), bs::Zero<r_t>());
+  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::round), bs::One<r_t>());
+  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::round2even), bs::Zero<r_t>());
+  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::fix), bs::Zero<r_t>());
 }

--- a/test/function/scalar/div.cpp
+++ b/test/function/scalar/div.cpp
@@ -9,14 +9,13 @@
 //==================================================================================================
 #include <boost/simd/function/div.hpp>
 #include <simd_test.hpp>
-//#include <nontrivial.hpp>
 #include <boost/simd/constant/inf.hpp>
 #include <boost/simd/constant/minf.hpp>
 #include <boost/simd/constant/mone.hpp>
 #include <boost/simd/constant/nan.hpp>
 #include <boost/simd/constant/one.hpp>
 #include <boost/simd/constant/zero.hpp>
-#include <boost/simd/options.hpp>
+#include <boost/simd/constant/half.hpp>
 #include <boost/simd/function/ceil.hpp>
 
 STF_CASE_TPL( "Check div behavior with floating", STF_IEEE_TYPES )
@@ -35,16 +34,6 @@ STF_CASE_TPL( "Check div behavior with floating", STF_IEEE_TYPES )
   STF_IEEE_EQUAL(div(bs::Zero<T>(), bs::Zero<T>()), bs::Nan<r_t>());
   STF_IEEE_EQUAL(div(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
 }
-
-
-// STF_CASE_TPL( "Check div behavior with fast option", STF_IEEE_TYPES )
-// {
-//   namespace bs = boost::simd;
-//   using bs::div;
-//   using bs::fast_;
-
-//   STF_EQUAL(div(T(1), T(2), fast_), T(1/2.0));
-// }
 
 
 STF_CASE_TPL( "Check div behavior with options", STF_NUMERIC_TYPES )

--- a/test/function/scalar/div.cpp
+++ b/test/function/scalar/div.cpp
@@ -37,26 +37,26 @@ STF_CASE_TPL( "Check div behavior with floating", STF_IEEE_TYPES )
 }
 
 
-STF_CASE_TPL( "Check div behavior with fast option", STF_IEEE_TYPES )
-{
-  namespace bs = boost::simd;
-  using bs::div;
-  using bs::fast_;
+// STF_CASE_TPL( "Check div behavior with fast option", STF_IEEE_TYPES )
+// {
+//   namespace bs = boost::simd;
+//   using bs::div;
+//   using bs::fast_;
 
-  STF_EQUAL(div(T(1), T(2), fast_), T(1/2.0));
-}
+//   STF_EQUAL(div(T(1), T(2), fast_), T(1/2.0));
+// }
 
 
 STF_CASE_TPL( "Check div behavior with options", STF_NUMERIC_TYPES )
 {
   namespace bs = boost::simd;
   using bs::div;
-  using r_t = decltype(div(T(), T()));
-  STF_TYPE_IS(r_t, T);
-
-  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::ceil), bs::One<r_t>());
-  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::floor), bs::Zero<r_t>());
-  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::round), bs::One<r_t>());
-  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::round2even), bs::Zero<r_t>());
-  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::fix), bs::Zero<r_t>());
+//   using r_t = decltype(div(T(), T()));
+//   STF_TYPE_IS(r_t, T);
+  std::cout << stf::type_id(bs::ceil) << std::endl;//div(bs::One<T>(), bs::Two<T>(), bs::ceil);
+//  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::ceil), bs::One<r_t>());
+//   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::floor), bs::Zero<r_t>());
+//   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::round), bs::One<r_t>());
+//   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::round2even), bs::Zero<r_t>());
+//   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::fix), bs::Zero<r_t>());
 }

--- a/test/function/scalar/div.cpp
+++ b/test/function/scalar/div.cpp
@@ -1,0 +1,62 @@
+//==================================================================================================
+/*!
+
+  Copyright 2015 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#include <boost/simd/function/div.hpp>
+#include <simd_test.hpp>
+//#include <nontrivial.hpp>
+#include <boost/simd/constant/inf.hpp>
+#include <boost/simd/constant/minf.hpp>
+#include <boost/simd/constant/mone.hpp>
+#include <boost/simd/constant/nan.hpp>
+#include <boost/simd/constant/one.hpp>
+#include <boost/simd/constant/zero.hpp>
+#include <boost/simd/options.hpp>
+#include <boost/simd/function/ceil.hpp>
+
+STF_CASE_TPL( "Check div behavior with floating", STF_IEEE_TYPES )
+{
+  namespace bs = boost::simd;
+  using bs::div;
+  using r_t = decltype(div(T(), T()));
+  STF_TYPE_IS(r_t, T);
+
+#ifndef STF_NO_INVALIDS
+  STF_IEEE_EQUAL(div(bs::Inf<T>(),  bs::Inf<T>()), bs::Nan<r_t>());
+  STF_IEEE_EQUAL(div(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
+  STF_IEEE_EQUAL(div(bs::Nan<T>(),  bs::Nan<T>()), bs::Nan<r_t>());
+#endif
+  STF_IEEE_EQUAL(div(bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>());
+  STF_IEEE_EQUAL(div(bs::Zero<T>(), bs::Zero<T>()), bs::Nan<r_t>());
+  STF_IEEE_EQUAL(div(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
+}
+
+
+STF_CASE_TPL( "Check div behavior with fast option", STF_IEEE_TYPES )
+{
+  namespace bs = boost::simd;
+  using bs::div;
+  using bs::fast_;
+
+  STF_EQUAL(div(T(1), T(2), fast_), T(1/2.0));
+}
+
+
+STF_CASE_TPL( "Check div behavior with options", STF_NUMERIC_TYPES )
+{
+  namespace bs = boost::simd;
+  using bs::div;
+  using r_t = decltype(div(T(), T()));
+  STF_TYPE_IS(r_t, T);
+
+  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::tag::ceil_()), bs::One<r_t>());
+  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::tag::floor_()), bs::Zero<r_t>());
+  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::tag::round_()), bs::One<r_t>());
+  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::tag::round2even_()), bs::Zero<r_t>());
+  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::tag::fix_()), bs::Zero<r_t>());
+}

--- a/test/function/scalar/div.cpp
+++ b/test/function/scalar/div.cpp
@@ -59,4 +59,10 @@ STF_CASE_TPL( "Check div behavior with options", STF_NUMERIC_TYPES )
   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::tag::round_()), bs::One<r_t>());
   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::tag::round2even_()), bs::Zero<r_t>());
   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::tag::fix_()), bs::Zero<r_t>());
+
+//   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::ceil), bs::One<r_t>());
+//   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::floor), bs::Zero<r_t>());
+//   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::round), bs::One<r_t>());
+//   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::round2even), bs::Zero<r_t>());
+//   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::fix), bs::Zero<r_t>());
 }

--- a/test/function/scalar/div.cpp
+++ b/test/function/scalar/div.cpp
@@ -51,12 +51,12 @@ STF_CASE_TPL( "Check div behavior with options", STF_NUMERIC_TYPES )
 {
   namespace bs = boost::simd;
   using bs::div;
-//   using r_t = decltype(div(T(), T()));
-//   STF_TYPE_IS(r_t, T);
-  std::cout << stf::type_id(bs::ceil) << std::endl;//div(bs::One<T>(), bs::Two<T>(), bs::ceil);
-//  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::ceil), bs::One<r_t>());
-//   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::floor), bs::Zero<r_t>());
-//   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::round), bs::One<r_t>());
-//   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::round2even), bs::Zero<r_t>());
-//   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::fix), bs::Zero<r_t>());
+  using r_t = decltype(div(T(), T()));
+  STF_TYPE_IS(r_t, T);
+  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>())          , bs::Zero<r_t>());
+  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::ceil), bs::One<r_t>());
+  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::floor), bs::Zero<r_t>());
+  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::round), bs::One<r_t>());
+  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::round2even), bs::Zero<r_t>());
+  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::fix), bs::Zero<r_t>());
 }

--- a/test/function/scalar/div.cpp
+++ b/test/function/scalar/div.cpp
@@ -42,7 +42,7 @@ STF_CASE_TPL( "Check div behavior with options", STF_NUMERIC_TYPES )
   using bs::div;
   using r_t = decltype(div(T(), T()));
   STF_TYPE_IS(r_t, T);
-  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>())          , bs::Zero<r_t>());
+  STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>())          , bs::Half<r_t>());
   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::ceil), bs::One<r_t>());
   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::floor), bs::Zero<r_t>());
   STF_IEEE_EQUAL(div(bs::One<T>(), bs::Two<T>(), bs::round), bs::One<r_t>());

--- a/test/function/scalar/divceil.cpp
+++ b/test/function/scalar/divceil.cpp
@@ -7,7 +7,7 @@
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 */
 //==================================================================================================
-#include <boost/simd/function/divceil.hpp>
+#include <boost/simd/function/div.hpp>
 #include <simd_test.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>
 #include <boost/simd/constant/inf.hpp>
@@ -21,61 +21,50 @@
 #include <boost/simd/constant/two.hpp>
 
 
-STF_CASE_TPL (" divceil real",  STF_IEEE_TYPES)
+STF_CASE_TPL (" div real",  STF_IEEE_TYPES)
 {
   namespace bs = boost::simd;
-  using bs::divceil;
-  using r_t = decltype(divceil(T(), T()));
+  using bs::div;
+  using r_t = decltype(div(T(), T()));
 
-  STF_TYPE_IS(r_t, T);
-
-  // specific values tests
-#ifndef STF_NO_INVALIDS
-  STF_IEEE_EQUAL(divceil(bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(divceil(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(divceil(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
+  STF_IEEE_EQUAL(div(bs::Inf<T>(), bs::Inf<T>(), bs::ceil), bs::Nan<r_t>());
+  STF_IEEE_EQUAL(div(bs::Minf<T>(), bs::Minf<T>(), bs::ceil), bs::Nan<r_t>());
+  STF_IEEE_EQUAL(div(bs::Nan<T>(), bs::Nan<T>(), bs::ceil), bs::Nan<r_t>());
 #endif
-  STF_EQUAL(divceil(T(4),T(0)), bs::Inf<r_t>());
-  STF_EQUAL(divceil(T(4),T(3)), 2);
-  STF_EQUAL(divceil(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(divceil(bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>());
-  STF_EQUAL(divceil(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(divceil(bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(divceil(bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>());
+  STF_EQUAL(div(T(4),T(0), bs::ceil), bs::Inf<r_t>());
+  STF_EQUAL(div(T(4),T(3), bs::ceil), 2);
+  STF_EQUAL(div(bs::Mone<T>(), bs::Mone<T>(), bs::ceil), bs::One<r_t>());
+  STF_EQUAL(div(bs::Mone<T>(),bs::Zero<T>(), bs::ceil), bs::Minf<r_t>());
+  STF_EQUAL(div(bs::One<T>(), bs::One<T>(), bs::ceil), bs::One<r_t>());
+  STF_EQUAL(div(bs::One<T>(),bs::Zero<T>(), bs::ceil), bs::Inf<r_t>());
+  STF_IEEE_EQUAL(div(bs::Zero<T>(),bs::Zero<T>(), bs::ceil), bs::Nan<r_t>());
 } // end of test for floating_
 
-STF_CASE_TPL (" divceil unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL (" div unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
-  using bs::divceil;
-  using r_t = decltype(divceil(T(), T()));
+  using bs::div;
 
-  STF_TYPE_IS(r_t, T);
-
-  // specific values tests
-  STF_EQUAL(divceil(T(4),T(0)), bs::Valmax<r_t>());
-  STF_EQUAL(divceil(T(4),T(3)), T(2));
-  STF_EQUAL(divceil(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(divceil(bs::Valmax<T>(),  bs::Two<T>()), bs::Valmax<r_t>()/bs::Two<T>()+bs::One<T>());
+  STF_EQUAL(div(T(4),T(0), bs::ceil), bs::Valmax<r_t>());
+  STF_EQUAL(div(T(4),T(3), bs::ceil), T(2));
+  STF_EQUAL(div(bs::One<T>(), bs::One<T>(), bs::ceil), bs::One<r_t>());
+  STF_EQUAL(div(bs::Valmax<T>(),  bs::Two<T>(), bs::ceil), bs::Valmax<r_t>()/bs::Two<T>()+bs::One<T>());
 } // end of test for unsigned_int_
 
-STF_CASE_TPL (" divceil signed_int",  STF_SIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL (" div signed_int",  STF_SIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
-  using bs::divceil;
-  using r_t = decltype(divceil(T(), T()));
+  using bs::div;
+  using r_t = decltype(div(T(), T()));
 
-  STF_TYPE_IS(r_t, T);
-
-  // specific values tests
-  STF_EQUAL(divceil(T(-4),T(0)), bs::Valmin<r_t>());
-  STF_EQUAL(divceil(T(4),T(0)), bs::Valmax<r_t>());
-  STF_EQUAL(divceil(T(4),T(3)), T(2));
-  STF_EQUAL(divceil(T(-4),T(-3)), T(2));
-  STF_EQUAL(divceil(T(4),T(-3)), T(-1));
-  STF_EQUAL(divceil(T(-4),T(3)), T(-1));
-  STF_EQUAL(divceil(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(divceil(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
+  STF_EQUAL(div(T(-4),T(0), bs::ceil), bs::Valmin<r_t>());
+  STF_EQUAL(div(T(4),T(0), bs::ceil), bs::Valmax<r_t>());
+  STF_EQUAL(div(T(4),T(3), bs::ceil), T(2));
+  STF_EQUAL(div(T(-4),T(-3), bs::ceil), T(2));
+  STF_EQUAL(div(T(4),T(-3), bs::ceil), T(-1));
+  STF_EQUAL(div(T(-4),T(3), bs::ceil), T(-1));
+  STF_EQUAL(div(bs::Mone<T>(), bs::Mone<T>(), bs::ceil), bs::One<r_t>());
+  STF_EQUAL(div(bs::One<T>(), bs::One<T>(), bs::ceil), bs::One<r_t>());
 } // end of test for signed_int_
 
 

--- a/test/function/scalar/divceil.cpp
+++ b/test/function/scalar/divceil.cpp
@@ -27,6 +27,7 @@ STF_CASE_TPL (" div real",  STF_IEEE_TYPES)
   using bs::div;
   using r_t = decltype(div(T(), T()));
 
+#ifndef BOOST_SIMD_NO_INVALIDS
   STF_IEEE_EQUAL(div(bs::Inf<T>(), bs::Inf<T>(), bs::ceil), bs::Nan<r_t>());
   STF_IEEE_EQUAL(div(bs::Minf<T>(), bs::Minf<T>(), bs::ceil), bs::Nan<r_t>());
   STF_IEEE_EQUAL(div(bs::Nan<T>(), bs::Nan<T>(), bs::ceil), bs::Nan<r_t>());
@@ -44,6 +45,7 @@ STF_CASE_TPL (" div unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
   using bs::div;
+  using r_t = decltype(div(T(), T()));
 
   STF_EQUAL(div(T(4),T(0), bs::ceil), bs::Valmax<r_t>());
   STF_EQUAL(div(T(4),T(3), bs::ceil), T(2));

--- a/test/function/scalar/divfloor.cpp
+++ b/test/function/scalar/divfloor.cpp
@@ -7,7 +7,7 @@
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 */
 //==================================================================================================
-#include <boost/simd/function/divfloor.hpp>
+#include <boost/simd/function/div.hpp>
 #include <simd_test.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>
 #include <boost/simd/constant/inf.hpp>
@@ -19,63 +19,63 @@
 #include <boost/simd/constant/two.hpp>
 
 
-STF_CASE_TPL (" divfloorreal",  STF_IEEE_TYPES)
+STF_CASE_TPL (" divreal",  STF_IEEE_TYPES)
 {
   namespace bs = boost::simd;
-  using bs::divfloor;
-  using r_t = decltype(divfloor(T(), T()));
+  using bs::div;
+  using r_t = decltype(div(T(), T()));
 
   // return type conformity test
   STF_TYPE_IS(r_t,T);
 
   // specific values tests
 #ifndef STF_NO_INVALIDS
-  STF_IEEE_EQUAL(divfloor(bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(divfloor(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(divfloor(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
+  STF_IEEE_EQUAL(div(bs::Inf<T>(), bs::Inf<T>(), bs::floor), bs::Nan<r_t>());
+  STF_IEEE_EQUAL(div(bs::Minf<T>(), bs::Minf<T>(), bs::floor), bs::Nan<r_t>());
+  STF_IEEE_EQUAL(div(bs::Nan<T>(), bs::Nan<T>(), bs::floor), bs::Nan<r_t>());
 #endif
-  STF_EQUAL(divfloor(T(4),T(0)), bs::Inf<r_t>());
-  STF_EQUAL(divfloor(T(4),T(3)), bs::One<r_t>());
-  STF_EQUAL(divfloor(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(divfloor(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(divfloor(bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>());
-  STF_EQUAL(divfloor(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(divfloor(bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(divfloor(bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>());
+  STF_EQUAL(div(T(4),T(0), bs::floor), bs::Inf<r_t>());
+  STF_EQUAL(div(T(4),T(3), bs::floor), bs::One<r_t>());
+  STF_EQUAL(div(bs::Mone<T>(), bs::Mone<T>(), bs::floor), bs::One<r_t>());
+  STF_EQUAL(div(bs::One<T>(), bs::One<T>(), bs::floor), bs::One<r_t>());
+  STF_EQUAL(div(bs::Mone<T>(),bs::Zero<T>(), bs::floor), bs::Minf<r_t>());
+  STF_EQUAL(div(bs::One<T>(), bs::One<T>(), bs::floor), bs::One<r_t>());
+  STF_EQUAL(div(bs::One<T>(),bs::Zero<T>(), bs::floor), bs::Inf<r_t>());
+  STF_IEEE_EQUAL(div(bs::Zero<T>(),bs::Zero<T>(), bs::floor), bs::Nan<r_t>());
 } // end of test for floating_
 
-STF_CASE_TPL (" divfloorunsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL (" divunsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
-  using bs::divfloor;
-  using r_t = decltype(divfloor(T(), T()));
+  using bs::div;
+  using r_t = decltype(div(T(), T()));
 
   STF_TYPE_IS(r_t,T);
 
   // specific values tests
-  STF_EQUAL(divfloor(T(4),T(0)), bs::Valmax<r_t>());
-  STF_EQUAL(divfloor(T(4),T(3)), T(1));
-  STF_EQUAL(divfloor(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(divfloor(bs::Valmax<T>(),  bs::Two<T>()), bs::Valmax<r_t>()/bs::Two<T>());
+  STF_EQUAL(div(T(4),T(0), bs::floor), bs::Valmax<r_t>());
+  STF_EQUAL(div(T(4),T(3), bs::floor), T(1));
+  STF_EQUAL(div(bs::One<T>(), bs::One<T>(), bs::floor), bs::One<r_t>());
+  STF_EQUAL(div(bs::Valmax<T>(),  bs::Two<T>(), bs::floor), bs::Valmax<r_t>()/bs::Two<T>());
 } // end of test for unsigned_int_
 
-STF_CASE_TPL (" divfloorsigned_int",  STF_SIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL (" divsigned_int",  STF_SIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
-  using bs::divfloor;
-  using r_t = decltype(divfloor(T(), T()));
+  using bs::div;
+  using r_t = decltype(div(T(), T()));
 
   STF_TYPE_IS(r_t,T);
 
   // specific values tests
-  STF_EQUAL(divfloor(T(-4),T(0)), bs::Valmin<r_t>());
-  STF_EQUAL(divfloor(T(4),T(0)), bs::Valmax<r_t>());
-  STF_EQUAL(divfloor(T(4),T(3)), T(1));
-  STF_EQUAL(divfloor(T(-4),T(-3)), T(1));
-  STF_EQUAL(divfloor(T(4),T(-3)), T(-2));
-  STF_EQUAL(divfloor(T(-4),T(3)), T(-2));
-  STF_EQUAL(divfloor(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(divfloor(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
+  STF_EQUAL(div(T(-4),T(0), bs::floor), bs::Valmin<r_t>());
+  STF_EQUAL(div(T(4),T(0), bs::floor), bs::Valmax<r_t>());
+  STF_EQUAL(div(T(4),T(3), bs::floor), T(1));
+  STF_EQUAL(div(T(-4),T(-3), bs::floor), T(1));
+  STF_EQUAL(div(T(4),T(-3), bs::floor), T(-2));
+  STF_EQUAL(div(T(-4),T(3), bs::floor), T(-2));
+  STF_EQUAL(div(bs::Mone<T>(), bs::Mone<T>(), bs::floor), bs::One<r_t>());
+  STF_EQUAL(div(bs::One<T>(), bs::One<T>(), bs::floor), bs::One<r_t>());
 } // end of test for signed_int_
 
 

--- a/test/function/scalar/divround.cpp
+++ b/test/function/scalar/divround.cpp
@@ -7,7 +7,7 @@
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 */
 //==================================================================================================
-#include <boost/simd/function/divround.hpp>
+#include <boost/simd/function/div.hpp>
 #include <simd_test.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>
 #include <boost/simd/constant/inf.hpp>
@@ -18,89 +18,80 @@
 #include <boost/simd/constant/zero.hpp>
 #include <boost/simd/constant/two.hpp>
 
-
-STF_CASE_TPL (" divroundreal",  STF_IEEE_TYPES)
+STF_CASE_TPL (" divreal",  STF_IEEE_TYPES)
 {
   namespace bs = boost::simd;
-  using bs::divround;
-  using r_t = decltype(divround(T(), T()));
+  using bs::div;
+  using r_t = decltype(div(T(), T()));
 
-  // return type conformity test
-  STF_TYPE_IS(r_t, T);
-
-  // specific values tests
-#ifndef STF_NO_INVALIDS
-  STF_IEEE_EQUAL(divround(bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(divround(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(divround(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
+  STF_IEEE_EQUAL(div(bs::Inf<T>(), bs::Inf<T>(), bs::round), bs::Nan<r_t>());
+  STF_IEEE_EQUAL(div(bs::Minf<T>(), bs::Minf<T>(), bs::round), bs::Nan<r_t>());
+  STF_IEEE_EQUAL(div(bs::Nan<T>(), bs::Nan<T>(), bs::round), bs::Nan<r_t>());
 #endif
-  STF_EQUAL(divround(T(4),T(0)), bs::Inf<r_t>());
-  STF_EQUAL(divround(T(4),T(3)), bs::One<r_t>());
-  STF_EQUAL(divround(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(divround(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(divround(bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>());
-  STF_EQUAL(divround(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(divround(bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(divround(bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>());
+  STF_EQUAL(div(T(4),T(0), bs::round), bs::Inf<r_t>());
+  STF_EQUAL(div(T(4),T(3), bs::round), bs::One<r_t>());
+  STF_EQUAL(div(bs::Mone<T>(), bs::Mone<T>(), bs::round), bs::One<r_t>());
+  STF_EQUAL(div(bs::One<T>(), bs::One<T>(), bs::round), bs::One<r_t>());
+  STF_EQUAL(div(bs::Mone<T>(),bs::Zero<T>(), bs::round), bs::Minf<r_t>());
+  STF_EQUAL(div(bs::One<T>(), bs::One<T>(), bs::round), bs::One<r_t>());
+  STF_EQUAL(div(bs::One<T>(),bs::Zero<T>(), bs::round), bs::Inf<r_t>());
+  STF_IEEE_EQUAL(div(bs::Zero<T>(),bs::Zero<T>(), bs::round), bs::Nan<r_t>());
 } // end of test for floating_
 
-STF_CASE_TPL (" divroundunsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL (" divunsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
-  using bs::divround;
-  using r_t = decltype(divround(T(), T()));
+  using bs::div;
+  using r_t = decltype(div(T(), T()));
 
-  STF_TYPE_IS(r_t, T);
-
-  // specific values tests
-  STF_EQUAL(divround(T(4),T(0)), bs::Valmax<r_t>());
-  STF_EQUAL(divround(T(4),T(3)), T(1));
-  STF_EQUAL(divround(T(6),T(4)), T(2));
-  STF_EQUAL(divround(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(divround(bs::Valmax<T>(),  bs::Two<T>()), bs::Valmax<r_t>()/bs::Two<T>()+bs::One<r_t>());
+  STF_EQUAL(div(T(4),T(0), bs::round), bs::Valmax<r_t>());
+  STF_EQUAL(div(T(4),T(3), bs::round), T(1));
+  STF_EQUAL(div(T(6),T(4), bs::round), T(2));
+  STF_EQUAL(div(bs::One<T>(), bs::One<T>(), bs::round), bs::One<r_t>());
+  STF_EQUAL(div(bs::Valmax<T>(),  bs::Two<T>(), bs::round), bs::Valmax<r_t>()/bs::Two<T>()+bs::One<r_t>());
 } // end of test for unsigned_int_
 
-STF_CASE_TPL (" divroundsigned_int",  STF_SIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL (" divsigned_int",  STF_SIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
 
-  using bs::divround;
-  using r_t = decltype(divround(T(), T()));
+  using bs::div;
+  using r_t = decltype(div(T(), T()));
   STF_TYPE_IS(r_t,T);
 
   // specific values tests
-  STF_EQUAL(divround(T(-4),T(0)), bs::Valmin<r_t>());
-  STF_EQUAL(divround(T(4),T(0)), bs::Valmax<r_t>());
-  STF_EQUAL(divround(T(4),T(3)), T(1));
-  STF_EQUAL(divround(T(-4),T(-3)), T(1));
-  STF_EQUAL(divround(T(4),T(-3)), T(-1));
-  STF_EQUAL(divround(T(-4),T(3)), T(-1));
-  STF_EQUAL(divround(T(5),T(3)), T(2));
-  STF_EQUAL(divround(T(-5),T(-3)), T(2));
-  STF_EQUAL(divround(T(5),T(-3)), T(-2));
-  STF_EQUAL(divround(T(-5),T(3)), T(-2));
+  STF_EQUAL(div(T(-4),T(0), bs::round), bs::Valmin<r_t>());
+  STF_EQUAL(div(T(4),T(0), bs::round), bs::Valmax<r_t>());
+  STF_EQUAL(div(T(4),T(3), bs::round), T(1));
+  STF_EQUAL(div(T(-4),T(-3), bs::round), T(1));
+  STF_EQUAL(div(T(4),T(-3), bs::round), T(-1));
+  STF_EQUAL(div(T(-4),T(3), bs::round), T(-1));
+  STF_EQUAL(div(T(5),T(3), bs::round), T(2));
+  STF_EQUAL(div(T(-5),T(-3), bs::round), T(2));
+  STF_EQUAL(div(T(5),T(-3), bs::round), T(-2));
+  STF_EQUAL(div(T(-5),T(3), bs::round), T(-2));
 
-  STF_EQUAL(divround(T(5),T(4)), T(1));
-  STF_EQUAL(divround(T(-5),T(-4)), T(1));
-  STF_EQUAL(divround(T(5),T(-4)), T(-1));
-  STF_EQUAL(divround(T(-5),T(4)), T(-1));
-  STF_EQUAL(divround(T(6),T(4)), T(2));
-  STF_EQUAL(divround(T(-6),T(-4)), T(2));
-  STF_EQUAL(divround(T(6),T(-4)), T(-2));
-  STF_EQUAL(divround(T(-6),T(4)), T(-2));
-  STF_EQUAL(divround(T(8),T(4)), T(2));
-  STF_EQUAL(divround(T(-8),T(-4)), T(2));
-  STF_EQUAL(divround(T(8),T(-4)), T(-2));
-  STF_EQUAL(divround(T(-8),T(4)), T(-2));
-  STF_EQUAL(divround(T(9),T(4)), T(2));
-  STF_EQUAL(divround(T(-9),T(-4)), T(2));
-  STF_EQUAL(divround(T(9),T(-4)), T(-2));
-  STF_EQUAL(divround(T(-9),T(4)), T(-2));
-  STF_EQUAL(divround(T(10),T(4)), T(3));
-  STF_EQUAL(divround(T(-10),T(-4)), T(3));
-  STF_EQUAL(divround(T(10),T(-4)), T(-3));
-  STF_EQUAL(divround(T(-10),T(4)), T(-3));
+  STF_EQUAL(div(T(5),T(4), bs::round), T(1));
+  STF_EQUAL(div(T(-5),T(-4), bs::round), T(1));
+  STF_EQUAL(div(T(5),T(-4), bs::round), T(-1));
+  STF_EQUAL(div(T(-5),T(4), bs::round), T(-1));
+  STF_EQUAL(div(T(6),T(4), bs::round), T(2));
+  STF_EQUAL(div(T(-6),T(-4), bs::round), T(2));
+  STF_EQUAL(div(T(6),T(-4), bs::round), T(-2));
+  STF_EQUAL(div(T(-6),T(4), bs::round), T(-2));
+  STF_EQUAL(div(T(8),T(4), bs::round), T(2));
+  STF_EQUAL(div(T(-8),T(-4), bs::round), T(2));
+  STF_EQUAL(div(T(8),T(-4), bs::round), T(-2));
+  STF_EQUAL(div(T(-8),T(4), bs::round), T(-2));
+  STF_EQUAL(div(T(9),T(4), bs::round), T(2));
+  STF_EQUAL(div(T(-9),T(-4), bs::round), T(2));
+  STF_EQUAL(div(T(9),T(-4), bs::round), T(-2));
+  STF_EQUAL(div(T(-9),T(4), bs::round), T(-2));
+  STF_EQUAL(div(T(10),T(4), bs::round), T(3));
+  STF_EQUAL(div(T(-10),T(-4), bs::round), T(3));
+  STF_EQUAL(div(T(10),T(-4), bs::round), T(-3));
+  STF_EQUAL(div(T(-10),T(4), bs::round), T(-3));
 
-  STF_EQUAL(divround(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(divround(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
+  STF_EQUAL(div(bs::Mone<T>(), bs::Mone<T>(), bs::round), bs::One<r_t>());
+  STF_EQUAL(div(bs::One<T>(), bs::One<T>(), bs::round), bs::One<r_t>());
 } // end of test for signed_int_

--- a/test/function/scalar/divround.cpp
+++ b/test/function/scalar/divround.cpp
@@ -24,6 +24,7 @@ STF_CASE_TPL (" divreal",  STF_IEEE_TYPES)
   using bs::div;
   using r_t = decltype(div(T(), T()));
 
+#ifndef BOOST_SIMD_NO_INVALIDS
   STF_IEEE_EQUAL(div(bs::Inf<T>(), bs::Inf<T>(), bs::round), bs::Nan<r_t>());
   STF_IEEE_EQUAL(div(bs::Minf<T>(), bs::Minf<T>(), bs::round), bs::Nan<r_t>());
   STF_IEEE_EQUAL(div(bs::Nan<T>(), bs::Nan<T>(), bs::round), bs::Nan<r_t>());

--- a/test/function/scalar/divround2even.cpp
+++ b/test/function/scalar/divround2even.cpp
@@ -7,7 +7,7 @@
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 */
 //==================================================================================================
-#include <boost/simd/function/divround2even.hpp>
+#include <boost/simd/function/div.hpp>
 #include <simd_test.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>
 #include <boost/simd/constant/inf.hpp>
@@ -17,96 +17,84 @@
 #include <boost/simd/constant/one.hpp>
 #include <boost/simd/constant/zero.hpp>
 
-STF_CASE_TPL (" divround2even real",  STF_IEEE_TYPES)
+STF_CASE_TPL (" div real",  STF_IEEE_TYPES)
 {
   namespace bs = boost::simd;
-  using bs::divround2even;
-  using r_t = decltype(divround2even(T(), T()));
+  using bs::div;
+  using r_t = decltype(div(T(), T()));
 
-  // return type conformity test
-  STF_TYPE_IS( r_t, T );
-
-  // specific values tests
-  STF_IEEE_EQUAL(divround2even(bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(divround2even(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_EQUAL(divround2even(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_IEEE_EQUAL(divround2even(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
-  STF_EQUAL(divround2even(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
+  STF_IEEE_EQUAL(div(bs::Inf<T>(), bs::Inf<T>(), bs::round2even), bs::Nan<r_t>());
+  STF_IEEE_EQUAL(div(bs::Minf<T>(), bs::Minf<T>(), bs::round2even), bs::Nan<r_t>());
+  STF_EQUAL(div(bs::Mone<T>(), bs::Mone<T>(), bs::round2even), bs::One<r_t>());
+  STF_IEEE_EQUAL(div(bs::Nan<T>(), bs::Nan<T>(), bs::round2even), bs::Nan<r_t>());
+  STF_EQUAL(div(bs::One<T>(), bs::One<T>(), bs::round2even), bs::One<r_t>());
 } // end of test for floating_
 
-STF_CASE_TPL (" divround2even unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL (" div unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
 
-  using bs::divround2even;
-  using r_t = decltype(divround2even(T(), T()));
+  using bs::div;
+  using r_t = decltype(div(T(), T()));
 
-  // return type conformity test
-  STF_TYPE_IS( r_t, T );
-
-  // specific values tests
-  STF_EQUAL(divround2even(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(divround2even(T(5), T(2)), T(2));
-  STF_EQUAL(divround2even(T(7), T(2)), T(4));
-  STF_EQUAL(divround2even(T(9), T(3)), T(3));
-  STF_EQUAL(divround2even(T(10), T(3)), T(3));
-  STF_EQUAL(divround2even(T(11), T(3)), T(4));
-  STF_EQUAL(divround2even(T(12), T(3)), T(4));
-  STF_EQUAL(divround2even(T(18), T(6)), T(3));
-  STF_EQUAL(divround2even(T(20), T(6)), T(3));
-  STF_EQUAL(divround2even(T(22), T(6)), T(4));
-  STF_EQUAL(divround2even(T(24), T(6)), T(4));
-  STF_EQUAL(divround2even(bs::Valmax<T>(),bs::Two<T>()), bs::Valmax<T>()/bs::Two<T>()+bs::One<T>());
+  STF_EQUAL(div(bs::One<T>(), bs::One<T>(), bs::round2even), bs::One<r_t>());
+  STF_EQUAL(div(T(5), T(2), bs::round2even), T(2));
+  STF_EQUAL(div(T(7), T(2), bs::round2even), T(4));
+  STF_EQUAL(div(T(9), T(3), bs::round2even), T(3));
+  STF_EQUAL(div(T(10), T(3), bs::round2even), T(3));
+  STF_EQUAL(div(T(11), T(3), bs::round2even), T(4));
+  STF_EQUAL(div(T(12), T(3), bs::round2even), T(4));
+  STF_EQUAL(div(T(18), T(6), bs::round2even), T(3));
+  STF_EQUAL(div(T(20), T(6), bs::round2even), T(3));
+  STF_EQUAL(div(T(22), T(6), bs::round2even), T(4));
+  STF_EQUAL(div(T(24), T(6), bs::round2even), T(4));
+  STF_EQUAL(div(bs::Valmax<T>(),bs::Two<T>(), bs::round2even), bs::Valmax<T>()/bs::Two<T>()+bs::One<T>());
 
 } // end of test for unsigned_int_
 
-STF_CASE_TPL (" divround2even signed_int", STF_SIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL (" div signed_int", STF_SIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
-  using bs::divround2even;
-  using r_t = decltype(divround2even(T(), T()));
+  using bs::div;
+  using r_t = decltype(div(T(), T()));
 
-  // return type conformity test
-  STF_TYPE_IS( r_t, T );
+  STF_EQUAL(div(bs::Mone<T>(), bs::Mone<T>(), bs::round2even), bs::One<r_t>());
+  STF_EQUAL(div(bs::One<T>(), bs::One<T>(), bs::round2even), bs::One<r_t>());
+  STF_EQUAL(div(T(5), T(2), bs::round2even), T(2));
+  STF_EQUAL(div(T(7), T(2), bs::round2even), T(4));
+  STF_EQUAL(div(T(-5), T(2), bs::round2even), T(-2));
+  STF_EQUAL(div(T(-7), T(2), bs::round2even), T(-4));
+  STF_EQUAL(div(T(-4),T(0), bs::round2even), bs::Valmin<r_t>());
+  STF_EQUAL(div(T(4),T(0), bs::round2even), bs::Valmax<r_t>());
+  STF_EQUAL(div(T(4),T(3), bs::round2even), T(1));
+  STF_EQUAL(div(T(-4),T(-3), bs::round2even), T(1));
+  STF_EQUAL(div(T(4),T(-3), bs::round2even), T(-1));
+  STF_EQUAL(div(T(-4),T(3), bs::round2even), T(-1));
+  STF_EQUAL(div(T(5),T(3), bs::round2even), T(2));
+  STF_EQUAL(div(T(-5),T(-3), bs::round2even), T(2));
+  STF_EQUAL(div(T(5),T(-3), bs::round2even), T(-2));
+  STF_EQUAL(div(T(-5),T(3), bs::round2even), T(-2));
 
-  // specific values tests
-  STF_EQUAL(divround2even(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(divround2even(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(divround2even(T(5), T(2)), T(2));
-  STF_EQUAL(divround2even(T(7), T(2)), T(4));
-  STF_EQUAL(divround2even(T(-5), T(2)), T(-2));
-  STF_EQUAL(divround2even(T(-7), T(2)), T(-4));
-  STF_EQUAL(divround2even(T(-4),T(0)), bs::Valmin<r_t>());
-  STF_EQUAL(divround2even(T(4),T(0)), bs::Valmax<r_t>());
-  STF_EQUAL(divround2even(T(4),T(3)), T(1));
-  STF_EQUAL(divround2even(T(-4),T(-3)), T(1));
-  STF_EQUAL(divround2even(T(4),T(-3)), T(-1));
-  STF_EQUAL(divround2even(T(-4),T(3)), T(-1));
-  STF_EQUAL(divround2even(T(5),T(3)), T(2));
-  STF_EQUAL(divround2even(T(-5),T(-3)), T(2));
-  STF_EQUAL(divround2even(T(5),T(-3)), T(-2));
-  STF_EQUAL(divround2even(T(-5),T(3)), T(-2));
-
-  STF_EQUAL(divround2even(T(5),T(4)), T(1));
-  STF_EQUAL(divround2even(T(-5),T(-4)), T(1));
-  STF_EQUAL(divround2even(T(5),T(-4)), T(-1));
-  STF_EQUAL(divround2even(T(-5),T(4)), T(-1));
-  STF_EQUAL(divround2even(T(6),T(4)), T(2));
-  STF_EQUAL(divround2even(T(-6),T(-4)), T(2));
-  STF_EQUAL(divround2even(T(6),T(-4)), T(-2));
-  STF_EQUAL(divround2even(T(-6),T(4)), T(-2));
-  STF_EQUAL(divround2even(T(8),T(4)), T(2));
-  STF_EQUAL(divround2even(T(-8),T(-4)), T(2));
-  STF_EQUAL(divround2even(T(8),T(-4)), T(-2));
-  STF_EQUAL(divround2even(T(-8),T(4)), T(-2));
-  STF_EQUAL(divround2even(T(9),T(4)), T(2));
-  STF_EQUAL(divround2even(T(-9),T(-4)), T(2));
-  STF_EQUAL(divround2even(T(9),T(-4)), T(-2));
-  STF_EQUAL(divround2even(T(-9),T(4)), T(-2));
-  STF_EQUAL(divround2even(T(10),T(4)), T(2));
-  STF_EQUAL(divround2even(T(-10),T(-4)), T(2));
-  STF_EQUAL(divround2even(T(10),T(-4)), T(-2));
-  STF_EQUAL(divround2even(T(-10),T(4)), T(-2));
+  STF_EQUAL(div(T(5),T(4), bs::round2even), T(1));
+  STF_EQUAL(div(T(-5),T(-4), bs::round2even), T(1));
+  STF_EQUAL(div(T(5),T(-4), bs::round2even), T(-1));
+  STF_EQUAL(div(T(-5),T(4), bs::round2even), T(-1));
+  STF_EQUAL(div(T(6),T(4), bs::round2even), T(2));
+  STF_EQUAL(div(T(-6),T(-4), bs::round2even), T(2));
+  STF_EQUAL(div(T(6),T(-4), bs::round2even), T(-2));
+  STF_EQUAL(div(T(-6),T(4), bs::round2even), T(-2));
+  STF_EQUAL(div(T(8),T(4), bs::round2even), T(2));
+  STF_EQUAL(div(T(-8),T(-4), bs::round2even), T(2));
+  STF_EQUAL(div(T(8),T(-4), bs::round2even), T(-2));
+  STF_EQUAL(div(T(-8),T(4), bs::round2even), T(-2));
+  STF_EQUAL(div(T(9),T(4), bs::round2even), T(2));
+  STF_EQUAL(div(T(-9),T(-4), bs::round2even), T(2));
+  STF_EQUAL(div(T(9),T(-4), bs::round2even), T(-2));
+  STF_EQUAL(div(T(-9),T(4), bs::round2even), T(-2));
+  STF_EQUAL(div(T(10),T(4), bs::round2even), T(2));
+  STF_EQUAL(div(T(-10),T(-4), bs::round2even), T(2));
+  STF_EQUAL(div(T(10),T(-4), bs::round2even), T(-2));
+  STF_EQUAL(div(T(-10),T(4), bs::round2even), T(-2));
 
 } // end of test for signed_int_
 

--- a/test/function/scalar/divtrunc.cpp
+++ b/test/function/scalar/divtrunc.cpp
@@ -7,7 +7,7 @@
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 */
 //==================================================================================================
-#include <boost/simd/function/divtrunc.hpp>
+#include <boost/simd/function/div.hpp>
 #include <simd_test.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>
 #include <boost/simd/constant/inf.hpp>
@@ -21,64 +21,64 @@ STF_CASE_TPL (" divtrunc real",  STF_IEEE_TYPES)
 {
   namespace bs = boost::simd;
 
-  using bs::divtrunc;
-  using r_t = decltype(divtrunc(T(), T()));
+  using bs::div;
+  using r_t = decltype(div(T(), T()));
   // return type conformity test
   STF_TYPE_IS(r_t, T);
 
   // specific values tests
 #ifndef STF_NO_INVALIDS
-  STF_IEEE_EQUAL(divtrunc(bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(divtrunc(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(divtrunc(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
+  STF_IEEE_EQUAL(div(bs::Inf<T>(), bs::Inf<T>(), bs::trunc), bs::Nan<r_t>());
+  STF_IEEE_EQUAL(div(bs::Minf<T>(), bs::Minf<T>(), bs::trunc), bs::Nan<r_t>());
+  STF_IEEE_EQUAL(div(bs::Nan<T>(), bs::Nan<T>(), bs::trunc), bs::Nan<r_t>());
 #endif
-  STF_EQUAL(divtrunc(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(divtrunc(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(divtrunc(bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>());
-  STF_EQUAL(divtrunc(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(divtrunc(bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(divtrunc(bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>());
-  STF_EQUAL(divtrunc(T(4),T(3)), T(1));
-  STF_EQUAL(divtrunc(T(-4),T(3)), T(-1));
+  STF_EQUAL(div(bs::Mone<T>(), bs::Mone<T>(), bs::trunc), bs::One<r_t>());
+  STF_EQUAL(div(bs::One<T>(), bs::One<T>(), bs::trunc), bs::One<r_t>());
+  STF_EQUAL(div(bs::Mone<T>(),bs::Zero<T>(), bs::trunc), bs::Minf<r_t>());
+  STF_EQUAL(div(bs::One<T>(), bs::One<T>(), bs::trunc), bs::One<r_t>());
+  STF_EQUAL(div(bs::One<T>(),bs::Zero<T>(), bs::trunc), bs::Inf<r_t>());
+  STF_IEEE_EQUAL(div(bs::Zero<T>(),bs::Zero<T>(), bs::trunc), bs::Nan<r_t>());
+  STF_EQUAL(div(T(4),T(3), bs::trunc), T(1));
+  STF_EQUAL(div(T(-4),T(3), bs::trunc), T(-1));
 } // end of test for floating_
 
-STF_CASE_TPL (" divtrunc unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL (" div unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
-  using bs::divtrunc;
-  using r_t = decltype(divtrunc(T(), T()));
+  using bs::div;
+  using r_t = decltype(div(T(), T()));
 
   // return type conformity test
   STF_TYPE_IS(r_t, T);
 
   // specific values tests
-  STF_EQUAL(divtrunc(T(4),T(0)), bs::Valmax<r_t>());
-  STF_EQUAL(divtrunc(T(4),T(3)), T(1));
-  STF_EQUAL(divtrunc(bs::One<T>(), bs::One<T>()), bs::One<T>());
-  STF_EQUAL(divtrunc(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>());
-  STF_EQUAL(divtrunc(bs::One<T>(), bs::Zero<T>()), bs::Valmax<r_t>());
+  STF_EQUAL(div(T(4),T(0), bs::trunc), bs::Valmax<r_t>());
+  STF_EQUAL(div(T(4),T(3), bs::trunc), T(1));
+  STF_EQUAL(div(bs::One<T>(), bs::One<T>(), bs::trunc), bs::One<T>());
+  STF_EQUAL(div(bs::Zero<T>(), bs::Zero<T>(), bs::trunc), bs::Zero<T>());
+  STF_EQUAL(div(bs::One<T>(), bs::Zero<T>(), bs::trunc), bs::Valmax<r_t>());
 } // end of test for unsigned_int_
 
-STF_CASE_TPL (" divtrunc signed_int",  STF_SIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL (" div signed_int",  STF_SIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
-  using bs::divtrunc;
-  using r_t = decltype(divtrunc(T(), T()));
+  using bs::div;
+  using r_t = decltype(div(T(), T()));
 
   STF_TYPE_IS(r_t, T);
 
   // specific values tests
-  STF_EQUAL(divtrunc(T(-4),T(0)), bs::Valmin<r_t>());
-  STF_EQUAL(divtrunc(T(4),T(0)), bs::Valmax<r_t>());
-  STF_EQUAL(divtrunc(T(4),T(3)), T(1));
-  STF_EQUAL(divtrunc(T(-4),T(-3)), T(1));
-  STF_EQUAL(divtrunc(T(4),T(-3)), T(-1));
-  STF_EQUAL(divtrunc(T(-4),T(3)), T(-1));
-  STF_EQUAL(divtrunc(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(divtrunc(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(divtrunc(bs::Mone<T>(), bs::Zero<T>()), bs::Valmin<r_t>());
-  STF_EQUAL(divtrunc(bs::One<T>(), bs::Zero<T>()), bs::Valmax<r_t>());
-  STF_EQUAL(divtrunc(bs::Valmax<T>(),bs::One<T>()), bs::Valmax<T>());
+  STF_EQUAL(div(T(-4),T(0), bs::trunc), bs::Valmin<r_t>());
+  STF_EQUAL(div(T(4),T(0), bs::trunc), bs::Valmax<r_t>());
+  STF_EQUAL(div(T(4),T(3), bs::trunc), T(1));
+  STF_EQUAL(div(T(-4),T(-3), bs::trunc), T(1));
+  STF_EQUAL(div(T(4),T(-3), bs::trunc), T(-1));
+  STF_EQUAL(div(T(-4),T(3), bs::trunc), T(-1));
+  STF_EQUAL(div(bs::Mone<T>(), bs::Mone<T>(), bs::trunc), bs::One<r_t>());
+  STF_EQUAL(div(bs::One<T>(), bs::One<T>(), bs::trunc), bs::One<r_t>());
+  STF_EQUAL(div(bs::Mone<T>(), bs::Zero<T>(), bs::trunc), bs::Valmin<r_t>());
+  STF_EQUAL(div(bs::One<T>(), bs::Zero<T>(), bs::trunc), bs::Valmax<r_t>());
+  STF_EQUAL(div(bs::Valmax<T>(),bs::One<T>(), bs::trunc), bs::Valmax<T>());
 } // end of test for signed_int_
 
 

--- a/test/function/scalar/idiv.cpp
+++ b/test/function/scalar/idiv.cpp
@@ -1,0 +1,57 @@
+//==================================================================================================
+/*!
+
+  Copyright 2015 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#include <boost/simd/function/idiv.hpp>
+#include <simd_test.hpp>
+//#include <nontrivial.hpp>
+#include <boost/simd/constant/inf.hpp>
+#include <boost/simd/constant/minf.hpp>
+#include <boost/simd/constant/mone.hpp>
+#include <boost/simd/constant/nan.hpp>
+#include <boost/simd/constant/one.hpp>
+#include <boost/simd/constant/zero.hpp>
+#include <boost/simd/options.hpp>
+#include <boost/simd/function/ceil.hpp>
+#include <boost/dispatch/meta/as_integer.hpp>
+
+STF_CASE_TPL( "Check idiv behavior with floating", STF_IEEE_TYPES )
+{
+  namespace bs = boost::simd;
+  namespace bd = boost::dispatch;
+  using bs::idiv;
+  using r_t = decltype(idiv(T(), T()));
+  STF_TYPE_IS(r_t, bd::as_integer_t<T>);
+
+#ifndef STF_NO_INVALIDS
+  STF_IEEE_EQUAL(idiv(bs::Inf<T>(),  bs::Inf<T>()), bs::Nan<r_t>());
+  STF_IEEE_EQUAL(idiv(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
+  STF_IEEE_EQUAL(idiv(bs::Nan<T>(),  bs::Nan<T>()), bs::Nan<r_t>());
+#endif
+  STF_IEEE_EQUAL(idiv(bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>());
+  STF_IEEE_EQUAL(idiv(bs::Zero<T>(), bs::Zero<T>()), bs::Nan<r_t>());
+  STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
+}
+
+
+
+STF_CASE_TPL( "Check idiv behavior with options", STF_NUMERIC_TYPES )
+{
+  namespace bs = boost::simd;
+  namespace bd = boost::dispatch;
+  using bs::idiv;
+  using r_t = decltype(idiv(T(), T()));
+  STF_TYPE_IS(r_t, bd::as_integer_t<T>);
+
+  STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>()), bs::Zero<r_t>());
+  STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::tag::ceil_()), bs::One<r_t>());
+  STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::tag::floor_()), bs::Zero<r_t>());
+  STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::tag::round_()), bs::One<r_t>());
+  STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::tag::round2even_()), bs::Zero<r_t>());
+  STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::tag::fix_()), bs::Zero<r_t>());
+}

--- a/test/function/scalar/idiv.cpp
+++ b/test/function/scalar/idiv.cpp
@@ -54,4 +54,9 @@ STF_CASE_TPL( "Check idiv behavior with options", STF_NUMERIC_TYPES )
   STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::tag::round_()), bs::One<r_t>());
   STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::tag::round2even_()), bs::Zero<r_t>());
   STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::tag::fix_()), bs::Zero<r_t>());
+//   STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::ceil), bs::One<r_t>());
+//   STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::floor), bs::Zero<r_t>());
+//   STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::round), bs::One<r_t>());
+//   STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::round2even), bs::Zero<r_t>());
+//   STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::fix), bs::Zero<r_t>());
 }

--- a/test/function/scalar/idiv.cpp
+++ b/test/function/scalar/idiv.cpp
@@ -16,7 +16,6 @@
 #include <boost/simd/constant/nan.hpp>
 #include <boost/simd/constant/one.hpp>
 #include <boost/simd/constant/zero.hpp>
-#include <boost/simd/options.hpp>
 #include <boost/simd/function/ceil.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>
 

--- a/test/function/scalar/idiv.cpp
+++ b/test/function/scalar/idiv.cpp
@@ -49,14 +49,10 @@ STF_CASE_TPL( "Check idiv behavior with options", STF_NUMERIC_TYPES )
   STF_TYPE_IS(r_t, bd::as_integer_t<T>);
 
   STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>()), bs::Zero<r_t>());
-  STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::tag::ceil_()), bs::One<r_t>());
-  STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::tag::floor_()), bs::Zero<r_t>());
-  STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::tag::round_()), bs::One<r_t>());
-  STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::tag::round2even_()), bs::Zero<r_t>());
-  STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::tag::fix_()), bs::Zero<r_t>());
-//   STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::ceil), bs::One<r_t>());
-//   STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::floor), bs::Zero<r_t>());
-//   STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::round), bs::One<r_t>());
-//   STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::round2even), bs::Zero<r_t>());
-//   STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::fix), bs::Zero<r_t>());
+
+  STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::ceil), bs::One<r_t>());
+  STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::floor), bs::Zero<r_t>());
+  STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::round), bs::One<r_t>());
+  STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::round2even), bs::Zero<r_t>());
+  STF_IEEE_EQUAL(idiv(bs::One<T>(), bs::Two<T>(), bs::fix), bs::Zero<r_t>());
 }

--- a/test/function/scalar/idivceil.cpp
+++ b/test/function/scalar/idivceil.cpp
@@ -7,7 +7,7 @@
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 */
 //==================================================================================================
-#include <boost/simd/function/idivceil.hpp>
+#include <boost/simd/function/idiv.hpp>
 #include <simd_test.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>
 #include <boost/simd/constant/inf.hpp>
@@ -20,72 +20,61 @@
 #include <boost/simd/constant/valmin.hpp>
 #include <boost/simd/constant/mzero.hpp>
 
-STF_CASE_TPL (" idivceil real",  STF_IEEE_TYPES)
+
+STF_CASE_TPL (" idiv real",  STF_IEEE_TYPES)
 {
   namespace bs = boost::simd;
   namespace bd = boost::dispatch;
 
-  using bs::idivceil;
-  using r_t = decltype(idivceil(T(), T()));
+  using bs::idiv;
+  using r_t = decltype(idiv(T(), T()));
 
-  // return type conformity test
-  STF_TYPE_IS(r_t, bd::as_integer_t<T>);
-
-  // specific values tests
-#ifndef STF_NO_INVALIDS
-  STF_EQUAL(idivceil(bs::Inf<T>(), bs::Inf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(idivceil(bs::Minf<T>(), bs::Minf<T>()), bs::Zero<r_t>());
-  STF_IEEE_EQUAL(idivceil(bs::Nan<T>(), bs::Nan<T>()), bs::Zero<r_t>());
+  STF_EQUAL(idiv(bs::Inf<T>(), bs::Inf<T>(), bs::ceil), bs::Zero<r_t>());
+  STF_EQUAL(idiv(bs::Minf<T>(), bs::Minf<T>(), bs::ceil), bs::Zero<r_t>());
+  STF_IEEE_EQUAL(idiv(bs::Nan<T>(), bs::Nan<T>(), bs::ceil), bs::Zero<r_t>());
 #endif
- STF_EQUAL(idivceil(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(idivceil(bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>());
-  STF_EQUAL(idivceil(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(idivceil(bs::One<T>(),bs::Zero<T>()), bs::Valmax<r_t>());
-  STF_EQUAL(idivceil(bs::One<T>(),bs::Mzero<T>()), bs::Valmin<r_t>());
-  STF_EQUAL(idivceil(bs::Zero<T>(),bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(idivceil(T(4),T(3)), r_t(2));
-  STF_EQUAL(idivceil(T(-4),T(-3)), r_t(2));
-  STF_EQUAL(idivceil(T(-4),T(3)), r_t(-1));
-  STF_EQUAL(idivceil(T(4),T(-3)), r_t(-1));
+ STF_EQUAL(idiv(bs::Mone<T>(), bs::Mone<T>(), bs::ceil), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::Mone<T>(),bs::Zero<T>(), bs::ceil), bs::Minf<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(), bs::One<T>(), bs::ceil), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(),bs::Zero<T>(), bs::ceil), bs::Valmax<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(),bs::Mzero<T>(), bs::ceil), bs::Valmin<r_t>());
+  STF_EQUAL(idiv(bs::Zero<T>(),bs::Zero<T>(), bs::ceil), bs::Zero<r_t>());
+  STF_EQUAL(idiv(T(4),T(3)  , bs::ceil), r_t(2) );
+  STF_EQUAL(idiv(T(-4),T(-3), bs::ceil), r_t(2) );
+  STF_EQUAL(idiv(T(-4),T(3) , bs::ceil), r_t(-1));
+  STF_EQUAL(idiv(T(4),T(-3) , bs::ceil), r_t(-1));
 } // end of test for floating_
 
-STF_CASE_TPL (" idivceil unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL (" idiv unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
   namespace bd = boost::dispatch;
 
-  using bs::idivceil;
-  using r_t = decltype(idivceil(T(), T()));
+  using bs::idiv;
+  using r_t = decltype(idiv(T(), T()));
 
-  // return type conformity test
-  STF_TYPE_IS(r_t, (bd::as_integer_t<T, unsigned>));
-
-  // specific values tests
-  STF_EQUAL(idivceil(T(4),T(3)), T(2));
-  STF_EQUAL(idivceil(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(idivceil(bs::One<T>(), bs::Zero<T>()), bs::Valmax<r_t>());
+  STF_EQUAL(idiv(T(4),T(3), bs::ceil), T(2));
+  STF_EQUAL(idiv(bs::One<T>(), bs::One<T>(), bs::ceil), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(), bs::Zero<T>(), bs::ceil), bs::Valmax<r_t>());
 } // end of test for unsigned_int_
 
-STF_CASE_TPL (" idivceil signed_int",  STF_SIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL (" idiv signed_int",  STF_SIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
   namespace bd = boost::dispatch;
-  using bs::idivceil;
+  using bs::idiv;
 
-  using r_t = decltype(idivceil(T(), T()));
+  using r_t = decltype(idiv(T(), T()));
 
-  // return type conformity test
-  STF_TYPE_IS(r_t, bd::as_integer_t<T>);
+  STF_EQUAL(idiv(T(4),T(3), bs::ceil), r_t(2));
+  STF_EQUAL(idiv(T(-4),T(-3), bs::ceil), r_t(2));
+  STF_EQUAL(idiv(T(-4),T(3), bs::ceil), r_t(-1));
+  STF_EQUAL(idiv(T(4),T(-3), bs::ceil), r_t(-1));
+  STF_EQUAL(idiv(bs::Mone<T>(), bs::Mone<T>(), bs::ceil), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(), bs::One<T>(), bs::ceil), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(), bs::Zero<T>(), bs::ceil), bs::Valmax<r_t>());
+  STF_EQUAL(idiv(bs::Mone<T>(), bs::Zero<T>(), bs::ceil), bs::Valmin<r_t>());
 
-  // specific values tests
-  STF_EQUAL(idivceil(T(4),T(3)), r_t(2));
-  STF_EQUAL(idivceil(T(-4),T(-3)), r_t(2));
-  STF_EQUAL(idivceil(T(-4),T(3)), r_t(-1));
-  STF_EQUAL(idivceil(T(4),T(-3)), r_t(-1));
-  STF_EQUAL(idivceil(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(idivceil(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(idivceil(bs::One<T>(), bs::Zero<T>()), bs::Valmax<r_t>());
-  STF_EQUAL(idivceil(bs::Mone<T>(), bs::Zero<T>()), bs::Valmin<r_t>());
 } // end of test for signed_int_
 
 

--- a/test/function/scalar/idivceil.cpp
+++ b/test/function/scalar/idivceil.cpp
@@ -29,6 +29,7 @@ STF_CASE_TPL (" idiv real",  STF_IEEE_TYPES)
   using bs::idiv;
   using r_t = decltype(idiv(T(), T()));
 
+#ifndef BOOST_SIMD_NO_INVALIDS
   STF_EQUAL(idiv(bs::Inf<T>(), bs::Inf<T>(), bs::ceil), bs::Zero<r_t>());
   STF_EQUAL(idiv(bs::Minf<T>(), bs::Minf<T>(), bs::ceil), bs::Zero<r_t>());
   STF_IEEE_EQUAL(idiv(bs::Nan<T>(), bs::Nan<T>(), bs::ceil), bs::Zero<r_t>());

--- a/test/function/scalar/idivfix.cpp
+++ b/test/function/scalar/idivfix.cpp
@@ -7,7 +7,7 @@
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 */
 //==================================================================================================
-#include <boost/simd/function/idivfix.hpp>
+#include <boost/simd/function/idiv.hpp>
 #include <simd_test.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>
 #include <boost/simd/constant/inf.hpp>
@@ -18,69 +18,60 @@
 #include <boost/simd/constant/valmax.hpp>
 #include <boost/simd/constant/valmin.hpp>
 
-STF_CASE_TPL (" idivfix real",  STF_IEEE_TYPES)
+STF_CASE_TPL (" idiv real",  STF_IEEE_TYPES)
 {
   namespace bs = boost::simd;
   namespace bd = boost::dispatch;
-  using bs::idivfix;
-  using r_t = decltype(idivfix(T(), T()));
+  using bs::idiv;
+  using r_t = decltype(idiv(T(), T()));
 
   // return type conformity test
   STF_TYPE_IS(r_t, bd::as_integer_t<T>);
 
-  // specific values tests
-#ifndef STF_NO_INVALIDS
-  STF_EQUAL(idivfix(bs::Inf<T>(), bs::Inf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(idivfix(bs::Minf<T>(), bs::Minf<T>()), bs::Zero<r_t>());
-  STF_IEEE_EQUAL(idivfix(bs::Nan<T>(), bs::Nan<T>()), bs::Zero<r_t>());
+  STF_EQUAL(idiv(bs::Inf<T>(), bs::Inf<T>(), bs::fix), bs::Zero<r_t>());
+  STF_EQUAL(idiv(bs::Minf<T>(), bs::Minf<T>(), bs::fix), bs::Zero<r_t>());
+  STF_IEEE_EQUAL(idiv(bs::Nan<T>(), bs::Nan<T>(), bs::fix), bs::Zero<r_t>());
 #endif
- STF_EQUAL(idivfix(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(idivfix(bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>());
-  STF_EQUAL(idivfix(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(idivfix(bs::One<T>(),bs::Zero<T>()), bs::Valmax<r_t>());
-  STF_EQUAL(idivfix(bs::One<T>(),bs::Mzero<T>()), bs::Valmin<r_t>());
-  STF_EQUAL(idivfix(bs::Zero<T>(),bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(idivfix(T(4),T(3)), r_t(1));
-  STF_EQUAL(idivfix(T(-4),T(-3)), r_t(1));
-  STF_EQUAL(idivfix(T(-4),T(3)), r_t(-1));
-  STF_EQUAL(idivfix(T(4),T(-3)), r_t(-1));
+ STF_EQUAL(idiv(bs::Mone<T>(), bs::Mone<T>(), bs::fix), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::Mone<T>(),bs::Zero<T>(), bs::fix), bs::Minf<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(), bs::One<T>(), bs::fix), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(),bs::Zero<T>(), bs::fix), bs::Valmax<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(),bs::Mzero<T>(), bs::fix), bs::Valmin<r_t>());
+  STF_EQUAL(idiv(bs::Zero<T>(),bs::Zero<T>(), bs::fix), bs::Zero<r_t>());
+  STF_EQUAL(idiv(T(4),T(3), bs::fix), r_t(1));
+  STF_EQUAL(idiv(T(-4),T(-3), bs::fix), r_t(1));
+  STF_EQUAL(idiv(T(-4),T(3), bs::fix), r_t(-1));
+  STF_EQUAL(idiv(T(4),T(-3), bs::fix), r_t(-1));
 } // end of test for floating_
 
-STF_CASE_TPL (" idivfix unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL (" idiv unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
   namespace bd = boost::dispatch;
-  using bs::idivfix;
-  using r_t = decltype(idivfix(T(), T()));
+  using bs::idiv;
+  using r_t = decltype(idiv(T(), T()));
 
-  // return type conformity test
-  STF_TYPE_IS(r_t, bd::as_integer_t<T>);
-
-  // specific values tests
-  STF_EQUAL(idivfix(T(4),T(3)), T(1));
-  STF_EQUAL(idivfix(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(idivfix(bs::One<T>(), bs::Zero<T>()), bs::Valmax<r_t>());
+  STF_EQUAL(idiv(T(4),T(3), bs::fix), T(1));
+  STF_EQUAL(idiv(bs::One<T>(), bs::One<T>(), bs::fix), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(), bs::Zero<T>(), bs::fix), bs::Valmax<r_t>());
 } // end of test for unsigned_int_
 
-STF_CASE_TPL (" idivfix signed_int",  STF_SIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL (" idiv signed_int",  STF_SIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
   namespace bd = boost::dispatch;
-  using bs::idivfix;
-  using r_t = decltype(idivfix(T(), T()));
+  using bs::idiv;
+  using r_t = decltype(idiv(T(), T()));
 
-  // return type conformity test
-  STF_TYPE_IS(r_t, bd::as_integer_t<T>);
+  STF_EQUAL(idiv(T(4),T(3), bs::fix), r_t(1));
+  STF_EQUAL(idiv(T(-4),T(-3), bs::fix), r_t(1));
+  STF_EQUAL(idiv(T(-4),T(3), bs::fix), r_t(-1));
+  STF_EQUAL(idiv(T(4),T(-3), bs::fix), r_t(-1));
+  STF_EQUAL(idiv(bs::Mone<T>(), bs::Mone<T>(), bs::fix), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(), bs::One<T>(), bs::fix), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(), bs::Zero<T>(), bs::fix), bs::Valmax<r_t>());
+  STF_EQUAL(idiv(bs::Mone<T>(), bs::Zero<T>(), bs::fix), bs::Valmin<r_t>());
 
-  // specific values tests
-  STF_EQUAL(idivfix(T(4),T(3)), r_t(1));
-  STF_EQUAL(idivfix(T(-4),T(-3)), r_t(1));
-  STF_EQUAL(idivfix(T(-4),T(3)), r_t(-1));
-  STF_EQUAL(idivfix(T(4),T(-3)), r_t(-1));
-  STF_EQUAL(idivfix(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(idivfix(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(idivfix(bs::One<T>(), bs::Zero<T>()), bs::Valmax<r_t>());
-  STF_EQUAL(idivfix(bs::Mone<T>(), bs::Zero<T>()), bs::Valmin<r_t>());
 } // end of test for signed_int_
 
 

--- a/test/function/scalar/idivfix.cpp
+++ b/test/function/scalar/idivfix.cpp
@@ -28,6 +28,7 @@ STF_CASE_TPL (" idiv real",  STF_IEEE_TYPES)
   // return type conformity test
   STF_TYPE_IS(r_t, bd::as_integer_t<T>);
 
+#ifndef BOOST_SIMD_NO_INVALIDS
   STF_EQUAL(idiv(bs::Inf<T>(), bs::Inf<T>(), bs::fix), bs::Zero<r_t>());
   STF_EQUAL(idiv(bs::Minf<T>(), bs::Minf<T>(), bs::fix), bs::Zero<r_t>());
   STF_IEEE_EQUAL(idiv(bs::Nan<T>(), bs::Nan<T>(), bs::fix), bs::Zero<r_t>());

--- a/test/function/scalar/idivfloor.cpp
+++ b/test/function/scalar/idivfloor.cpp
@@ -27,6 +27,7 @@ STF_CASE_TPL (" idivreal",  STF_IEEE_TYPES)
   using bs::idiv;
   using r_t = decltype(idiv(T(), T()));
 
+#ifndef BOOST_SIMD_NO_INVALIDS
   STF_EQUAL(idiv(bs::Inf<T>(), bs::Inf<T>(), bs::floor), bs::Zero<r_t>());
   STF_EQUAL(idiv(bs::Minf<T>(), bs::Minf<T>(), bs::floor), bs::Zero<r_t>());
   STF_EQUAL(idiv(bs::Nan<T>(), bs::Nan<T>(), bs::floor), bs::Zero<r_t>());
@@ -50,9 +51,9 @@ STF_CASE_TPL (" idivunsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
   using bs::idiv;
   using r_t = decltype(idiv(T(), T()));
 
-  STF_EQUAL(idivfloor(T(4),T(3)), T(1));
-  STF_EQUAL(idivfloor(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(idivfloor(bs::One<T>(), bs::Zero<T>()), bs::Valmax<r_t>());
+  STF_EQUAL(idiv(T(4),T(3), bs::floor), T(1));
+  STF_EQUAL(idiv(bs::One<T>(), bs::One<T>(), bs::floor), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(), bs::Zero<T>(), bs::floor), bs::Valmax<r_t>());
 } // end of test for unsigned_int_
 
 STF_CASE_TPL (" idiv signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/idivfloor.cpp
+++ b/test/function/scalar/idivfloor.cpp
@@ -7,7 +7,7 @@
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 */
 //==================================================================================================
-#include <boost/simd/function/idivfloor.hpp>
+#include <boost/simd/function/idiv.hpp>
 #include <simd_test.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>
 #include <boost/simd/constant/inf.hpp>
@@ -20,69 +20,54 @@
 #include <boost/simd/constant/valmin.hpp>
 #include <boost/simd/constant/mzero.hpp>
 
-STF_CASE_TPL (" idivfloorreal",  STF_IEEE_TYPES)
+STF_CASE_TPL (" idivreal",  STF_IEEE_TYPES)
 {
   namespace bs = boost::simd;
   namespace bd = boost::dispatch;
-  using bs::idivfloor;
-  using r_t = decltype(idivfloor(T(), T()));
+  using bs::idiv;
+  using r_t = decltype(idiv(T(), T()));
 
-  // return type conformity test
-  STF_TYPE_IS(r_t, bd::as_integer_t<T>);
-
-
-  // specific values tests
-#ifndef STF_NO_INVALIDS
-  STF_EQUAL(idivfloor(bs::Inf<T>(), bs::Inf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(idivfloor(bs::Minf<T>(), bs::Minf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(idivfloor(bs::Nan<T>(), bs::Nan<T>()), bs::Zero<r_t>());
+  STF_EQUAL(idiv(bs::Inf<T>(), bs::Inf<T>(), bs::floor), bs::Zero<r_t>());
+  STF_EQUAL(idiv(bs::Minf<T>(), bs::Minf<T>(), bs::floor), bs::Zero<r_t>());
+  STF_EQUAL(idiv(bs::Nan<T>(), bs::Nan<T>(), bs::floor), bs::Zero<r_t>());
 #endif
- STF_EQUAL(idivfloor(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(idivfloor(bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>());
-  STF_EQUAL(idivfloor(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(idivfloor(bs::One<T>(),bs::Zero<T>()), bs::Valmax<r_t>());
-  STF_EQUAL(idivfloor(bs::One<T>(),bs::Mzero<T>()), bs::Valmin<r_t>());
-  STF_EQUAL(idivfloor(bs::Zero<T>(),bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(idivfloor(T(4),T(3)), r_t(1));
-  STF_EQUAL(idivfloor(T(-4),T(-3)), r_t(1));
-  STF_EQUAL(idivfloor(T(-4),T(3)), r_t(-2));
-  STF_EQUAL(idivfloor(T(4),T(-3)), r_t(-2));
+ STF_EQUAL(idiv(bs::Mone<T>(), bs::Mone<T>(), bs::floor), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::Mone<T>(),bs::Zero<T>(), bs::floor), bs::Minf<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(), bs::One<T>(), bs::floor), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(),bs::Zero<T>(), bs::floor), bs::Valmax<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(),bs::Mzero<T>(), bs::floor), bs::Valmin<r_t>());
+  STF_EQUAL(idiv(bs::Zero<T>(),bs::Zero<T>(), bs::floor), bs::Zero<r_t>());
+  STF_EQUAL(idiv(T(4),T(3), bs::floor), r_t(1));
+  STF_EQUAL(idiv(T(-4),T(-3), bs::floor), r_t(1));
+  STF_EQUAL(idiv(T(-4),T(3), bs::floor), r_t(-2));
+  STF_EQUAL(idiv(T(4),T(-3), bs::floor), r_t(-2));
 } // end of test for floating_
 
-STF_CASE_TPL (" idivfloorunsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL (" idivunsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
   namespace bd = boost::dispatch;
-  using bs::idivfloor;
-  using r_t = decltype(idivfloor(T(), T()));
+  using bs::idiv;
+  using r_t = decltype(idiv(T(), T()));
 
-  // return type conformity test
-  STF_TYPE_IS(r_t, bd::as_integer_t<T>);
-
-
-  // specific values tests
   STF_EQUAL(idivfloor(T(4),T(3)), T(1));
   STF_EQUAL(idivfloor(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
   STF_EQUAL(idivfloor(bs::One<T>(), bs::Zero<T>()), bs::Valmax<r_t>());
 } // end of test for unsigned_int_
 
-STF_CASE_TPL (" idivfloorsigned_int",  STF_SIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL (" idiv signed_int",  STF_SIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
   namespace bd = boost::dispatch;
   using bs::idivfloor;
   using r_t = decltype(idivfloor(T(), T()));
 
-  // return type conformity test
-  STF_TYPE_IS(r_t, bd::as_integer_t<T>);
-
-  // specific values tests
-  STF_EQUAL(idivfloor(T(4),T(3)), r_t(1));
-  STF_EQUAL(idivfloor(T(-4),T(-3)), r_t(1));
-  STF_EQUAL(idivfloor(T(-4),T(3)), r_t(-2));
-  STF_EQUAL(idivfloor(T(4),T(-3)), r_t(-2));
-  STF_EQUAL(idivfloor(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(idivfloor(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(idivfloor(bs::One<T>(), bs::Zero<T>()), bs::Valmax<r_t>());
-  STF_EQUAL(idivfloor(bs::Mone<T>(), bs::Zero<T>()), bs::Valmin<r_t>());
+  STF_EQUAL(idiv(T(4),T(3), bs::floor), r_t(1));
+  STF_EQUAL(idiv(T(-4),T(-3), bs::floor), r_t(1));
+  STF_EQUAL(idiv(T(-4),T(3), bs::floor), r_t(-2));
+  STF_EQUAL(idiv(T(4),T(-3), bs::floor), r_t(-2));
+  STF_EQUAL(idiv(bs::Mone<T>(), bs::Mone<T>(), bs::floor), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(), bs::One<T>(), bs::floor), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(), bs::Zero<T>(), bs::floor), bs::Valmax<r_t>());
+  STF_EQUAL(idiv(bs::Mone<T>(), bs::Zero<T>(), bs::floor), bs::Valmin<r_t>());
 } // end of test for signed_int_

--- a/test/function/scalar/idivround.cpp
+++ b/test/function/scalar/idivround.cpp
@@ -28,6 +28,7 @@ STF_CASE_TPL (" idivreal",  STF_IEEE_TYPES)
   using bs::idiv;
 
   using r_t = decltype(idiv(T(), T()));
+#ifndef BOOST_SIMD_NO_INVALIDS
   STF_EQUAL(idiv(bs::Inf<T>(), bs::Inf<T>(), bs::round), bs::Zero<r_t>());
   STF_EQUAL(idiv(bs::Minf<T>(), bs::Minf<T>(), bs::round), bs::Zero<r_t>());
   STF_EQUAL(idiv(bs::Nan<T>(), bs::Nan<T>(), bs::round), bs::Zero<r_t>());

--- a/test/function/scalar/idivround.cpp
+++ b/test/function/scalar/idivround.cpp
@@ -7,7 +7,7 @@
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 */
 //==================================================================================================
-#include <boost/simd/function/idivround.hpp>
+#include <boost/simd/function/idiv.hpp>
 #include <simd_test.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>
 #include <boost/simd/constant/inf.hpp>
@@ -20,70 +20,59 @@
 #include <boost/simd/constant/valmin.hpp>
 #include <boost/simd/constant/mzero.hpp>
 
-STF_CASE_TPL (" idivroundreal",  STF_IEEE_TYPES)
+STF_CASE_TPL (" idivreal",  STF_IEEE_TYPES)
 {
   namespace bs = boost::simd;
   namespace bd = boost::dispatch;
 
-  using bs::idivround;
+  using bs::idiv;
 
-  using r_t = decltype(idivround(T(), T()));
-
-  // return type conformity test
-  STF_TYPE_IS(r_t, bd::as_integer_t<T>);
-
-  // specific values tests
-#ifndef STF_NO_INVALIDS
-  STF_EQUAL(idivround(bs::Inf<T>(), bs::Inf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(idivround(bs::Minf<T>(), bs::Minf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(idivround(bs::Nan<T>(), bs::Nan<T>()), bs::Zero<r_t>());
+  using r_t = decltype(idiv(T(), T()));
+  STF_EQUAL(idiv(bs::Inf<T>(), bs::Inf<T>(), bs::round), bs::Zero<r_t>());
+  STF_EQUAL(idiv(bs::Minf<T>(), bs::Minf<T>(), bs::round), bs::Zero<r_t>());
+  STF_EQUAL(idiv(bs::Nan<T>(), bs::Nan<T>(), bs::round), bs::Zero<r_t>());
 #endif
- STF_EQUAL(idivround(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(idivround(bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>());
-  STF_EQUAL(idivround(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(idivround(bs::One<T>(),bs::Zero<T>()), bs::Valmax<r_t>());
-  STF_EQUAL(idivround(bs::One<T>(),bs::Mzero<T>()), bs::Valmin<r_t>());
-  STF_EQUAL(idivround(bs::Zero<T>(),bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(idivround(T(4),T(3)), r_t(1));
-  STF_EQUAL(idivround(T(-4),T(-3)), r_t(1));
-  STF_EQUAL(idivround(T(-4),T(3)), r_t(-1));
-  STF_EQUAL(idivround(T(4),T(-3)), r_t(-1));
+ STF_EQUAL(idiv(bs::Mone<T>(), bs::Mone<T>(), bs::round), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::Mone<T>(),bs::Zero<T>(), bs::round), bs::Minf<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(), bs::One<T>(), bs::round), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(),bs::Zero<T>(), bs::round), bs::Valmax<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(),bs::Mzero<T>(), bs::round), bs::Valmin<r_t>());
+  STF_EQUAL(idiv(bs::Zero<T>(),bs::Zero<T>(), bs::round), bs::Zero<r_t>());
+  STF_EQUAL(idiv(T(4),T(3), bs::round), r_t(1));
+  STF_EQUAL(idiv(T(-4),T(-3), bs::round), r_t(1));
+  STF_EQUAL(idiv(T(-4),T(3), bs::round), r_t(-1));
+  STF_EQUAL(idiv(T(4),T(-3), bs::round), r_t(-1));
 } // end of test for floating_
 
-STF_CASE_TPL (" idivroundunsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL (" idivunsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
   namespace bd = boost::dispatch;
-  using bs::idivround;
-  using r_t = decltype(idivround(T(), T()));
+  using bs::idiv;
+  using r_t = decltype(idiv(T(), T()));
 
-  // return type conformity test
-  STF_TYPE_IS(r_t, bd::as_integer_t<T>);
-
-  // specific values tests
-  STF_EQUAL(idivround(T(4),T(3)), T(1));
-  STF_EQUAL(idivround(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(idivround(bs::One<T>(), bs::Zero<T>()), bs::Valmax<r_t>());
+  STF_EQUAL(idiv(T(4),T(3), bs::round), T(1));
+  STF_EQUAL(idiv(bs::One<T>(), bs::One<T>(), bs::round), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(), bs::Zero<T>(), bs::round), bs::Valmax<r_t>());
 } // end of test for unsigned_int_
 
-STF_CASE_TPL (" idivroundsigned_int",  STF_SIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL (" idivsigned_int",  STF_SIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
   namespace bd = boost::dispatch;
-  using bs::idivround;
-  using r_t = decltype(idivround(T(), T()));
-
+  using bs::idiv;
+  using r_t = decltype(idiv(T(), T()));
   // return type conformity test
   STF_TYPE_IS(r_t, bd::as_integer_t<T>);
 
   // specific values tests
-  STF_EQUAL(idivround(T(4),T(3)), r_t(1));
-  STF_EQUAL(idivround(T(-4),T(-3)), r_t(1));
-  STF_EQUAL(idivround(T(-4),T(3)), r_t(-1));
-  STF_EQUAL(idivround(T(4),T(-3)), r_t(-1));
-  STF_EQUAL(idivround(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(idivround(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(idivround(bs::One<T>(), bs::Zero<T>()), bs::Valmax<r_t>());
-  STF_EQUAL(idivround(bs::Mone<T>(), bs::Zero<T>()), bs::Valmin<r_t>());
+  STF_EQUAL(idiv(T(4),T(3), bs::round), r_t(1));
+  STF_EQUAL(idiv(T(-4),T(-3), bs::round), r_t(1));
+  STF_EQUAL(idiv(T(-4),T(3), bs::round), r_t(-1));
+  STF_EQUAL(idiv(T(4),T(-3), bs::round), r_t(-1));
+  STF_EQUAL(idiv(bs::Mone<T>(), bs::Mone<T>(), bs::round), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(), bs::One<T>(), bs::round), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(), bs::Zero<T>(), bs::round), bs::Valmax<r_t>());
+  STF_EQUAL(idiv(bs::Mone<T>(), bs::Zero<T>(), bs::round), bs::Valmin<r_t>());
 } // end of test for signed_int_
 

--- a/test/function/scalar/idivround2even.cpp
+++ b/test/function/scalar/idivround2even.cpp
@@ -30,6 +30,7 @@ STF_CASE_TPL (" idivround2evenreal",  STF_IEEE_TYPES)
   // return type conformity test
   STF_TYPE_IS(r_t,  bd::as_integer_t<T>);
 
+#ifndef BOOST_SIMD_NO_INVALIDS
   STF_EQUAL(idiv(bs::Inf<T>(), bs::Inf<T>(), bs::round2even), bs::Zero<r_t>());
   STF_EQUAL(idiv(bs::Minf<T>(), bs::Minf<T>(), bs::round2even), bs::Zero<r_t>());
   STF_EQUAL(idiv(bs::Nan<T>(), bs::Nan<T>(), bs::round2even), bs::Zero<r_t>());

--- a/test/function/scalar/idivround2even.cpp
+++ b/test/function/scalar/idivround2even.cpp
@@ -7,7 +7,7 @@
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 */
 //==================================================================================================
-#include <boost/simd/function/idivround2even.hpp>
+#include <boost/simd/function/idiv.hpp>
 #include <simd_test.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>
 #include <boost/simd/constant/inf.hpp>
@@ -30,58 +30,48 @@ STF_CASE_TPL (" idivround2evenreal",  STF_IEEE_TYPES)
   // return type conformity test
   STF_TYPE_IS(r_t,  bd::as_integer_t<T>);
 
-  // specific values tests
-#ifndef STF_NO_INVALIDS
-  STF_EQUAL(idivround2even(bs::Inf<T>(), bs::Inf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(idivround2even(bs::Minf<T>(), bs::Minf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(idivround2even(bs::Nan<T>(), bs::Nan<T>()), bs::Zero<r_t>());
+  STF_EQUAL(idiv(bs::Inf<T>(), bs::Inf<T>(), bs::round2even), bs::Zero<r_t>());
+  STF_EQUAL(idiv(bs::Minf<T>(), bs::Minf<T>(), bs::round2even), bs::Zero<r_t>());
+  STF_EQUAL(idiv(bs::Nan<T>(), bs::Nan<T>(), bs::round2even), bs::Zero<r_t>());
 #endif
- STF_EQUAL(idivround2even(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(idivround2even(bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>());
-  STF_EQUAL(idivround2even(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(idivround2even(bs::One<T>(),bs::Zero<T>()), bs::Valmax<r_t>());
-  STF_EQUAL(idivround2even(bs::One<T>(),bs::Mzero<T>()), bs::Valmin<r_t>());
-  STF_EQUAL(idivround2even(bs::Zero<T>(),bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(idivround2even(T(4),T(3)), r_t(1));
-  STF_EQUAL(idivround2even(T(-4),T(-3)), r_t(1));
-  STF_EQUAL(idivround2even(T(-4),T(3)), r_t(-1));
-  STF_EQUAL(idivround2even(T(4),T(-3)), r_t(-1));
+ STF_EQUAL(idiv(bs::Mone<T>(), bs::Mone<T>(), bs::round2even), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::Mone<T>(),bs::Zero<T>(), bs::round2even), bs::Minf<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(), bs::One<T>(), bs::round2even), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(),bs::Zero<T>(), bs::round2even), bs::Valmax<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(),bs::Mzero<T>(), bs::round2even), bs::Valmin<r_t>());
+  STF_EQUAL(idiv(bs::Zero<T>(),bs::Zero<T>(), bs::round2even), bs::Zero<r_t>());
+  STF_EQUAL(idiv(T(4),T(3), bs::round2even), r_t(1));
+  STF_EQUAL(idiv(T(-4),T(-3), bs::round2even), r_t(1));
+  STF_EQUAL(idiv(T(-4),T(3), bs::round2even), r_t(-1));
+  STF_EQUAL(idiv(T(4),T(-3), bs::round2even), r_t(-1));
 } // end of test for floating_
 
-STF_CASE_TPL (" idivround2evenunsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL (" idivunsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
   namespace bd = boost::dispatch;
-  using bs::idivround2even;
-  using r_t = decltype(idivround2even(T(), T()));
+  using bs::idiv;
+  using r_t = decltype(idiv(T(), T()));
 
-  // return type conformity test
-  STF_TYPE_IS(r_t,  (bd::as_integer_t<T, unsigned>));
-
-  // specific values tests
-  STF_EQUAL(idivround2even(T(4),T(3)), T(1));
-  STF_EQUAL(idivround2even(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(idivround2even(bs::One<T>(), bs::Zero<T>()), bs::Valmax<r_t>());
+  STF_EQUAL(idiv(T(4),T(3), bs::round2even), T(1));
+  STF_EQUAL(idiv(bs::One<T>(), bs::One<T>(), bs::round2even), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(), bs::Zero<T>(), bs::round2even), bs::Valmax<r_t>());
 } // end of test for unsigned_int_
 
-STF_CASE_TPL (" idivround2evensigned_int",  STF_SIGNED_INTEGRAL_TYPES)
+STF_CASE_TPL (" idivsigned_int",  STF_SIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
   namespace bd = boost::dispatch;
-  using bs::idivround2even;
-  using r_t = decltype(idivround2even(T(), T()));
+  using bs::idiv;
+  using r_t = decltype(idiv(T(), T()));
 
-  // return type conformity test
-   STF_TYPE_IS(r_t,  bd::as_integer_t<T>);
-
-  // specific values tests
-  STF_EQUAL(idivround2even(T(4),T(3)), r_t(1));
-  STF_EQUAL(idivround2even(T(-4),T(-3)), r_t(1));
-  STF_EQUAL(idivround2even(T(-4),T(3)), r_t(-1));
-  STF_EQUAL(idivround2even(T(4),T(-3)), r_t(-1));
-  STF_EQUAL(idivround2even(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(idivround2even(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(idivround2even(bs::One<T>(), bs::Zero<T>()), bs::Valmax<r_t>());
-  STF_EQUAL(idivround2even(bs::Mone<T>(), bs::Zero<T>()), bs::Valmin<r_t>());
+  STF_EQUAL(idiv(T(4),T(3), bs::round2even), r_t(1));
+  STF_EQUAL(idiv(T(-4),T(-3), bs::round2even), r_t(1));
+  STF_EQUAL(idiv(T(-4),T(3), bs::round2even), r_t(-1));
+  STF_EQUAL(idiv(T(4),T(-3), bs::round2even), r_t(-1));
+  STF_EQUAL(idiv(bs::Mone<T>(), bs::Mone<T>(), bs::round2even), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(), bs::One<T>(), bs::round2even), bs::One<r_t>());
+  STF_EQUAL(idiv(bs::One<T>(), bs::Zero<T>(), bs::round2even), bs::Valmax<r_t>());
+  STF_EQUAL(idiv(bs::Mone<T>(), bs::Zero<T>(), bs::round2even), bs::Valmin<r_t>());
 } // end of test for signed_int_
 


### PR DESCRIPTION
divivides (the division functor) can have many flavours, this pull request adds to functions div and idiv that can be called with an option among  floor, fix, ceil, round, round2even or no option. For example

div(a,b) is equivalent to divides(a,b) (a/b)
div(a,b,ceil) is equivalent to divceil(a,b) etc.

It is the same for idiv which always return integral types
idiv(a,b) is equivalent to divfix(a,b) (same as a/b for integer)
div(a,b,ceil) is equivalent to divceil(a,b) etc.
