### PR TITLE
Suppress ref params

### DIFF
--- a/include/boost/simd/arch/common/generic/function/remquo.hpp
+++ b/include/boost/simd/arch/common/generic/function/remquo.hpp
@@ -30,73 +30,28 @@
 namespace boost { namespace simd { namespace ext
 {
   namespace bd = boost::dispatch;
-  BOOST_DISPATCH_OVERLOAD ( remquo_
-                          , (typename A0, typename A1)
-                          , bd::cpu_
-                          , bd::generic_< bd::floating_<A0> >
-                          , bd::generic_< bd::floating_<A0> >
-                          , bd::generic_< bd::integer_<A1> >
-                          )
-  {
-    using result_type = A0;
-
-    BOOST_FORCEINLINE
-      result_type operator() ( A0 a0,A0 a1,A1& a3
-                              , typename std::enable_if< std::is_same<
-                                     typename bd::as_integer_t<A0,signed>
-                                    , A1>::value>* = 0
-                             ) const BOOST_NOEXCEPT
-    {
-      result_type a2;
-      boost::simd::remquo(a0, a1, a2, a3);
-      return a2;
-    }
-  };
 
   BOOST_DISPATCH_OVERLOAD ( remquo_
                           , (typename A0)
                           , bd::cpu_
-                          , bd::generic_< bd::floating_<A0> >
-                          , bd::generic_< bd::floating_<A0> >
+                          , bd::generic_<bd::floating_<A0> >
+                          , bd::generic_<bd::floating_<A0> >
                           )
   {
     using quo_t = bd::as_integer_t<A0, signed>;
     using result_type = std::pair<A0,quo_t>;
 
-    BOOST_FORCEINLINE result_type operator() ( A0 a0,A0 a1) const BOOST_NOEXCEPT
-    {
-      A0 first;
-      quo_t second;
-      boost::simd::remquo( a0, a1, first, second );
-      return result_type(first, second);
-    }
-  };
-
-  BOOST_DISPATCH_OVERLOAD ( remquo_
-                          , (typename A0, typename A1)
-                          , bd::cpu_
-                          , bd::generic_<bd::floating_<A0> >
-                          , bd::generic_<bd::floating_<A0> >
-                          , bd::generic_<bd::floating_<A0> >
-                          , bd::generic_<bd::integer_ <A1> >
-                          )
-  {
-
-    BOOST_FORCEINLINE void operator() ( A0 a0, A0 a1,A0& a2, A1& a3
-                                      , typename std::enable_if< std::is_same<
-                                        typename bd::as_integer_t<A0,signed>
-                                      , A1>::value>* = 0
+    BOOST_FORCEINLINE std::pair<A0, quo_t> operator() ( A0 a0, A0 a1
                                       ) const BOOST_NOEXCEPT
     {
       A0 const d = round2even(a0/a1);
 
 #if defined(BOOST_SIMD_NO_INVALIDS)
-      a2 = if_allbits_else(is_eqz(a1), a0-d*a1);
+      A0  a2 = if_allbits_else(is_eqz(a1), a0-d*a1);
 #else
-      a2 = if_allbits_else(logical_or(is_invalid(a0), is_eqz(a1)), a0-d*a1);
+      A0  a2 = if_allbits_else(logical_or(is_invalid(a0), is_eqz(a1)), a0-d*a1);
 #endif
-
-      a3 = toint(d);
+      return {a2, toint(d)};
     }
   };
 } } }

--- a/include/boost/simd/arch/common/generic/function/two_add.hpp
+++ b/include/boost/simd/arch/common/generic/function/two_add.hpp
@@ -24,21 +24,6 @@
 namespace boost { namespace simd { namespace ext
 {
   namespace bd = boost::dispatch;
-  BOOST_DISPATCH_OVERLOAD ( two_add_
-                          , (typename A0)
-                          , bd::cpu_
-                          , bd::generic_< bd::floating_<A0> >
-                          , bd::generic_< bd::floating_<A0> >
-                          , bd::generic_< bd::floating_<A0> >
-                          )
-  {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0,A0 const& a1,A0& a3) const BOOST_NOEXCEPT
-    {
-      A0 a2;
-      boost::simd::two_add(a0, a1, a2, a3);
-      return a2;
-    }
-  };
 
   BOOST_DISPATCH_OVERLOAD ( two_add_
                           , (typename A0)
@@ -49,33 +34,17 @@ namespace boost { namespace simd { namespace ext
   {
     using result_t = std::pair<A0,A0>                                  ;
 
-    BOOST_FORCEINLINE result_t operator() ( A0 const& a0,A0 const& a1) const BOOST_NOEXCEPT
-    {
-      A0 first, second;
-      boost::simd::two_add( a0, a1, first, second );
-      return {first, second};
-    }
-  };
-
-  BOOST_DISPATCH_OVERLOAD ( two_add_
-                          , (typename A0)
-                          , bd::cpu_
-                          , bd::generic_< bd::floating_<A0> >
-                          , bd::generic_< bd::floating_<A0> >
-                          , bd::generic_< bd::floating_<A0> >
-                          , bd::generic_< bd::floating_<A0> >
-                          )
-  {
-    BOOST_FORCEINLINE void operator() ( A0 const& a,A0 const& b, A0 & r0,A0 & r1) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE result_t operator() ( A0 const& a,A0 const& b) const BOOST_NOEXCEPT
     {
       detail::enforce_precision<A0> enforcer;
-      r0   = a  + b;
+      A0 r0 = a  + b;
       A0 z = r0 - a;
 #if defined(BOOST_SIMD_NO_INFINITIES)
-      r1   = a-(r0-z)+(b-z);
+      A0 r1 = a-(r0-z)+(b-z);
 #else
-      r1   = if_zero_else(is_inf(r0), (a-(r0-z))+(b-z));
+      A0 r1 = if_zero_else(is_inf(r0), (a-(r0-z))+(b-z));
 #endif
+      return {r0, r1};
     }
   };
 } } }

--- a/include/boost/simd/arch/common/generic/function/two_prod.hpp
+++ b/include/boost/simd/arch/common/generic/function/two_prod.hpp
@@ -25,23 +25,6 @@
 namespace boost { namespace simd { namespace ext
 {
   namespace bd = boost::dispatch;
-  BOOST_DISPATCH_OVERLOAD ( two_prod_
-
-                          , (typename A0)
-                          , bd::cpu_
-                          , bd::generic_< bd::floating_<A0> >
-                          , bd::generic_< bd::floating_<A0> >
-                          , bd::generic_< bd::floating_<A0> >
-                          )
-  {
-    BOOST_FORCEINLINE
-      A0 operator() ( A0 const& a0,A0 const& a1,A0& a3) const BOOST_NOEXCEPT
-    {
-      A0 a2;
-      boost::simd::two_prod(a0, a1, a2, a3);
-      return a2;
-    }
-  };
 
   BOOST_DISPATCH_OVERLOAD ( two_prod_
                           , (typename A0)
@@ -51,37 +34,18 @@ namespace boost { namespace simd { namespace ext
                           )
   {
     using result_t = std::pair<A0,A0>;
-    BOOST_FORCEINLINE result_t operator() ( A0 const& a0,A0 const& a1) const BOOST_NOEXCEPT
-    {
-      A0 first, second;
-      boost::simd::two_prod( a0, a1, first, second );
-      return  {first, second};
-    }
-  };
-
-  BOOST_DISPATCH_OVERLOAD ( two_prod_
-                          , (typename A0)
-                          , bd::cpu_
-                          , bd::generic_< bd::floating_<A0> >
-                          , bd::generic_< bd::floating_<A0> >
-                          , bd::generic_< bd::floating_<A0> >
-                          , bd::generic_< bd::floating_<A0> >
-                          )
-  {
     BOOST_FORCEINLINE
-      void operator() ( A0 const& a,A0 const& b, A0 & r0,A0 & r1) const BOOST_NOEXCEPT
+      result_t operator() ( A0 const& a,A0 const& b) const BOOST_NOEXCEPT
     {
       detail::enforce_precision<A0> enforcer;
       A0 a1, a2, b1, b2;
-      r0  = a*b;
-
-      two_split(a, a1, a2);
-      two_split(b, b1, b2);
-
+      std::tie(a1, a2) = two_split(a);
+      std::tie(b1, b2) = two_split(b);
+      A0 r0 = a*b;
 #if defined(BOOST_SIMD_NO_INVALIDS)
-      r1 = a2*b2 -(((r0-a1*b1)-a2*b1)-a1*b2);
+      return {r0, a2*b2 -(((r0-a1*b1)-a2*b1)-a1*b2)};
 #else
-      r1 = if_zero_else(is_invalid(r0), a2*b2 -(((r0-a1*b1)-a2*b1)-a1*b2));
+      return {r0, if_zero_else(is_invalid(r0), a2*b2 -(((r0-a1*b1)-a2*b1)-a1*b2))};
 #endif
 
     }

--- a/include/boost/simd/arch/common/generic/function/two_split.hpp
+++ b/include/boost/simd/arch/common/generic/function/two_split.hpp
@@ -23,21 +23,6 @@
 namespace boost { namespace simd { namespace ext
 {
   namespace bd = boost::dispatch;
-  BOOST_DISPATCH_OVERLOAD ( two_split_
-                          , (typename A0)
-                          , bd::cpu_
-                          , bd::generic_< bd::floating_<A0> >
-                          , bd::generic_< bd::floating_<A0> >
-                          )
-  {
-    BOOST_FORCEINLINE
-      A0 operator() ( A0 const& a0,A0& a2) const BOOST_NOEXCEPT
-    {
-      A0 a1;
-      boost::simd::two_split(a0, a1, a2);
-      return a1;
-    }
-  };
 
   BOOST_DISPATCH_OVERLOAD ( two_split_
                           , (typename A0)
@@ -46,29 +31,13 @@ namespace boost { namespace simd { namespace ext
                           )
   {
     using result_t = std::pair<A0,A0>;                                 ;
-    BOOST_FORCEINLINE result_t operator() ( A0 const& a0) const BOOST_NOEXCEPT
-    {
-      A0 first, second;
-      boost::simd::two_split( a0, first, second );
-      return  {first, second};
-    }
-  };
-
-  BOOST_DISPATCH_OVERLOAD ( two_split_
-                          , (typename A0)
-                          , bd::cpu_
-                          , bd::generic_< bd::floating_<A0> >
-                          , bd::generic_< bd::floating_<A0> >
-                          , bd::generic_< bd::floating_<A0> >
-                          )
-  {
-    BOOST_FORCEINLINE void operator() ( A0 const& a, A0 & r0,A0 & r1) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE result_t operator() ( A0 const& a) const BOOST_NOEXCEPT
     {
       detail::enforce_precision<A0> enforcer;
       A0 const c = Splitfactor<A0>()*a;
       A0 const c1 = c-a;
-      r0 = c-c1;
-      r1 = a-r0;
+      A0 r0 = c-c1;
+      return {r0, a-r0};
     }
   };
 } } }

--- a/include/boost/simd/arch/common/scalar/function/correct_fma.hpp
+++ b/include/boost/simd/arch/common/scalar/function/correct_fma.hpp
@@ -25,6 +25,7 @@
 #include <boost/dispatch/meta/as_integer.hpp>
 #include <boost/config.hpp>
 #include <cmath>
+#include <tuple>
 
 namespace boost { namespace simd { namespace ext
 {
@@ -66,12 +67,12 @@ namespace boost { namespace simd { namespace ext
       auto choose = (e0 > e1);
       A0 amax = choose ? ldexp(a0, e) : ldexp(a1, e);
       A0 amin = choose ? a1 : a0;
-      two_prod(amax, amin, p, rp);
-      two_add(p, ae2, s, rs);
+      std::tie(p, rp) = two_prod(amax, amin);
+      std::tie(s, rs) = two_add(p, ae2);
       return ldexp(s+(rp+rs), -e);
     #else
-      two_prod(a0, a1, p, rp);
-      two_add(p, a2, s, rs);
+      std::tie(p, rp) = two_prod(a0, a1);
+      std::tie(s, rs) = two_add(p, a2);
       return s+(rp+rs);
     #endif
     }

--- a/include/boost/simd/arch/common/scalar/function/remquo.hpp
+++ b/include/boost/simd/arch/common/scalar/function/remquo.hpp
@@ -21,6 +21,7 @@
 namespace boost { namespace simd { namespace ext
 {
   namespace bd = boost::dispatch;
+  namespace bs = boost::simd;
 
   BOOST_DISPATCH_OVERLOAD ( remquo_
                           , (typename A0)

--- a/include/boost/simd/arch/common/scalar/function/remquo.hpp
+++ b/include/boost/simd/arch/common/scalar/function/remquo.hpp
@@ -1,0 +1,46 @@
+//==================================================================================================
+/*!
+  @file
+
+  @copyright 2015 NumScale SAS
+  @copyright 2015 J.T. Lapreste
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_COMMON_SCALAR_FUNCTION_REMQUO_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_COMMON_SCALAR_FUNCTION_REMQUO_HPP_INCLUDED
+
+#include <boost/simd/function/std.hpp>
+#include <boost/dispatch/function/overload.hpp>
+#include <boost/config.hpp>
+#include <utility>
+#include <cmath>
+
+namespace boost { namespace simd { namespace ext
+{
+  namespace bd = boost::dispatch;
+
+  BOOST_DISPATCH_OVERLOAD ( remquo_
+                          , (typename A0)
+                          , bd::cpu_
+                          , bs::std_tag
+                          , bd::scalar_<bd::floating_<A0> >
+                          , bd::scalar_<bd::floating_<A0> >
+                          )
+  {
+    using result_type = std::pair<A0,int>;
+
+    BOOST_FORCEINLINE result_type operator() ( A0 a0, A0 a1
+                                             ) const BOOST_NOEXCEPT
+    {
+      int q;
+      A0 r = std::remquo(a0, a1, &q);
+      return {r, q};
+    }
+  };
+} } }
+
+
+#endif

--- a/include/boost/simd/function/scalar/remquo.hpp
+++ b/include/boost/simd/function/scalar/remquo.hpp
@@ -13,6 +13,7 @@
 #define BOOST_SIMD_FUNCTION_SCALAR_REMQUO_HPP_INCLUDED
 
 #include <boost/simd/function/definition/remquo.hpp>
+#include <boost/simd/arch/common/scalar/function/remquo.hpp>
 #include <boost/simd/arch/common/generic/function/remquo.hpp>
 
 #endif

--- a/test/function/scalar/remquo.cpp
+++ b/test/function/scalar/remquo.cpp
@@ -37,95 +37,32 @@ STF_CASE_TPL(" remquo invalid", STF_IEEE_TYPES)
   T zero_ = bs::Zero<T>();
   T one_  = bs::One<T>();
 
-  {
-    // n is unspecified by the standard so we don't test it
-    iT n;
-    T  r;
+  // n is unspecified by the standard so we don't test it
+  std::pair<T,iT> p;
 
-    remquo(one_,nan_, r, n);
-    STF_IEEE_EQUAL(r, nan_);
+  p =  remquo(one_,nan_);
+  STF_IEEE_EQUAL(p.first, nan_);
 
-    remquo(one_,inf_, r, n);
-    STF_IEEE_EQUAL(r, nan_);
+  p =  remquo(one_,inf_);
+  STF_IEEE_EQUAL(p.first, nan_);
 
-    remquo(one_,zero_, r, n);
-    STF_IEEE_EQUAL(r, nan_);
+  p =  remquo(one_,zero_);
+  STF_IEEE_EQUAL(p.first, nan_);
 
-    remquo(inf_,zero_, r, n);
-    STF_IEEE_EQUAL(r, nan_);
+  p =  remquo(inf_,zero_);
+  STF_IEEE_EQUAL(p.first, nan_);
 
-    remquo(nan_,zero_, r, n);
-    STF_IEEE_EQUAL(r, nan_);
+  p =  remquo(nan_,zero_);
+  STF_IEEE_EQUAL(p.first, nan_);
 
-    remquo(nan_,one_, r, n);
-    STF_IEEE_EQUAL(r, nan_);
+  p =  remquo(nan_,one_);
+  STF_IEEE_EQUAL(p.first, nan_);
 
-    remquo(nan_,nan_, r, n);
-    STF_IEEE_EQUAL(r, nan_);
+  p =  remquo(nan_,nan_);
+  STF_IEEE_EQUAL(p.first, nan_);
 
-    remquo(nan_,inf_, r, n);
-    STF_IEEE_EQUAL(r, nan_);
-  }
-
-  {
-    // n is unspecified by the standard so we don't test it
-    iT n;
-    T  r;
-
-    r = remquo(one_,nan_, n);
-    STF_IEEE_EQUAL(r, nan_);
-
-    r = remquo(one_,inf_, n);
-    STF_IEEE_EQUAL(r, nan_);
-
-    r = remquo(one_,zero_, n);
-    STF_IEEE_EQUAL(r, nan_);
-
-    r = remquo(inf_,zero_, n);
-    STF_IEEE_EQUAL(r, nan_);
-
-    r = remquo(nan_,zero_, n);
-    STF_IEEE_EQUAL(r, nan_);
-
-    r = remquo(nan_,one_, n);
-    STF_IEEE_EQUAL(r, nan_);
-
-    r = remquo(nan_,nan_, n);
-    STF_IEEE_EQUAL(r, nan_);
-
-    r = remquo(nan_,inf_, n);
-    STF_IEEE_EQUAL(r, nan_);
-  }
-
-
-  {
-    // n is unspecified by the standard so we don't test it
-    std::pair<T,iT> p;
-
-    p =  remquo(one_,nan_);
-    STF_IEEE_EQUAL(p.first, nan_);
-
-    p =  remquo(one_,inf_);
-    STF_IEEE_EQUAL(p.first, nan_);
-
-    p =  remquo(one_,zero_);
-    STF_IEEE_EQUAL(p.first, nan_);
-
-    p =  remquo(inf_,zero_);
-    STF_IEEE_EQUAL(p.first, nan_);
-
-    p =  remquo(nan_,zero_);
-    STF_IEEE_EQUAL(p.first, nan_);
-
-    p =  remquo(nan_,one_);
-    STF_IEEE_EQUAL(p.first, nan_);
-
-    p =  remquo(nan_,nan_);
-    STF_IEEE_EQUAL(p.first, nan_);
-
-    p =  remquo(nan_,inf_);
-    STF_IEEE_EQUAL(p.first, nan_);
-  }
+  p =  remquo(nan_,inf_);
+  STF_IEEE_EQUAL(p.first, nan_);
 }
 #endif
 
@@ -138,47 +75,20 @@ STF_CASE_TPL(" remquo valid", STF_IEEE_TYPES)
   using iT =  bd::as_integer_t<T,signed>;
 
   STF_EXPR_IS( (remquo(T(), T()))
-                  , (std::pair<T,iT>)
-                  );
+             , (std::pair<T,iT>)
+             );
 
   T a0[] = { T(1), T(2), T(3), T(4.5) };
   T a1[] = { T(2), T(1), T(7), T(3.2) };
 
   std::size_t nb = sizeof(a0)/sizeof(T);
 
+  std::pair<T,iT> p;
+
+  for(std::size_t i=0;i<nb;++i)
   {
-    iT n;
-    T  r;
-
-    for(std::size_t i=0;i<nb;++i)
-    {
-      remquo(a0[i],a1[i], r, n);
-      STF_EQUAL(n, iT(a0[i] / a1[i]));
-      STF_EQUAL(r, a0[i] - n*a1[i]);
-    }
-  }
-
-  {
-    iT n;
-    T  r;
-
-    for(std::size_t i=0;i<nb;++i)
-    {
-      r = remquo(a0[i],a1[i], n);
-      STF_EQUAL(n, iT(a0[i] / a1[i]));
-      STF_EQUAL(r, a0[i] - n*a1[i]);
-    }
-  }
-
-  {
-
-    std::pair<T,iT> p;
-
-    for(std::size_t i=0;i<nb;++i)
-    {
-      p = remquo(a0[i],a1[i]);
-      STF_EQUAL(p.second, iT(a0[i] / a1[i]));
-      STF_EQUAL(p.first, a0[i] - p.second*a1[i]);
-    }
+    p = remquo(a0[i],a1[i]);
+    STF_EQUAL(p.second, iT(a0[i] / a1[i]));
+    STF_EQUAL(p.first, a0[i] - p.second*a1[i]);
   }
 }

--- a/test/function/scalar/two_add.cpp
+++ b/test/function/scalar/two_add.cpp
@@ -38,63 +38,21 @@ STF_CASE_TPL(" two_add", STF_IEEE_TYPES)
   T eps_    = bs::Eps<T>();
   T eps_2_  = eps_/T(2);
 
-  {
-    T s,r;
+  std::pair<T,T> p;
 
-    two_add(inf_,zero_, s, r);
-    STF_EQUAL(s, inf_);
-    STF_EQUAL(r, zero_);
+  p = two_add(inf_,zero_);
+  STF_EQUAL(p.first, inf_);
+  STF_EQUAL(p.second, zero_);
 
-    two_add(zero_, inf_, s, r);
-    STF_EQUAL(s, inf_);
-    STF_EQUAL(r, zero_);
+  p = two_add(zero_, inf_);
+  STF_EQUAL(p.first, inf_);
+  STF_EQUAL(p.second, zero_);
 
-    two_add(half_+ eps_2_, half_, s, r);
-    STF_EQUAL(s, one_);
-    STF_EQUAL(r, eps_2_);
+  p = two_add(half_+ eps_2_, half_);
+  STF_EQUAL(p.first, one_);
+  STF_EQUAL(p.second, eps_2_);
 
-    two_add(half_, half_+ eps_2_, s, r);
-    STF_EQUAL(s, one_);
-    STF_EQUAL(r, eps_2_);
-  }
-
-  {
-    T s,r;
-
-    s = two_add(inf_,zero_, r);
-    STF_EQUAL(s, inf_);
-    STF_EQUAL(r, zero_);
-
-    s = two_add(zero_, inf_, r);
-    STF_EQUAL(s, inf_);
-    STF_EQUAL(r, zero_);
-
-    s = two_add(half_+ eps_2_, half_, r);
-    STF_EQUAL(s, one_);
-    STF_EQUAL(r, eps_2_);
-
-    s = two_add(half_, half_+ eps_2_, r);
-    STF_EQUAL(s, one_);
-    STF_EQUAL(r, eps_2_);
-  }
-
-  {
-    std::pair<T,T> p;
-
-    p = two_add(inf_,zero_);
-    STF_EQUAL(p.first, inf_);
-    STF_EQUAL(p.second, zero_);
-
-    p = two_add(zero_, inf_);
-    STF_EQUAL(p.first, inf_);
-    STF_EQUAL(p.second, zero_);
-
-    p = two_add(half_+ eps_2_, half_);
-    STF_EQUAL(p.first, one_);
-    STF_EQUAL(p.second, eps_2_);
-
-    p = two_add(half_, half_+ eps_2_);
-    STF_EQUAL(p.first, one_);
-    STF_EQUAL(p.second, eps_2_);
-  }
+  p = two_add(half_, half_+ eps_2_);
+  STF_EQUAL(p.first, one_);
+  STF_EQUAL(p.second, eps_2_);
 }

--- a/test/function/scalar/two_prod.cpp
+++ b/test/function/scalar/two_prod.cpp
@@ -37,63 +37,21 @@ STF_CASE_TPL(" two_prod", STF_IEEE_TYPES)
   T eps_    = bs::Eps<T>();
   T meps2_   = -eps_*eps_;
 
-  {
-    T s,r;
+  std::pair<T,T> p;
 
-    two_prod(inf_,one_, s, r);
-    STF_EQUAL(s, inf_);
-    STF_EQUAL(r, zero_);
+  p = two_prod(inf_,one_);
+  STF_EQUAL(p.first, inf_);
+  STF_EQUAL(p.second, zero_);
 
-    two_prod(one_, inf_, s, r);
-    STF_EQUAL(s, inf_);
-    STF_EQUAL(r, zero_);
+  p = two_prod(one_, inf_);
+  STF_EQUAL(p.first, inf_);
+  STF_EQUAL(p.second, zero_);
 
-    two_prod(one_ + eps_, one_ - eps_, s, r);
-    STF_EQUAL(s, one_);
-    STF_EQUAL(r, meps2_);
+  p = two_prod(one_ + eps_, one_ - eps_);
+  STF_EQUAL(p.first, one_);
+  STF_EQUAL(p.second, meps2_);
 
-    two_prod(one_ - eps_,one_ + eps_, s, r);
-    STF_EQUAL(s, one_);
-    STF_EQUAL(r, meps2_);
-  }
-
-  {
-    T s,r;
-
-    s = two_prod(inf_,one_, r);
-    STF_EQUAL(s, inf_);
-    STF_EQUAL(r, zero_);
-
-    s = two_prod(one_, inf_, r);
-    STF_EQUAL(s, inf_);
-    STF_EQUAL(r, zero_);
-
-    s = two_prod(one_ + eps_, one_ - eps_, r);
-    STF_EQUAL(s, one_);
-    STF_EQUAL(r, meps2_);
-
-    s = two_prod(one_ - eps_,one_ + eps_, r);
-    STF_EQUAL(s, one_);
-    STF_EQUAL(r, meps2_);
-  }
-
-  {
-    std::pair<T,T> p;
-
-    p = two_prod(inf_,one_);
-    STF_EQUAL(p.first, inf_);
-    STF_EQUAL(p.second, zero_);
-
-    p = two_prod(one_, inf_);
-    STF_EQUAL(p.first, inf_);
-    STF_EQUAL(p.second, zero_);
-
-    p = two_prod(one_ + eps_, one_ - eps_);
-    STF_EQUAL(p.first, one_);
-    STF_EQUAL(p.second, meps2_);
-
-    p = two_prod(one_ - eps_,one_ + eps_);
-    STF_EQUAL(p.first, one_);
-    STF_EQUAL(p.second, meps2_);
-  }
+  p = two_prod(one_ - eps_,one_ + eps_);
+  STF_EQUAL(p.first, one_);
+  STF_EQUAL(p.second, meps2_);
 }

--- a/test/function/scalar/two_split.cpp
+++ b/test/function/scalar/two_split.cpp
@@ -34,28 +34,10 @@ STF_CASE_TPL(" two_split", STF_IEEE_TYPES)
   T eps_ = bs::Eps<T>();
   T one_ = bs::One<T>();
 
-  {
-    T f,s;
+  std::pair<T,T> p;
 
-    two_split(one_-eps_, f, s);
-    STF_EQUAL(f, one_);
-    STF_EQUAL(s, -eps_);
-  }
-
-  {
-    T f,s;
-
-    f = two_split(one_-eps_, s);
-    STF_EQUAL(f, one_);
-    STF_EQUAL(s, -eps_);
-  }
-
-  {
-    std::pair<T,T> p;
-
-    p = two_split(one_-eps_);
-    STF_EQUAL(p.first, one_);
-    STF_EQUAL(p.second, -eps_);
-  }
+  p = two_split(one_-eps_);
+  STF_EQUAL(p.first, one_);
+  STF_EQUAL(p.second, -eps_);
 }
 

--- a/test/function/simd/CMakeLists.txt
+++ b/test/function/simd/CMakeLists.txt
@@ -45,6 +45,7 @@ clz.cpp
 complement.cpp
 conj.cpp
 copysign.cpp
+correct_fma.cpp
 ctz.cpp
 dec.cpp
 dec_s.cpp
@@ -239,7 +240,7 @@ unary_plus.cpp
 #compare_less.cpp
 #compare_less_equal.cpp
 #compare_not_equal.cpp
-#correct_fma.cpp TODO
+
 #divceil
 #divfix
 #divfloor

--- a/test/function/simd/correct_fma.cpp
+++ b/test/function/simd/correct_fma.cpp
@@ -25,25 +25,27 @@ void test(Env& $)
   namespace bs = boost::simd;
   namespace bd = boost::dispatch;
 
-  T a1[N], a2[N], a3[N];
+  T a1[N], a2[N], a3[N], b[N];
   for(int i = 0; i < N; ++i)
   {
      a1[i] = (i%2) ? T(i) : T(-i);
      a2[i] = (i%2) ? T(i+N) : T(-(i+N));
      a3[i] = (i%2) ? T(i+2*N) : T(-(i+2*N));
+     b[i] = bs::correct_fma(a1[i], a2[i], a3[i]);
    }
   p_t aa1(&a1[0], &a1[N]);
   p_t aa2(&a2[0], &a2[N]);
   p_t aa3(&a3[0], &a3[N]);
-  STF_IEEE_EQUAL(bs::correct_fma(aa1, aa2, aa3), bs::plus(bs::multiplies(aa1, aa2), aa3));
+  p_t bb (&b [0], &b [N]);
+  STF_IEEE_EQUAL(bs::correct_fma(aa1, aa2, aa3), bb);
 }
 
-STF_CASE_TPL("Check correct_fma on pack" , STF_NUMERIC_TYPES)
+STF_CASE_TPL("Check correct_fma on pack" , STF_IEEE_TYPES)
 {
   namespace bs = boost::simd;
   using p_t = bs::pack<T>;
   static const std::size_t N = bs::cardinal_of<p_t>::value;
   test<T, N>($);
-//  test<T, N/2>($);
-//  test<T, Nx2>($);
+  test<T, N/2>($);
+  test<T, N*2>($);
 }

--- a/test/function/simd/remquo.cpp
+++ b/test/function/simd/remquo.cpp
@@ -31,14 +31,16 @@ void test(Env& $)
   {
      a1[i] = (i%2) ? T(i) : T(-i);
      a2[i] = (i%2) ? T(i+N) : T(-(i+N));
-     m[i] = bs::remquo(a1[i], a2[i], e[i]);
+     std::tie(m[i], e[i]) = bs::remquo(a1[i], a2[i]);
    }
   p_t aa1(&a1[0], &a1[N]);
   p_t aa2(&a2[0], &a2[N]);
   i_t ee1;
   p_t mm(&m[0], &m[N]);
   i_t ee(&e[0], &e[N]);
-  STF_IEEE_EQUAL(bs::remquo(aa1, aa2, ee1), mm);
+  p_t mm1;
+  std::tie(mm1, ee1) = bs::remquo(aa1, aa2);
+  STF_IEEE_EQUAL(mm1, mm);
   STF_IEEE_EQUAL(ee1, ee);
 }
 
@@ -48,6 +50,6 @@ STF_CASE_TPL("Check remquo on pack" , STF_IEEE_TYPES)
   using p_t = bs::pack<T>;
   static const std::size_t N = bs::cardinal_of<p_t>::value;
   test<T, N>($);
-//  test<T, N/2>($);
-//  test<T, Nx2>($);
+  test<T, N/2>($);
+  test<T, N*2>($);
 }

--- a/test/function/simd/two_add.cpp
+++ b/test/function/simd/two_add.cpp
@@ -11,6 +11,7 @@
 //==================================================================================================
 #include <boost/simd/pack.hpp>
 #include <boost/simd/function/two_add.hpp>
+#include <boost/simd/constant/eps.hpp>
 #include <boost/simd/meta/cardinal_of.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>
 #include <simd_test.hpp>
@@ -28,16 +29,17 @@ void test(Env& $)
   for(std::size_t i = 0; i < N; ++i)
   {
      a1[i] = (i%2) ? T(i) : T(-i);
-     a2[i] = (i%2) ? T(i+N) :T(-(i+N));
-     r1[i] = bs::two_add(a1[i], a2[i], r2[i]);
+     a2[i] = (i%2) ? T(i+N) :T(-(i+2*N*bs::Eps<T>()));
+     std::tie(r1[i], r2[i]) = bs::two_add(a1[i], a2[i]);
    }
   p_t aa1(&a1[0], &a1[N]);
   p_t aa2(&a2[0], &a2[N]);
-  p_t rr21;
+  p_t rr21, rr22;
   p_t rr1(&r1[0], &r1[N]);
   p_t rr2(&r2[0], &r2[N]);
- STF_IEEE_EQUAL(bs::two_add(aa1, aa2, rr21), rr1);
-  STF_IEEE_EQUAL(rr21, rr2);
+  std::tie(rr21, rr22) = bs::two_add(aa1, aa2);
+  STF_IEEE_EQUAL(rr21, rr1);
+  STF_IEEE_EQUAL(rr22, rr2);
 }
 
 STF_CASE_TPL("Check two_add on pack" , STF_IEEE_TYPES)
@@ -46,6 +48,6 @@ STF_CASE_TPL("Check two_add on pack" , STF_IEEE_TYPES)
   using p_t = bs::pack<T>;
   static const std::size_t N = bs::cardinal_of<p_t>::value;
   test<T, N>($);
-//  test<T, N/2>($);
-//  test<T, Nx2>($);
+  test<T, N/2>($);
+  test<T, N*2>($);
 }

--- a/test/function/simd/two_prod.cpp
+++ b/test/function/simd/two_prod.cpp
@@ -11,6 +11,7 @@
 //==================================================================================================
 #include <boost/simd/pack.hpp>
 #include <boost/simd/function/two_prod.hpp>
+#include <boost/simd/constant/eps.hpp>
 #include <boost/simd/meta/cardinal_of.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>
 #include <simd_test.hpp>
@@ -28,16 +29,17 @@ void test(Env& $)
   for(std::size_t i = 0; i < N; ++i)
   {
      a1[i] = (i%2) ? T(i) : T(-i);
-     a2[i] = (i%2) ? T(i+N) :T(-(i+N));
-     r1[i] = bs::two_prod(a1[i], a2[i], r2[i]);
+     a2[i] = (i%2) ? T(i+N) :T(-(i+2*N*bs::Eps<T>()));
+     std::tie(r1[i], r2[i]) = bs::two_prod(a1[i], a2[i]);
    }
   p_t aa1(&a1[0], &a1[N]);
   p_t aa2(&a2[0], &a2[N]);
-  p_t rr21;
+  p_t rr21, rr22;
   p_t rr1(&r1[0], &r1[N]);
   p_t rr2(&r2[0], &r2[N]);
-  STF_IEEE_EQUAL(bs::two_prod(aa1, aa2, rr21), rr1);
-  STF_IEEE_EQUAL(rr21, rr2);
+  std::tie(rr21, rr22) = bs::two_prod(aa1, aa2);
+  STF_IEEE_EQUAL(rr21, rr1);
+  STF_IEEE_EQUAL(rr22, rr2);
 }
 
 STF_CASE_TPL("Check two_prod on pack" , STF_IEEE_TYPES)
@@ -46,6 +48,6 @@ STF_CASE_TPL("Check two_prod on pack" , STF_IEEE_TYPES)
   using p_t = bs::pack<T>;
   static const std::size_t N = bs::cardinal_of<p_t>::value;
   test<T, N>($);
-//  test<T, N/2>($);
-//  test<T, Nx2>($);
+  test<T, N/2>($);
+  test<T, N*2>($);
 }

--- a/test/function/simd/two_split.cpp
+++ b/test/function/simd/two_split.cpp
@@ -25,19 +25,17 @@ void test(Env& $)
   using p_t = bs::pack<T, N>;
 
 
-  T a1[N], a2[N], r1[N], r2[N];
+  T a1[N], r1[N], r2[N];
   for(std::size_t i = 0; i < N; ++i)
   {
      a1[i] = (i%2) ? T(i) : T(-i);
-     a2[i] = (i%2) ? T(i+N) :T(-(i+2*N*bs::Eps<T>()));
-     std::tie(r1[i], r2[i]) = bs::two_split(a1[i], a2[i]);
+     std::tie(r1[i], r2[i]) = bs::two_split(a1[i]);
    }
   p_t aa1(&a1[0], &a1[N]);
-  p_t aa2(&a2[0], &a2[N]);
   p_t rr21, rr22;
   p_t rr1(&r1[0], &r1[N]);
   p_t rr2(&r2[0], &r2[N]);
-  std::tie(rr21, rr22) = bs::two_split(aa1, aa2);
+  std::tie(rr21, rr22) = bs::two_split(aa1);
   STF_IEEE_EQUAL(rr21, rr1);
   STF_IEEE_EQUAL(rr22, rr2);
 }

--- a/test/function/simd/two_split.cpp
+++ b/test/function/simd/two_split.cpp
@@ -11,6 +11,7 @@
 //==================================================================================================
 #include <boost/simd/pack.hpp>
 #include <boost/simd/function/two_split.hpp>
+#include <boost/simd/constant/eps.hpp>
 #include <boost/simd/meta/cardinal_of.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>
 #include <simd_test.hpp>
@@ -24,18 +25,21 @@ void test(Env& $)
   using p_t = bs::pack<T, N>;
 
 
-  T a1[N], r1[N], r2[N];
+  T a1[N], a2[N], r1[N], r2[N];
   for(std::size_t i = 0; i < N; ++i)
   {
      a1[i] = (i%2) ? T(i) : T(-i);
-     r1[i] = bs::two_split(a1[i], r2[i]);
+     a2[i] = (i%2) ? T(i+N) :T(-(i+2*N*bs::Eps<T>()));
+     std::tie(r1[i], r2[i]) = bs::two_split(a1[i], a2[i]);
    }
   p_t aa1(&a1[0], &a1[N]);
-  p_t rr21;
+  p_t aa2(&a2[0], &a2[N]);
+  p_t rr21, rr22;
   p_t rr1(&r1[0], &r1[N]);
   p_t rr2(&r2[0], &r2[N]);
-  STF_IEEE_EQUAL(bs::two_split(aa1, rr21), rr1);
-  STF_IEEE_EQUAL(rr21, rr2);
+  std::tie(rr21, rr22) = bs::two_split(aa1, aa2);
+  STF_IEEE_EQUAL(rr21, rr1);
+  STF_IEEE_EQUAL(rr22, rr2);
 }
 
 STF_CASE_TPL("Check two_split on pack" , STF_IEEE_TYPES)
@@ -44,6 +48,6 @@ STF_CASE_TPL("Check two_split on pack" , STF_IEEE_TYPES)
   using p_t = bs::pack<T>;
   static const std::size_t N = bs::cardinal_of<p_t>::value;
   test<T, N>($);
-//  test<T, N/2>($);
-//  test<T, Nx2>($);
+  test<T, N/2>($);
+  test<T, N*2>($);
 }


### PR DESCRIPTION
just suppressing ref calls in remquo two_add/split/prod functors.
two_add and two_prod could be further attached to plus and multiplies with a decorator.
