### PR TITLE
workaround for floating bug in clang 3.7 and 3.8 for idivround2even 

### DIFF
--- a/include/boost/simd/arch/common/scalar/function/idivround2even.hpp
+++ b/include/boost/simd/arch/common/scalar/function/idivround2even.hpp
@@ -16,8 +16,8 @@
 // 04/24/2016
 
 #include <boost/predef/compiler.h>
-#if BOOST_COMP_CLANG >= BOOST_VERSION_NUMBER(3,7,0)
 
+#if BOOST_COMP_CLANG >= BOOST_VERSION_NUMBER(3,7,0)
 #include <boost/simd/constant/nan.hpp>
 #include <boost/simd/constant/valmin.hpp>
 #include <boost/simd/constant/valmax.hpp>
@@ -30,9 +30,6 @@
 
 namespace boost { namespace simd { namespace ext
 {
-
-
-
   BOOST_DISPATCH_OVERLOAD ( idivround2even_
                           , (typename A0)
                           , bd::cpu_
@@ -46,12 +43,9 @@ namespace boost { namespace simd { namespace ext
       if (a1) return  iround2even(a0/a1);
       if (!a0) return  Nan<result_t>();
       return is_negative(bitwise_or(a0, a1)) ? Valmin<result_t>() : Valmax<result_t>();
-
     }
   };
 } } }
 
 #endif
-
-
 #endif

--- a/include/boost/simd/arch/common/scalar/function/idivround2even.hpp
+++ b/include/boost/simd/arch/common/scalar/function/idivround2even.hpp
@@ -1,0 +1,57 @@
+//==================================================================================================
+/*!
+  @file
+
+  @copyright 2016 J.T. Lapreste
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_COMMON_SCALAR_FUNCTION_IDIVROUND2EVEN_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_COMMON_SCALAR_FUNCTION_IDIVROUND2EVEN_HPP_INCLUDED
+
+// workaround for "idivround2even(a0/a1) in floating scalar mode when a0 is non zero and a1 is zero
+// with clang 3.7 and 3.8
+// 04/24/2016
+
+#include <boost/predef/compiler.h>
+#if BOOST_COMP_CLANG >= BOOST_VERSION_NUMBER(3,7,0)
+
+#include <boost/simd/constant/nan.hpp>
+#include <boost/simd/constant/valmin.hpp>
+#include <boost/simd/constant/valmax.hpp>
+#include <boost/simd/function/scalar/bitwise_or.hpp>
+#include <boost/simd/function/scalar/iround2even.hpp>
+#include <boost/simd/function/scalar/is_negative.hpp>
+#include <boost/dispatch/function/overload.hpp>
+#include <boost/dispatch/meta/as_integer.hpp>
+#include <boost/config.hpp>
+
+namespace boost { namespace simd { namespace ext
+{
+
+
+
+  BOOST_DISPATCH_OVERLOAD ( idivround2even_
+                          , (typename A0)
+                          , bd::cpu_
+                          , bd::scalar_< bd::floating_<A0> >
+                          , bd::scalar_< bd::floating_<A0> >
+                          )
+  {
+    using result_t =  bd::as_integer_t<A0>;
+    BOOST_FORCEINLINE result_t operator() ( A0 const& a0, A0 const& a1) const BOOST_NOEXCEPT
+    {
+      if (a1) return  iround2even(a0/a1);
+      if (!a0) return  Nan<result_t>();
+      return is_negative(bitwise_or(a0, a1)) ? Valmin<result_t>() : Valmax<result_t>();
+
+    }
+  };
+} } }
+
+#endif
+
+
+#endif

--- a/include/boost/simd/arch/common/scalar/function/is_invalid.hpp
+++ b/include/boost/simd/arch/common/scalar/function/is_invalid.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE bool operator() ( A0 const&) const BOOST_NOEXCEPT
     {
-      return {false};
+      return false;
     }
   };
   BOOST_DISPATCH_OVERLOAD ( is_invalid_

--- a/include/boost/simd/function/scalar/idivround2even.hpp
+++ b/include/boost/simd/function/scalar/idivround2even.hpp
@@ -13,6 +13,7 @@
 #define BOOST_SIMD_FUNCTION_SCALAR_IDIVROUND2EVEN_HPP_INCLUDED
 
 #include <boost/simd/function/definition/idivround2even.hpp>
+#include <boost/simd/arch/common/scalar/function/idivround2even.hpp>
 #include <boost/simd/arch/common/generic/function/idivround2even.hpp>
 
 #endif


### PR DESCRIPTION
and correcting a brace warning in is_invalid.hpp in clang 3.7
