### PR TITLE
Implement slide

### DIFF
--- a/include/boost/simd/arch/common/scalar/constant/zero.hpp
+++ b/include/boost/simd/arch/common/scalar/constant/zero.hpp
@@ -1,0 +1,34 @@
+//==================================================================================================
+/*!
+  @file
+
+  @copyright 2015 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_COMMON_SCALAR_CONSTANT_ZERO_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_COMMON_SCALAR_CONSTANT_ZERO_HPP_INCLUDED
+
+#include <boost/simd/logical.hpp>
+#include <boost/dispatch/function/overload.hpp>
+#include <boost/dispatch/as.hpp>
+
+namespace boost { namespace simd { namespace ext
+{
+  namespace bs = boost::simd;
+  namespace bd = boost::dispatch;
+
+  BOOST_DISPATCH_OVERLOAD ( zero_, (typename T), bd::cpu_
+                          , bd::target_<bd::scalar_<bs::logical_<T>>>
+                          )
+  {
+    BOOST_FORCEINLINE typename T::type operator()(T const&) const BOOST_NOEXCEPT
+    {
+      return typename T::type( typename T::type::value_type(false) );
+    }
+  };
+} } }
+
+#endif

--- a/include/boost/simd/arch/common/scalar/function/slide.hpp
+++ b/include/boost/simd/arch/common/scalar/function/slide.hpp
@@ -1,0 +1,49 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_COMMON_SCALAR_FUNCTION_SLIDE_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_COMMON_SCALAR_FUNCTION_SLIDE_HPP_INCLUDED
+
+#include <boost/dispatch/adapted/std/integral_constant.hpp>
+#include <boost/dispatch/function/overload.hpp>
+#include <boost/config.hpp>
+
+namespace boost { namespace simd { namespace ext
+{
+  namespace bd = boost::dispatch;
+  namespace bs = boost::simd;
+
+  BOOST_DISPATCH_OVERLOAD ( slide_
+                          , (typename Value, typename Offset)
+                          , bd::cpu_
+                          , bd::scalar_<bd::unspecified_<Value>>
+                          , bd::constant_<bd::integer_<Offset>>
+                          )
+  {
+    BOOST_FORCEINLINE Value operator()(Value const& a0, Offset const&) const
+    {
+      return a0;
+    }
+  };
+
+  BOOST_DISPATCH_OVERLOAD ( slide_
+                          , (typename Value, typename Offset)
+                          , bd::cpu_
+                          , bd::scalar_<bd::unspecified_<Value>>
+                          , bd::scalar_<bd::unspecified_<Value>>
+                          , bd::constant_<bd::integer_<Offset>>
+                          )
+  {
+    BOOST_FORCEINLINE Value operator()(Value const& a0, Value const&, Offset const&) const
+    {
+      return a0;
+    }
+  };
+} } }
+
+#endif

--- a/include/boost/simd/arch/common/simd/constant/zero.hpp
+++ b/include/boost/simd/arch/common/simd/constant/zero.hpp
@@ -1,0 +1,34 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_COMMON_SIMD_CONSTANT_ZERO_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_COMMON_SIMD_CONSTANT_ZERO_HPP_INCLUDED
+
+#include <boost/simd/meta/hierarchy/logical.hpp>
+#include <boost/simd/meta/hierarchy/simd.hpp>
+#include <boost/dispatch/function/overload.hpp>
+#include <boost/dispatch/as.hpp>
+
+namespace boost { namespace simd { namespace ext
+{
+  namespace bd = boost::dispatch;
+
+  BOOST_DISPATCH_OVERLOAD ( zero_
+                          , (typename T, typename X)
+                          , bd::cpu_
+                          , bd::target_<bs::pack_<bs::logical_<T>,X>>
+                          )
+  {
+    BOOST_FORCEINLINE typename T::type operator()(T const&) const BOOST_NOEXCEPT
+    {
+      return typename T::type( typename T::type::value_type(false) );
+    }
+  };
+} } }
+
+#endif

--- a/include/boost/simd/arch/common/simd/function/slide.hpp
+++ b/include/boost/simd/arch/common/simd/function/slide.hpp
@@ -1,0 +1,108 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_SLIDE_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_SLIDE_HPP_INCLUDED
+
+#include <boost/simd/function/combine.hpp>
+#include <boost/simd/function/extract.hpp>
+#include <boost/simd/function/slice_low.hpp>
+#include <boost/simd/function/slice_high.hpp>
+#include <boost/simd/constant/zero.hpp>
+#include <boost/simd/detail/overload.hpp>
+#include <boost/simd/detail/brigand.hpp>
+
+namespace boost { namespace simd { namespace ext
+{
+  namespace bd = boost::dispatch;
+  namespace bs = boost::simd;
+
+  //------------------------------------------------------------------------------------------------
+  // unary slide uses binary slide with Zero
+  BOOST_DISPATCH_OVERLOAD ( slide_
+                          , (typename T, typename X, typename Offset)
+                          , bd::cpu_
+                          , bs::pack_< bd::unspecified_<T>, X >
+                          , bd::constant_<bd::integer_<Offset>>
+                          )
+  {
+    static BOOST_FORCEINLINE T do_(T const& a0, std::true_type const&) BOOST_NOEXCEPT
+    {
+      return slide<Offset::value>(a0,Zero<T>());
+    }
+
+    static BOOST_FORCEINLINE T do_(T const& a0, std::false_type const&) BOOST_NOEXCEPT
+    {
+      return slide<Offset::value+T::static_size>(Zero<T>(),a0);
+    }
+
+    BOOST_FORCEINLINE T operator()(T const& a0, Offset const&) const BOOST_NOEXCEPT
+    {
+      return do_(a0,brigand::bool_<(Offset::value >= 0)>());
+    }
+  };
+
+  //------------------------------------------------------------------------------------------------
+  // Binary slide reconstructs and optimizes
+  BOOST_DISPATCH_OVERLOAD ( slide_
+                          , (typename T, typename X, typename Offset)
+                          , bd::cpu_
+                          , bs::pack_< bd::unspecified_<T>, X >
+                          , bs::pack_< bd::unspecified_<T>, X >
+                          , bd::constant_<bd::integer_<Offset>>
+                          )
+  {
+    using hcard = std::integral_constant<std::size_t,T::static_size/2>;
+
+    // Slide by N gives whatever in non-aggregate storage
+    template<typename K, typename H, typename... L0, typename... L1>
+    static BOOST_FORCEINLINE T unroll ( T const& a0, T const& a1, K const&, H const&
+                                      , brigand::list<L0...> const&, brigand::list<L1...> const&
+                                      )
+    {
+      return T( extract<L0::value>(a0)..., extract<L1::value>(a1)... );
+    }
+
+    // Slide by N is optimized for aggregate storage
+    template<typename... L0, typename... L1>
+    static BOOST_FORCEINLINE T unroll ( T const& a0, T const& a1, aggregate_storage const&
+                                      , std::true_type const&
+                                      , brigand::list<L0...> const&, brigand::list<L1...> const&
+                                      )
+    {
+      return combine( slide<Offset::value%hcard::value>(a0.storage()[0], a0.storage()[1])
+                    , slide<Offset::value%hcard::value>(a0.storage()[1], a1.storage()[0])
+                    );
+    }
+
+    template<typename... L0, typename... L1>
+    static BOOST_FORCEINLINE T unroll ( T const& a0, T const& a1, aggregate_storage const&
+                                      , std::false_type const&
+                                      , brigand::list<L0...> const&, brigand::list<L1...> const&
+                                      )
+    {
+      return combine( slide<Offset::value%hcard::value>(a0.storage()[1], a1.storage()[0])
+                    , slide<Offset::value%hcard::value>(a1.storage()[0], a1.storage()[1])
+                    );
+    }
+
+    BOOST_FORCEINLINE T operator()(T const& a0, T const& a1, Offset const&) const
+    {
+      // Those integral constant lists contain the iteration steps to be used by the variadic
+      // unrolling seen above. We statically computes the indexes from a0 and a1 using their
+      // relative position with respect to the slide offset.
+      return unroll ( a0, a1, typename T::traits::storage_kind{}
+                    , brigand::bool_<(Offset::value < hcard::value)>{}
+                    , brigand::range<int,Offset::value, T::static_size>{}
+                    , brigand::range<int,0, Offset::value>{}
+                    );
+    }
+  };
+} } }
+
+#endif

--- a/include/boost/simd/arch/common/simd/pack_traits.hpp
+++ b/include/boost/simd/arch/common/simd/pack_traits.hpp
@@ -37,7 +37,8 @@ namespace boost { namespace simd { namespace detail
     using reference                 = value_type&;
     using const_reference           = value_type const&;
 
-    using static_range	            = brigand::range<std::size_t, 0, N>;
+    using static_range              = brigand::range<std::size_t, 0, N>;
+    using element_range	            = brigand::range<std::size_t, 0, N>;
 
     using storage_kind              = ::boost::simd::scalar_storage;
 
@@ -85,6 +86,7 @@ namespace boost { namespace simd { namespace detail
     using const_reference           = typename SIMD::const_reference;
 
     using static_range	            = brigand::range<std::size_t, 0, NumberOfVectors>;
+    using element_range             = brigand::range<std::size_t, 0, N>;
 
     using storage_kind              = ::boost::simd::aggregate_storage;
 

--- a/include/boost/simd/arch/x86/avx/simd/function/slide.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/slide.hpp
@@ -1,0 +1,65 @@
+//==================================================================================================
+/**
+  Copyright 2016 Numscale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_X86_AVX_SIMD_FUNCTION_SLIDE_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_X86_AVX_SIMD_FUNCTION_SLIDE_HPP_INCLUDED
+
+#include <boost/simd/detail/overload.hpp>
+#include <boost/simd/function/combine.hpp>
+
+namespace boost { namespace simd { namespace ext
+{
+  namespace bd = boost::dispatch;
+  namespace bs = boost::simd;
+
+  BOOST_DISPATCH_OVERLOAD ( slide_
+                          , (typename T, typename Offset)
+                          , bs::avx_
+                          , bs::pack_< bd::fundamental_<T>, bs::avx_ >
+                          , bs::pack_< bd::fundamental_<T>, bs::avx_ >
+                          , bd::constant_<bd::integer_<Offset>>
+                          )
+  {
+    using storage_t     = typename T::storage_type;
+    using hcard         = std::integral_constant<std::size_t,T::static_size/2>;
+    using sub_t         = typename T::template resize<hcard::value>;
+    using sub_storage_t = typename sub_t::storage_type;
+
+    // slide under half the cardinal
+    static BOOST_FORCEINLINE T do_(__m256i v0, __m256i v1, std::true_type const&) BOOST_NOEXCEPT
+    {
+      sub_t s0h((sub_storage_t)(_mm256_extractf128_si256(v0, 0)));
+      sub_t s1h((sub_storage_t)(_mm256_extractf128_si256(v1, 0)));
+      sub_t s1l((sub_storage_t)(_mm256_extractf128_si256(v1, 1)));
+
+      return combine( slide<Offset::value%hcard::value>(s1h, s1l)
+                    , slide<Offset::value%hcard::value>(s1l, s0h)
+                    );
+    }
+
+    static BOOST_FORCEINLINE T do_(__m256i v0, __m256i v1, std::false_type const&) BOOST_NOEXCEPT
+    {
+      sub_t s1l((sub_storage_t)(_mm256_extractf128_si256(v1, 1)));
+      sub_t s0h((sub_storage_t)(_mm256_extractf128_si256(v0, 0)));
+      sub_t s0l((sub_storage_t)(_mm256_extractf128_si256(v0, 1)));
+
+      return combine( slide<Offset::value%hcard::value>(s1l, s0h)
+                    , slide<Offset::value%hcard::value>(s0h, s0l)
+                    );
+    }
+
+    BOOST_FORCEINLINE T operator()(T const& a0, T const& a1, Offset const&) const BOOST_NOEXCEPT
+    {
+      return do_( (__m256i)(a1.storage()), (__m256i)(a0.storage())
+                , brigand::bool_<(Offset::value < hcard::value)>{}
+                );
+    }
+  };
+} } }
+
+#endif

--- a/include/boost/simd/arch/x86/sse2/simd/function/slide.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/slide.hpp
@@ -1,0 +1,76 @@
+//==================================================================================================
+/**
+  Copyright 2016 Numscale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_X86_SSE2_SIMD_FUNCTION_SLIDE_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_X86_SSE2_SIMD_FUNCTION_SLIDE_HPP_INCLUDED
+
+#include <boost/simd/function/bitwise_cast.hpp>
+#include <boost/simd/detail/overload.hpp>
+
+namespace boost { namespace simd { namespace ext
+{
+  namespace bd = boost::dispatch;
+  namespace bs = boost::simd;
+
+  BOOST_DISPATCH_OVERLOAD ( slide_
+                          , (typename T, typename Offset)
+                          , bs::sse2_
+                          , bs::pack_< bd::fundamental_<T>, bs::sse_ >
+                          , bd::constant_<bd::integer_<Offset>>
+                          )
+  {
+    using bits_t  = typename T::template rebind<std::uint8_t>::template resize<16>;
+    using bcnt    = std::integral_constant<std::size_t,16u/T::static_size>;
+
+    // slide with positive offset
+    static BOOST_FORCEINLINE T side(T const& a0, std::true_type const&) BOOST_NOEXCEPT
+    {
+      using imm = std::integral_constant<std::size_t,Offset::value*bcnt::value>;
+      return bitwise_cast<T>(_mm_srli_si128(bitwise_cast<bits_t>(a0),imm::value));
+    }
+
+    // slide with negative offset
+    static BOOST_FORCEINLINE T side( T const& a0, std::false_type const& ) BOOST_NOEXCEPT
+    {
+      using imm = std::integral_constant<std::size_t,(-Offset::value)*bcnt::value>;
+      return bitwise_cast<T>(_mm_slli_si128(bitwise_cast<bits_t>(a0),imm::value));
+    }
+
+    BOOST_FORCEINLINE T operator()(T const& a0, Offset const&) const BOOST_NOEXCEPT
+    {
+      return side(a0, brigand::bool_<(Offset::value >= 0)>{});
+    }
+  };
+
+  BOOST_DISPATCH_OVERLOAD ( slide_
+                          , (typename T, typename Offset)
+                          , bs::sse2_
+                          , bs::pack_< bd::fundamental_<T>, bs::sse_ >
+                          , bs::pack_< bd::fundamental_<T>, bs::sse_ >
+                          , bd::constant_<bd::integer_<Offset>>
+                          )
+  {
+    using bits_t  = typename T::template rebind<std::uint8_t>::template resize<16>;
+
+    BOOST_FORCEINLINE T operator()(T const& a0, T const& a1, Offset const&) const BOOST_NOEXCEPT
+    {
+      // Compute relative offsets for shifted loads pair
+      using bcnt  = std::integral_constant<std::size_t,(16u/T::static_size)>;
+      using ls    = std::integral_constant<std::size_t,bcnt::value*Offset::value>;
+      using rs    = std::integral_constant<std::size_t,bcnt::value*(T::static_size-Offset::value)>;
+
+      // Shift everything in place
+      return bitwise_cast<T>( _mm_or_si128( _mm_srli_si128(bitwise_cast<bits_t>(a0),ls::value)
+                                          , _mm_slli_si128(bitwise_cast<bits_t>(a1),rs::value)
+                                          )
+                            );
+    }
+  };
+} } }
+
+#endif

--- a/include/boost/simd/arch/x86/ssse3/simd/function/slide.hpp
+++ b/include/boost/simd/arch/x86/ssse3/simd/function/slide.hpp
@@ -1,0 +1,49 @@
+//==================================================================================================
+/**
+  Copyright 2016 Numscale SAS
+  Copyright 2016 J.T.Lapreste
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_X86_SSSE3_SIMD_FUNCTION_SLIDE_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_X86_SSSE3_SIMD_FUNCTION_SLIDE_HPP_INCLUDED
+
+#include <boost/simd/meta/as_arithmetic.hpp>
+#include <boost/simd/detail/overload.hpp>
+#include <boost/simd/detail/brigand.hpp>
+
+namespace boost { namespace simd { namespace ext
+{
+  namespace bd = boost::dispatch;
+  namespace bs = boost::simd;
+
+  BOOST_DISPATCH_OVERLOAD ( slide_
+                          , (typename T, typename Offset)
+                          , bs::ssse3_
+                          , bs::pack_< bd::fundamental_<T>, bs::sse_ >
+                          , bs::pack_< bd::fundamental_<T>, bs::sse_ >
+                          , bd::constant_<bd::integer_<Offset>>
+                          )
+  {
+    using storage_t = typename T::storage_type;
+
+    BOOST_FORCEINLINE T operator()(T const& a0, T const& a1, Offset const&) const BOOST_NOEXCEPT
+    {
+      // Compute relative offsets
+      using bitcount = std::integral_constant < std::size_t
+                                              , sizeof(as_arithmetic_t<typename T::value_type>)
+                                              * Offset::value
+                                              >;
+
+      // Shift everything in place
+      return (storage_t)( _mm_alignr_epi8 ( (__m128i)(a1.storage()), (__m128i)(a0.storage())
+                                          , bitcount::value
+                                          )
+                        );
+    }
+  };
+} } }
+
+#endif

--- a/include/boost/simd/constant/zero.hpp
+++ b/include/boost/simd/constant/zero.hpp
@@ -49,7 +49,8 @@ namespace boost { namespace simd
 #endif
 
 #include <boost/simd/constant/definition/zero.hpp>
+#include <boost/simd/arch/common/scalar/constant/zero.hpp>
 #include <boost/simd/arch/common/scalar/constant/constant_value.hpp>
 #include <boost/simd/arch/common/simd/constant/constant_value.hpp>
-
+#include <boost/simd/arch/common/simd/constant/zero.hpp>
 #endif

--- a/include/boost/simd/detail/logical.hpp
+++ b/include/boost/simd/detail/logical.hpp
@@ -37,6 +37,7 @@ namespace boost { namespace simd { namespace detail
     using substorage_type   = T;
 
     using static_range      = brigand::range<std::size_t, 0, N>;
+    using element_range     = brigand::range<std::size_t, 0, N>;
 
     enum { static_size = N, element_size = 1, number_of_vectors = 0 };
     enum { alignment = sizeof(T) };
@@ -68,6 +69,7 @@ namespace boost { namespace simd { namespace detail
     using substorage_type = SIMD;
 
     using static_range    = brigand::range<std::size_t, 0, NumberOfVectors>;
+    using element_range     = brigand::range<std::size_t, 0, N>;
 
     enum  { static_size = N
           , element_size = N / NumberOfVectors

--- a/include/boost/simd/detail/pack_traits.hpp
+++ b/include/boost/simd/detail/pack_traits.hpp
@@ -72,6 +72,7 @@ namespace boost { namespace simd { namespace detail
     };                                                                                             \
                                                                                                    \
     using static_range            = brigand::range<std::size_t, 0, N>;                             \
+    using element_range           = brigand::range<std::size_t, 0, N>;                             \
                                                                                                    \
     using storage_kind            = ::boost::simd::native_storage;                                 \
                                                                                                    \

--- a/include/boost/simd/function/definition/slide.hpp
+++ b/include/boost/simd/function/definition/slide.hpp
@@ -1,0 +1,47 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_FUNCTION_DEFINITION_SLIDE_HPP_INCLUDED
+#define BOOST_SIMD_FUNCTION_DEFINITION_SLIDE_HPP_INCLUDED
+
+#include <boost/simd/config.hpp>
+#include <boost/simd/meta/cardinal_of.hpp>
+#include <boost/dispatch/function/make_callable.hpp>
+#include <boost/dispatch/hierarchy/functions.hpp>
+#include <boost/simd/detail/dispatch.hpp>
+
+namespace boost { namespace simd
+{
+  namespace tag
+  {
+    BOOST_DISPATCH_MAKE_TAG(ext, slide_, boost::dispatch::abstract_<slide_>);
+  }
+
+  namespace ext
+  {
+    BOOST_DISPATCH_FUNCTION_DECLARATION(tag, slide_);
+  }
+
+  namespace detail
+  {
+    BOOST_DISPATCH_CALLABLE_DEFINITION(tag::slide_,slide);
+  }
+} }
+
+#include <boost/simd/function/detail/slide.hpp>
+
+namespace boost { namespace simd
+{
+  template<int N, typename T> BOOST_FORCEINLINE auto slide(T const& a0, T const& a1)
+  BOOST_NOEXCEPT_DECLTYPE_BODY((detail::slider<T,N,cardinal_of<T>::value,(N>=0)>::call(a0,a1)));
+
+  template<int N, typename T> BOOST_FORCEINLINE auto slide(T const& a0)
+  BOOST_NOEXCEPT_DECLTYPE_BODY((detail::slider<T,N,cardinal_of<T>::value,(N>=0)>::call(a0)));
+} }
+
+#endif

--- a/include/boost/simd/function/detail/slide.hpp
+++ b/include/boost/simd/function/detail/slide.hpp
@@ -1,0 +1,61 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_FUNCTION_DETAIL_SLIDE_HPP_INCLUDED
+#define BOOST_SIMD_FUNCTION_DETAIL_SLIDE_HPP_INCLUDED
+
+#include <boost/simd/config.hpp>
+#include <boost/simd/constant/zero.hpp>
+#include <type_traits>
+
+namespace boost { namespace simd { namespace detail
+{
+  // General case dispatch to arch-specific implementation
+  template<typename T,int N, int Card, bool isFwd> struct slider
+  {
+    static BOOST_FORCEINLINE auto call(T const& a0, T const& a1)
+    BOOST_NOEXCEPT_DECLTYPE_BODY(detail::slide(a0,a1,std::integral_constant<int, N>{}));
+
+    static BOOST_FORCEINLINE auto call(T const& a0)
+    BOOST_NOEXCEPT_DECLTYPE_BODY(detail::slide(a0,std::integral_constant<int, N>{}));
+  };
+
+  // Backward slide slides the swapped inputs by the complement of the offset except for
+  // unary case which may be optimized by the architecture
+  template<typename T,int N, int Card> struct slider<T,N,Card,false>
+  {
+    static BOOST_FORCEINLINE auto call(T const& a0, T const& a1)
+    BOOST_NOEXCEPT_DECLTYPE_BODY(detail::slide(a1,a0,std::integral_constant<int, Card+N>{}));
+
+    static BOOST_FORCEINLINE auto call(T const& a0)
+    BOOST_NOEXCEPT_DECLTYPE_BODY(detail::slide(a0,std::integral_constant<int, N>{}));
+  };
+
+  // Scalar-like value returns a0 in backward mode
+  template<typename T,int N> struct slider<T,N,1,false>
+  {
+    static BOOST_FORCEINLINE T call(T const&, T const& a1)  BOOST_NOEXCEPT { return a1;        }
+    static BOOST_FORCEINLINE T call(T const&)               BOOST_NOEXCEPT { return Zero<T>(); }
+  };
+
+  // Sliding by 0 is identity
+  template<typename T, int Card> struct slider<T,0,Card,true>
+  {
+    static BOOST_FORCEINLINE T call(T const& a0, T const&)  BOOST_NOEXCEPT  { return a0; }
+    static BOOST_FORCEINLINE T call(T const& a0)            BOOST_NOEXCEPT  { return a0; }
+  };
+
+  // Sliding by cardinal is the 2nd parameter (or zero if lack thereof)
+  template<int N,typename T> struct slider<T, N, N, true>
+  {
+    static BOOST_FORCEINLINE T call(T const&, T const& a1)  BOOST_NOEXCEPT  { return a1;        }
+    static BOOST_FORCEINLINE T call(T const& )              BOOST_NOEXCEPT  { return Zero<T>(); }
+  };
+} } }
+
+#endif

--- a/include/boost/simd/function/scalar/slide.hpp
+++ b/include/boost/simd/function/scalar/slide.hpp
@@ -1,0 +1,15 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_FUNCTION_SCALAR_SLIDE_HPP_INCLUDED
+#define BOOST_SIMD_FUNCTION_SCALAR_SLIDE_HPP_INCLUDED
+
+#include <boost/simd/function/definition/slide.hpp>
+#include <boost/simd/arch/common/scalar/function/slide.hpp>
+
+#endif

--- a/include/boost/simd/function/simd/slide.hpp
+++ b/include/boost/simd/function/simd/slide.hpp
@@ -1,0 +1,27 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_FUNCTION_SIMD_SLIDE_HPP_INCLUDED
+#define BOOST_SIMD_FUNCTION_SIMD_SLIDE_HPP_INCLUDED
+
+#include <boost/simd/function/scalar/slide.hpp>
+#include <boost/simd/arch/common/simd/function/slide.hpp>
+
+#if defined(BOOST_HW_SIMD_X86)
+#  if BOOST_HW_SIMD_X86 >= BOOST_HW_SIMD_X86_SSE2_VERSION
+#    include <boost/simd/arch/x86/sse2/simd/function/slide.hpp>
+#  endif
+#  if BOOST_HW_SIMD_X86 >= BOOST_HW_SIMD_X86_SSSE3_VERSION
+#    include <boost/simd/arch/x86/ssse3/simd/function/slide.hpp>
+#  endif
+#  if BOOST_HW_SIMD_X86 >= BOOST_HW_SIMD_X86_AVX_VERSION
+#    include <boost/simd/arch/x86/avx/simd/function/slide.hpp>
+#  endif
+#endif
+
+#endif

--- a/include/boost/simd/function/slide.hpp
+++ b/include/boost/simd/function/slide.hpp
@@ -1,0 +1,30 @@
+//==================================================================================================
+/*!
+  @file
+
+  @copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#ifndef BOOST_SIMD_FUNCTION_SLIDE_HPP_INCLUDED
+#define BOOST_SIMD_FUNCTION_SLIDE_HPP_INCLUDED
+
+namespace boost { namespace simd
+{
+#if defined(DOXYGEN_ONLY)
+  /*!
+
+  **/
+  template<std::size_t N, typename T> T slide(T const& a0, T const& a1) {}
+
+  /// @overload
+  template<std::size_t N, typename T> T slide(T const& a0) {}
+#endif
+} }
+
+#include <boost/simd/function/scalar/slide.hpp>
+#include <boost/simd/function/simd/slide.hpp>
+
+#endif

--- a/test/function/scalar/CMakeLists.txt
+++ b/test/function/scalar/CMakeLists.txt
@@ -15,6 +15,7 @@ set ( SOURCES
 #memory
    extract.cpp
    load.cpp
+   slide.cpp
    splat.cpp
    make.cpp
 #alias

--- a/test/function/scalar/slide.cpp
+++ b/test/function/scalar/slide.cpp
@@ -1,0 +1,24 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#include <boost/simd/function/scalar/slide.hpp>
+#include <simd_test.hpp>
+
+namespace bs = boost::simd;
+
+STF_CASE_TPL( "Check unary slide behavior", STF_NUMERIC_TYPES )
+{
+  STF_EQUAL( bs::slide< 0>(T(42)), T(42) );
+}
+
+STF_CASE_TPL( "Check binary slide behavior", STF_NUMERIC_TYPES )
+{
+  STF_EQUAL( bs::slide<-1>(T(13),T(37)), T(37)  );
+  STF_EQUAL( bs::slide< 0>(T(13),T(37)), T(13)  );
+  STF_EQUAL( bs::slide<+1>(T(13),T(37)), T(37)  );
+}

--- a/test/function/simd/CMakeLists.txt
+++ b/test/function/simd/CMakeLists.txt
@@ -14,6 +14,7 @@ add_subdirectory(insert)
 add_subdirectory(load)
 add_subdirectory(make)
 add_subdirectory(slice)
+add_subdirectory(slide)
 add_subdirectory(splat)
 
 set ( SOURCES

--- a/test/function/simd/slide/CMakeLists.txt
+++ b/test/function/simd/slide/CMakeLists.txt
@@ -1,0 +1,17 @@
+##===================================================================================================
+##                               Copyright 2016 NumScale SAS
+##
+##                   Distributed under the Boost Software License, Version 1.0.
+##                        See accompanying file LICENSE.txt or copy at
+##                            http://www.boost.org/LICENSE_1_0.txt
+##===================================================================================================
+
+set ( SOURCES
+  unary.arithmetic.cpp
+  unary.logical.cpp
+  binary.arithmetic.cpp
+  binary.logical.cpp
+)
+
+make_unit( "function.simd.slide"   ${SOURCES})
+make_coverage("function.simd.slide"  ${SOURCES})

--- a/test/function/simd/slide/binary.arithmetic.cpp
+++ b/test/function/simd/slide/binary.arithmetic.cpp
@@ -1,0 +1,51 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#include <boost/simd/function/slide.hpp>
+#include <boost/simd/detail/unroll.hpp>
+#include <boost/simd/pack.hpp>
+#include <simd_test.hpp>
+
+namespace bs = boost::simd;
+
+template <typename T, int N, typename Env> void test(Env& $)
+{
+  std::array<T,4*N> data;
+  for(std::size_t i = 0;i < data.size(); ++i) data[i] = T(0);
+  for(int i =   N;i < 2*N; ++i) data[i] = T(i);
+  for(int i = 2*N;i < 3*N; ++i) data[i] = T(i*2);
+
+  using p_t = bs::pack<T,N>;
+  p_t ref;
+  p_t l = bs::load<p_t>(&data[  N]);
+  p_t r = bs::load<p_t>(&data[2*N]);
+
+  STF_EQUAL( bs::slide<-N>(l,r), bs::slide<0>(r,l) );
+  STF_EQUAL( bs::slide<-1>(l,r), bs::slide<N-1>(r,l) );
+
+  ref = bs::load<p_t>(&data[N]);
+  STF_EQUAL( bs::slide<0>(l,r), ref );
+
+  ref = bs::load<p_t>(&data[N], +1);
+  STF_EQUAL( bs::slide<+1>(l,r), ref );
+
+  ref = bs::load<p_t>(&data[N], N-1);
+  STF_EQUAL( bs::slide<N-1>(l,r), ref );
+
+  STF_EQUAL( bs::slide<N>(l,r), r );
+}
+
+STF_CASE_TPL( "Check binary slide behavior", STF_NUMERIC_TYPES )
+{
+  namespace bs = boost::simd;
+  static const int N = bs::pack<T>::static_size;
+
+  test<T, N  >($);
+  test<T, N/2>($);
+  test<T, N*2>($);
+}

--- a/test/function/simd/slide/binary.logical.cpp
+++ b/test/function/simd/slide/binary.logical.cpp
@@ -1,0 +1,51 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#include <boost/simd/function/slide.hpp>
+#include <boost/simd/logical.hpp>
+#include <boost/simd/pack.hpp>
+#include <simd_test.hpp>
+
+namespace bs = boost::simd;
+
+template <typename T, int N, typename Env> void test(Env& $)
+{
+  std::array<bs::logical<T>,4*N> data;
+  for(std::size_t i = 0;i < data.size(); ++i) data[i] = T(0);
+  for(int i =   N;i < 2*N; ++i) data[i] = T(i%2);
+  for(int i = 2*N;i < 3*N; ++i) data[i] = T((i+1)%2);
+
+  using p_t = bs::pack<bs::logical<T>,N>;
+  p_t ref;
+  p_t l = bs::load<p_t>(&data[  N]);
+  p_t r = bs::load<p_t>(&data[2*N]);
+
+  STF_EQUAL( bs::slide<-N>(l,r), bs::slide<0>(r,l) );
+  STF_EQUAL( bs::slide<-1>(l,r), bs::slide<N-1>(r,l) );
+
+  ref = bs::load<p_t>(&data[N]);
+  STF_EQUAL( bs::slide<0>(l,r), ref );
+
+  ref = bs::load<p_t>(&data[N], +1);
+  STF_EQUAL( bs::slide<+1>(l,r), ref );
+
+  ref = bs::load<p_t>(&data[N], N-1);
+  STF_EQUAL( bs::slide<N-1>(l,r), ref );
+
+  STF_EQUAL( bs::slide<N>(l,r), r );
+}
+
+STF_CASE_TPL( "Check binary slide behavior", STF_NUMERIC_TYPES )
+{
+  namespace bs = boost::simd;
+  static const int N = bs::pack<bs::logical<T>>::static_size;
+
+  test<T, N  >($);
+  test<T, N/2>($);
+  test<T, N*2>($);
+}

--- a/test/function/simd/slide/unary.arithmetic.cpp
+++ b/test/function/simd/slide/unary.arithmetic.cpp
@@ -1,0 +1,46 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#include <boost/simd/function/slide.hpp>
+#include <boost/simd/detail/unroll.hpp>
+#include <boost/simd/pack.hpp>
+#include <simd_test.hpp>
+
+namespace bs = boost::simd;
+
+template <typename T, int N, typename Env> void test(Env& $)
+{
+  std::array<T,3*N> data;
+  for(std::size_t i = 0;i < data.size(); ++i) data[i] = T(0);
+  for(int i = N;i < 2*N; ++i) data[i] = T(i);
+
+  using p_t = bs::pack<T,N>;
+  p_t ref, p = bs::load<p_t>(&data[N], 0);
+
+  STF_EQUAL( bs::slide<-N>(p), bs::Zero<p_t>() );
+
+  ref = bs::load<p_t>(&data[N], -1);
+  STF_EQUAL( bs::slide<-1>(p), ref );
+
+  ref = bs::load<p_t>(&data[N]);
+  STF_EQUAL( bs::slide<0>(p), ref );
+
+  ref = bs::load<p_t>(&data[N], +1);
+  STF_EQUAL( bs::slide<+1>(p), ref );
+
+  STF_EQUAL( bs::slide<N>(p), bs::Zero<p_t>() );
+}
+
+STF_CASE_TPL( "Check unary slide behavior", STF_NUMERIC_TYPES )
+{
+  static const int N = bs::pack<T>::static_size;
+
+  test<T, N  >($);
+  test<T, N/2>($);
+  test<T, N*2>($);
+}

--- a/test/function/simd/slide/unary.logical.cpp
+++ b/test/function/simd/slide/unary.logical.cpp
@@ -1,0 +1,46 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#include <boost/simd/function/slide.hpp>
+#include <boost/simd/logical.hpp>
+#include <boost/simd/pack.hpp>
+#include <simd_test.hpp>
+
+namespace bs = boost::simd;
+
+template <typename T, int N, typename Env> void test(Env& $)
+{
+  std::array<bs::logical<T>,3*N> data;
+  for(std::size_t i = 0;i < data.size(); ++i) data[i] = T(0);
+  for(int i = N;i < 2*N; ++i) data[i] = T(i%2);
+
+  using p_t = bs::pack<bs::logical<T>,N>;
+  p_t ref, p = bs::load<p_t>(&data[N], 0);
+
+  STF_EQUAL( bs::slide<-N>(p), bs::Zero<p_t>() );
+
+  ref = bs::load<p_t>(&data[N], -1);
+  STF_EQUAL( bs::slide<-1>(p), ref );
+
+  ref = bs::load<p_t>(&data[N]);
+  STF_EQUAL( bs::slide<0>(p), ref );
+
+  ref = bs::load<p_t>(&data[N], +1);
+  STF_EQUAL( bs::slide<+1>(p), ref );
+
+  STF_EQUAL( bs::slide<N>(p), bs::Zero<p_t>() );
+}
+
+STF_CASE_TPL( "Check unary slide behavior", STF_NUMERIC_TYPES )
+{
+  static const int N = bs::pack<bs::logical<T>>::static_size;
+
+  test<T, N  >($);
+  test<T, N/2>($);
+  test<T, N*2>($);
+}


### PR DESCRIPTION
slide<N>(a,b) perform an element per element shift of value across multiple
packs. The offset N goes from -cardinal_of(a) to +cardinal_of(a) and represent
the amount of element to shift and the ordering of the shift with the following
rule :

```
 slide<-K>(a,b) == slide<cardinal_of(a)<-K>(b,a)
```

slide is primarily used to implement aligned_load with static misalignment
and some other functions where positional shift are required.

BREAKING CHANGE

---

Support for offset greater than the pack cardinal has been removed as it
proved complicated the implementation for no actual benefit for users.
