### PR TITLE
Fix #57 - Made pack alignment more sensible

### DIFF
--- a/include/boost/simd/arch/common/simd/function/aligned_load.hpp
+++ b/include/boost/simd/arch/common/simd/function/aligned_load.hpp
@@ -38,7 +38,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target_t operator()(Pointer p, Target const&) const BOOST_NOEXCEPT
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, sizeof(storage_t))
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target_t::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer"
                       );
 

--- a/include/boost/simd/arch/common/simd/pack_traits.hpp
+++ b/include/boost/simd/arch/common/simd/pack_traits.hpp
@@ -39,6 +39,7 @@ namespace boost { namespace simd { namespace detail
     using storage_kind = ::boost::simd::scalar_storage;
 
     enum { static_size = N, element_size = 1 };
+    enum { alignment = sizeof(T) };
 
     BOOST_FORCEINLINE static reference at(storage_type& d, std::size_t i) BOOST_NOEXCEPT
     {
@@ -61,6 +62,8 @@ namespace boost { namespace simd { namespace detail
       static_size  = N,
       element_size = N / NumberOfVectors
     };
+
+    enum { alignment = SIMD::alignment };
 
     using storage_type              = std::array<SIMD, NumberOfVectors>;
 

--- a/include/boost/simd/arch/x86/avx/simd/function/aligned_load.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/aligned_load.hpp
@@ -35,7 +35,7 @@ namespace boost { namespace simd { namespace ext
     using target = typename Target::type;
     BOOST_FORCEINLINE target operator()(Pointer p, Target const&) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, sizeof(target))
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of double"
                       );
 
@@ -56,7 +56,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator() ( Pointer p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, sizeof(target))
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of float"
                       );
 

--- a/include/boost/simd/arch/x86/avx2/simd/function/aligned_load.hpp
+++ b/include/boost/simd/arch/x86/avx2/simd/function/aligned_load.hpp
@@ -35,7 +35,7 @@ namespace boost { namespace simd { namespace ext
     using target = typename Target::type;
     BOOST_FORCEINLINE target operator()(Pointer p, Target const&) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, sizeof(target))
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of integer"
                       );
 

--- a/include/boost/simd/arch/x86/sse1/simd/function/aligned_load.hpp
+++ b/include/boost/simd/arch/x86/sse1/simd/function/aligned_load.hpp
@@ -36,7 +36,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Pointer p, Target const&) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, sizeof(target))
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of float"
                       );
 

--- a/include/boost/simd/arch/x86/sse2/simd/function/aligned_load.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/aligned_load.hpp
@@ -35,7 +35,7 @@ namespace boost { namespace simd { namespace ext
     using target = typename Target::type;
     BOOST_FORCEINLINE target operator()(Pointer p, Target const&) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, sizeof(target))
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of double"
                       );
 
@@ -56,7 +56,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator() ( Pointer p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, sizeof(target))
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of integer"
                       );
 

--- a/include/boost/simd/detail/pack_traits.hpp
+++ b/include/boost/simd/detail/pack_traits.hpp
@@ -48,6 +48,7 @@ namespace boost { namespace simd { namespace detail
     using size_type                 = std::size_t;
 
     enum { static_size = N };
+    enum { alignment = sizeof(Storage) };
 
     using reference               = value_type&;
     using const_reference         = value_type const&;
@@ -67,6 +68,7 @@ namespace boost { namespace simd { namespace detail
     using size_type                 = std::size_t;                                                 \
                                                                                                    \
     enum { static_size = N, element_size = 1 };                                                    \
+    enum { alignment = sizeof(VTYPE) };                                                            \
                                                                                                    \
     using reference               = value_type&;                                                   \
     using const_reference         = value_type const&;                                             \

--- a/include/boost/simd/pack.hpp
+++ b/include/boost/simd/pack.hpp
@@ -67,6 +67,8 @@ namespace boost { namespace simd
 
     enum { static_size = N };
 
+    enum { alignment = traits::alignment };
+
     /// @brief pack type rebinding alias
     template<typename U> using rebind = pack<U,N>;
 

--- a/test/api/pack/ctor/pointer.cpp
+++ b/test/api/pack/ctor/pointer.cpp
@@ -17,9 +17,8 @@ void test(Env& $)
 {
   namespace ba = boost::alignment;
   using pack_t = boost::simd::pack<T, N>;
-  std::size_t alg = sizeof(typename pack_t::storage_type);
 
-  T* ptr = static_cast<T*>(ba::aligned_alloc(alg, (sizeof(T)) * N));
+  T* ptr = static_cast<T*>(ba::aligned_alloc(pack_t::alignment, (sizeof(T)) * N));
   std::iota(ptr, ptr + N, T{1});
 
   pack_t p(ptr);

--- a/test/function/simd/aligned_load.cpp
+++ b/test/function/simd/aligned_load.cpp
@@ -20,9 +20,7 @@ void test(Env& $)
   namespace bs = boost::simd;
   using p_t = bs::pack<T, N>;
 
-  std::size_t alg = sizeof(typename p_t::storage_type); //this work but is not really required if the asserts were corrected
-
-  T* a1 = static_cast<T*>(ba::aligned_alloc(alg, (sizeof(T)) * N*3));
+  T* a1 = static_cast<T*>(ba::aligned_alloc(p_t::alignment, (sizeof(T)) * N*3));
   STF_TYPE_IS(p_t, decltype(bs::aligned_load<p_t>(&a1[0])));
   STF_TYPE_IS(p_t, decltype(bs::aligned_load<p_t>(&a1[0], std::size_t())));
 
@@ -46,4 +44,3 @@ STF_CASE_TPL( "Check aligned_load behavior with all types", STF_NUMERIC_TYPES )
   test<T, N/2>($);
   test<T, N*2>($);
 }
-


### PR DESCRIPTION
Make pack alignment a enum accessible from pack<T,N>.
The alignment value is now equal to :
- sizeof(T) when emulating a small pack
- sizeof(SIMD register) if pack<T,N> use native storage
- sizeof(underlying SIMD register>) when emulating
  larger pack.
