### PR TITLE
Msvc fixes

### DIFF
--- a/include/boost/simd/arch/common/scalar/function/splat.hpp
+++ b/include/boost/simd/arch/common/scalar/function/splat.hpp
@@ -1,20 +1,23 @@
 //==================================================================================================
-/*!
-  @file
-
-  @copyright 2016 NumScale SAS
-  @copyright 2016 J.T. Lapreste
+/**
+  Copyright 2016 NumScale SAS
+  Copyright 2016 J.T. Lapreste
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #ifndef BOOST_SIMD_ARCH_COMMON_SCALAR_FUNCTION_SPLAT_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_SCALAR_FUNCTION_SPLAT_HPP_INCLUDED
 
+#include <boost/simd/detail/overload.hpp>
 #include <boost/simd/as.hpp>
-#include <boost/dispatch/function/overload.hpp>
 #include <boost/config.hpp>
+
+#ifdef BOOST_MSVC
+# pragma warning(push)
+# pragma warning(disable: 4244) // conversion loss of data
+#endif
 
 namespace boost { namespace simd { namespace ext
 {
@@ -35,5 +38,9 @@ namespace boost { namespace simd { namespace ext
     }
   };
 } } }
+
+#ifdef BOOST_MSVC
+# pragma warning(pop)
+#endif
 
 #endif

--- a/include/boost/simd/arch/common/simd/function/is_ltz.hpp
+++ b/include/boost/simd/arch/common/simd/function/is_ltz.hpp
@@ -1,54 +1,49 @@
 //==================================================================================================
-/*!
-  @file
-
-  @copyright 2016 NumScale SAS
-  @copyright 2016 J.T. Lapreste
+/**
+  Copyright 2016 NumScale SAS
+  Copyright 2016 J.T. Lapreste
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #ifndef BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_IS_LTZ_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_IS_LTZ_HPP_INCLUDED
-#include <boost/simd/detail/overload.hpp>
 
-#include <boost/simd/meta/hierarchy/simd.hpp>
-#include <boost/simd/meta/as_logical.hpp>
-#include <boost/simd/constant/zero.hpp>
-#include <boost/simd/constant/false.hpp>
+#include <boost/simd/detail/overload.hpp>
 #include <boost/simd/function/simd/is_less.hpp>
+#include <boost/simd/meta/as_logical.hpp>
+#include <boost/simd/constant/false.hpp>
+#include <boost/simd/constant/zero.hpp>
 
 namespace boost { namespace simd { namespace ext
 {
    namespace bd = boost::dispatch;
    namespace bs = boost::simd;
-   BOOST_DISPATCH_OVERLOAD(is_ltz_
+
+  BOOST_DISPATCH_OVERLOAD ( is_ltz_
                           , (typename A0, typename X)
                           , bd::cpu_
                           , bs::pack_<bd::signed_<A0>, X>
                           )
-   {
-      BOOST_FORCEINLINE bs::as_logical_t<A0> operator()( const A0& a0) const BOOST_NOEXCEPT
-      {
-        return is_less(a0, Zero<A0>());
-      }
-   };
+  {
+    BOOST_FORCEINLINE auto operator()( const A0& a0) const BOOST_NOEXCEPT_DECLTYPE_BODY
+    (
+      is_less(a0, Zero<A0>())
+    )
+  };
 
-   BOOST_DISPATCH_OVERLOAD(is_ltz_
+  BOOST_DISPATCH_OVERLOAD ( is_ltz_
                           , (typename A0, typename X)
                           , bd::cpu_
                           , bs::pack_<bd::unsigned_<A0>, X>
                           )
-   {
-     using result = bs::as_logical_t<A0>;
-     BOOST_FORCEINLINE result operator()(const A0&) const BOOST_NOEXCEPT
-     {
-       return bs::False<result>();
-     }
-   };
-
+  {
+    BOOST_FORCEINLINE auto operator()(const A0&) const BOOST_NOEXCEPT_DECLTYPE_BODY
+    (
+      bs::False<bs::as_logical_t<A0>>()
+    )
+  };
 } } }
 
 #endif
-

--- a/include/boost/simd/arch/common/simd/function/is_ngez.hpp
+++ b/include/boost/simd/arch/common/simd/function/is_ngez.hpp
@@ -1,52 +1,49 @@
 //==================================================================================================
-/*!
-  @file
-
-  @copyright 2016 NumScale SAS
-  @copyright 2016 J.T. Lapreste
+/**
+  Copyright 2016 NumScale SAS
+  Copyright 2016 J.T. Lapreste
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #ifndef BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_IS_NGEZ_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_IS_NGEZ_HPP_INCLUDED
-#include <boost/simd/detail/overload.hpp>
 
-#include <boost/simd/meta/hierarchy/simd.hpp>
-#include <boost/simd/constant/zero.hpp>
-#include <boost/simd/function/simd/is_ltz.hpp>
+#include <boost/simd/detail/overload.hpp>
 #include <boost/simd/function/simd/is_not_greater_equal.hpp>
-#include <boost/simd/meta/as_logical.hpp>
+#include <boost/simd/function/simd/is_ltz.hpp>
+#include <boost/simd/constant/zero.hpp>
 
 namespace boost { namespace simd { namespace ext
 {
-   namespace bd = boost::dispatch;
-   namespace bs = boost::simd;
-   BOOST_DISPATCH_OVERLOAD(is_ngez_
+  namespace bd = boost::dispatch;
+  namespace bs = boost::simd;
+
+  BOOST_DISPATCH_OVERLOAD ( is_ngez_
                           , (typename A0, typename X)
                           , bd::cpu_
                           , bs::pack_<bd::floating_<A0>, X>
                           )
-   {
-      BOOST_FORCEINLINE bs::as_logical_t<A0>  operator()( const A0& a0) const BOOST_NOEXCEPT
-      {
-        return is_not_greater_equal(a0, Zero<A0>());
-      }
-   };
+  {
+    BOOST_FORCEINLINE auto operator()( const A0& a0) const BOOST_NOEXCEPT_DECLTYPE_BODY
+    (
+      is_not_greater_equal(a0, Zero<A0>())
+    )
+  };
 
-   BOOST_DISPATCH_OVERLOAD(is_ngez_
+  BOOST_DISPATCH_OVERLOAD ( is_ngez_
                           , (typename A0, typename X)
                           , bd::cpu_
                           , bs::pack_<bd::arithmetic_<A0>, X>
                           )
-   {
-      BOOST_FORCEINLINE bs::as_logical_t<A0>  operator()( const A0& a0) const BOOST_NOEXCEPT
-      {
-        return is_ltz(a0);
-      }
-   };
-
+  {
+    BOOST_FORCEINLINE auto operator()( const A0& a0) const BOOST_NOEXCEPT_DECLTYPE_BODY
+    (
+      is_ltz(a0)
+    )
+  };
 } } }
+
 #endif
 

--- a/include/boost/simd/arch/common/simd/function/splat.hpp
+++ b/include/boost/simd/arch/common/simd/function/splat.hpp
@@ -1,25 +1,25 @@
 //==================================================================================================
-/*!
-  @file
-
-  @copyright 2016 NumScale SAS
-  @copyright 2016 J.T. Lapreste
+/**
+  Copyright 2016 NumScale SAS
+  Copyright 2016 J.T. Lapreste
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #ifndef BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_SPLAT_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_SPLAT_HPP_INCLUDED
-#include <boost/simd/detail/overload.hpp>
 
 #include <boost/simd/function/bitwise_cast.hpp>
-#include <boost/simd/function/genmask.hpp>
-#include <boost/simd/meta/hierarchy/simd.hpp>
 #include <boost/simd/meta/as_arithmetic.hpp>
+#include <boost/simd/function/genmask.hpp>
+#include <boost/simd/detail/overload.hpp>
 #include <boost/simd/detail/brigand.hpp>
-#include <boost/dispatch/function/overload.hpp>
-#include <boost/config.hpp>
+
+#ifdef BOOST_MSVC
+#pragma warning(push)
+#pragma warning(disable: 4244) // conversion and loss of data
+#endif
 
 namespace boost { namespace simd { namespace ext
 {
@@ -85,10 +85,14 @@ namespace boost { namespace simd { namespace ext
     template<typename... N> static inline
     storage_t do_(V const& v, aggregate_storage const&, brigand::list<N...> const&) BOOST_NOEXCEPT
     {
-      typename storage_t::value_type s(v);
+      typename storage_t::value_type s(!!v);
       return {{ s, s }};
     }
   };
 } } }
+
+#ifdef BOOST_MSVC
+#pragma warning(pop)
+#endif
 
 #endif

--- a/include/boost/simd/arch/x86/sse2/simd/function/make.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/make.hpp
@@ -12,6 +12,7 @@
 #define BOOST_SIMD_ARCH_X86_SSE2_SIMD_FUNCTION_MAKE_HPP_INCLUDED
 
 #include <boost/simd/detail/overload.hpp>
+#include <boost/simd/function/insert.hpp>
 
 namespace boost { namespace simd { namespace ext
 {
@@ -52,10 +53,29 @@ namespace boost { namespace simd { namespace ext
   {
     using target_t  = typename Target::type;
 
+    static BOOST_FORCEINLINE target_t
+    do_(V0 const& v0, V1 const& v1, std::true_type const&) BOOST_NOEXCEPT
+    {
+      return _mm_set_epi64x(v0,v1);
+    }
+
+    static BOOST_FORCEINLINE target_t
+    do_(V0 const& v0, V1 const& v1, std::false_type const&) BOOST_NOEXCEPT
+    {
+      target_t t;
+
+      insert<0>(t,v0);
+      insert<1>(t,v1);
+
+      return t;
+    }
+
     BOOST_FORCEINLINE
     target_t operator()(Target const&, V0 const& v0, V1 const& v1) const BOOST_NOEXCEPT
     {
-      return _mm_set_epi64x(v1, v0);
+      return do_( v1, v0
+                , typename detail::support_mm_set_epi64x<long int>::type{}
+                );
     }
   };
 

--- a/include/boost/simd/arch/x86/sse2/simd/function/splat.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/splat.hpp
@@ -1,17 +1,20 @@
 //==================================================================================================
-/*!
-  @file
-
-  @copyright 2016 NumScale SAS
+/**
+  Copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #ifndef BOOST_SIMD_ARCH_X86_SSE2_SIMD_FUNCTION_SPLAT_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_X86_SSE2_SIMD_FUNCTION_SPLAT_HPP_INCLUDED
 
 #include <boost/simd/detail/overload.hpp>
+
+#ifdef BOOST_MSVC
+# pragma warning(push)
+# pragma warning(disable: 4244) // conversion loss of data
+#endif
 
 namespace boost { namespace simd { namespace ext
 {
@@ -48,7 +51,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Value const& v, Target const&) const BOOST_NOEXCEPT
     {
-      return _mm_set1_epi8( static_cast<char>(v) );
+      return _mm_set1_epi8(v);
     }
   };
 
@@ -65,7 +68,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Value const& v, Target const&) const BOOST_NOEXCEPT
     {
-      return _mm_set1_epi16( static_cast<short>(v) );
+      return _mm_set1_epi16(v);
     }
   };
 
@@ -82,7 +85,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Value const& v, Target const&) const BOOST_NOEXCEPT
     {
-      return _mm_set1_epi32( static_cast<int>(v) );
+      return _mm_set1_epi32(v);
     }
   };
 
@@ -97,11 +100,27 @@ namespace boost { namespace simd { namespace ext
   {
     using target = typename Target::type;
 
+    BOOST_FORCEINLINE target do_(long int v, std::true_type const&) const BOOST_NOEXCEPT
+    {
+      return _mm_set1_epi64x(v);
+    }
+
+    BOOST_FORCEINLINE target do_(long int v, std::false_type const&) const BOOST_NOEXCEPT
+    {
+      return target(v,v);
+    }
+
     BOOST_FORCEINLINE target operator()(Value const& v, Target const&) const BOOST_NOEXCEPT
     {
-      return _mm_set1_epi64x( static_cast<long int>(v));
+      return do_( static_cast<long int>(v)
+                , typename detail::support_mm_set1_epi64x<long int>::type{}
+                );
     }
   };
 } } }
+
+#ifdef BOOST_MSVC
+# pragma warning(pop)
+#endif
 
 #endif

--- a/include/boost/simd/arch/x86/sse2/spec.hpp
+++ b/include/boost/simd/arch/x86/sse2/spec.hpp
@@ -27,6 +27,7 @@
   #include <emmintrin.h>
   #include <boost/simd/arch/x86/sse2/as_simd.hpp>
   #include <boost/simd/arch/x86/sse2/pack_traits.hpp>
+  #include <boost/simd/arch/x86/sse2/supports.hpp>
 #endif
 
 #endif

--- a/include/boost/simd/arch/x86/sse2/supports.hpp
+++ b/include/boost/simd/arch/x86/sse2/supports.hpp
@@ -1,0 +1,43 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_X86_SSE2_SUPPORTS_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_X86_SSE2_SUPPORTS_HPP_INCLUDED
+
+namespace boost { namespace simd { namespace detail
+{
+  // Some compilers don't provide _mm_set1_epi64x
+  template<typename T> struct support_mm_set1_epi64x
+  {
+    template<typename U>
+    static auto test( int ) -> decltype ( _mm_set1_epi64x(std::declval<U>())
+                                        , std::true_type()
+                                        );
+
+    template<typename>
+    static auto test( ... ) -> std::false_type;
+
+    typedef std::is_same<decltype(test<T>(0)),std::true_type> type;
+  };
+
+  // Some compilers don't provide _mm_set_epi64x
+  template<typename T> struct support_mm_set_epi64x
+  {
+    template<typename U>
+    static auto test( int ) -> decltype ( _mm_set_epi64x(std::declval<U>(),std::declval<U>())
+                                        , std::true_type()
+                                        );
+
+    template<typename>
+    static auto test( ... ) -> std::false_type;
+
+    typedef std::is_same<decltype(test<T>(0)),std::true_type> type;
+  };
+} } }
+
+#endif

--- a/include/boost/simd/logical.hpp
+++ b/include/boost/simd/logical.hpp
@@ -44,7 +44,7 @@ namespace boost { namespace simd
     BOOST_FORCEINLINE logical(bool v) : value_(v) {}
 
     /// Constructor from non-boolean value
-    template<typename U> BOOST_FORCEINLINE explicit logical(U&& v) : value_(v != 0) {}
+    template<typename U> BOOST_FORCEINLINE explicit logical(U&& v) : value_(!!v) {}
 
     // Assignment operator
     BOOST_FORCEINLINE logical& operator=(logical const& v) = default;

--- a/test/function/scalar/saturate.cpp
+++ b/test/function/scalar/saturate.cpp
@@ -21,13 +21,14 @@
 #include <boost/simd/constant/inf.hpp>
 #include <boost/simd/constant/minf.hpp>
 
+using base = unsigned int;
+
 STF_CASE_TPL (" saturate types check",  STF_NUMERIC_TYPES)
 {
   namespace bs = boost::simd;
   using bs::saturate;
   using bs::Valmax;
   using bs::Valmin;
-
 
   // return type conformity test
   STF_EXPR_IS( saturate<T>(float(1)), float);
@@ -70,42 +71,42 @@ STF_CASE_TPL (" saturate signed_int16",  (int16_t))
   using bs::Valmax;
   using bs::Valmin;
   // specific values tests
-  STF_ULP_EQUAL(1u,           saturate<T>(1ull        ), 0);
-  STF_ULP_EQUAL(2u,           saturate<T>(2ull        ), 0);
-  STF_ULP_EQUAL(6u,           saturate<T>(6ull        ), 0);
-  STF_ULP_EQUAL(24u,          saturate<T>(24ull       ), 0);
-  STF_ULP_EQUAL(120u,         saturate<T>(120ull      ), 0);
-  STF_ULP_EQUAL(720u,         saturate<T>(720ull      ), 0);
-  STF_ULP_EQUAL(5040u,        saturate<T>(5040ull     ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(40320ull    ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(362880ull   ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(3628800ull  ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(39916800ull ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(479001600ull), 0);
-  STF_ULP_EQUAL(1,           saturate<T>(1ll        ), 0);
-  STF_ULP_EQUAL(2,           saturate<T>(2ll        ), 0);
-  STF_ULP_EQUAL(6,           saturate<T>(6ll        ), 0);
-  STF_ULP_EQUAL(24,          saturate<T>(24ll       ), 0);
-  STF_ULP_EQUAL(120,         saturate<T>(120ll      ), 0);
-  STF_ULP_EQUAL(720,         saturate<T>(720ll      ), 0);
-  STF_ULP_EQUAL(5040,        saturate<T>(5040ll     ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(40320ll    ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(362880ll   ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(3628800ll  ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(39916800ll ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(479001600ll), 0);
-  STF_ULP_EQUAL(-1,           saturate<T>(-1ll        ), 0);
-  STF_ULP_EQUAL(-2,           saturate<T>(-2ll        ), 0);
-  STF_ULP_EQUAL(-6,           saturate<T>(-6ll        ), 0);
-  STF_ULP_EQUAL(-24,          saturate<T>(-24ll       ), 0);
-  STF_ULP_EQUAL(-120,         saturate<T>(-120ll      ), 0);
-  STF_ULP_EQUAL(-720,         saturate<T>(-720ll      ), 0);
-  STF_ULP_EQUAL(-5040,        saturate<T>(-5040ll     ), 0);
-  STF_ULP_EQUAL(Valmin<T>(),  saturate<T>(-40320ll    ), 0);
-  STF_ULP_EQUAL(Valmin<T>(),  saturate<T>(-362880ll   ), 0);
-  STF_ULP_EQUAL(Valmin<T>(),  saturate<T>(-3628800ll  ), 0);
-  STF_ULP_EQUAL(Valmin<T>(),  saturate<T>(-39916800ll ), 0);
-  STF_ULP_EQUAL(Valmin<T>(),  saturate<T>(-479001600ll), 0);
+  STF_EQUAL(1u,           saturate<T>(1ull        ));
+  STF_EQUAL(2u,           saturate<T>(2ull        ));
+  STF_EQUAL(6u,           saturate<T>(6ull        ));
+  STF_EQUAL(24u,          saturate<T>(24ull       ));
+  STF_EQUAL(120u,         saturate<T>(120ull      ));
+  STF_EQUAL(720u,         saturate<T>(720ull      ));
+  STF_EQUAL(5040u,        saturate<T>(5040ull     ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(40320ull    ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(362880ull   ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(3628800ull  ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(39916800ull ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(479001600ull));
+  STF_EQUAL(1,           saturate<T>(1ll        ));
+  STF_EQUAL(2,           saturate<T>(2ll        ));
+  STF_EQUAL(6,           saturate<T>(6ll        ));
+  STF_EQUAL(24,          saturate<T>(24ll       ));
+  STF_EQUAL(120,         saturate<T>(120ll      ));
+  STF_EQUAL(720,         saturate<T>(720ll      ));
+  STF_EQUAL(5040,        saturate<T>(5040ll     ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(40320ll    ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(362880ll   ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(3628800ll  ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(39916800ll ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(479001600ll));
+  STF_EQUAL(-1,           saturate<T>(-1ll        ));
+  STF_EQUAL(-2,           saturate<T>(-2ll        ));
+  STF_EQUAL(-6,           saturate<T>(-6ll        ));
+  STF_EQUAL(-24,          saturate<T>(-24ll       ));
+  STF_EQUAL(-120,         saturate<T>(-120ll      ));
+  STF_EQUAL(-720,         saturate<T>(-720ll      ));
+  STF_EQUAL(-5040,        saturate<T>(-5040ll     ));
+  STF_EQUAL(Valmin<T>(),  saturate<T>(-40320ll    ));
+  STF_EQUAL(Valmin<T>(),  saturate<T>(-362880ll   ));
+  STF_EQUAL(Valmin<T>(),  saturate<T>(-3628800ll  ));
+  STF_EQUAL(Valmin<T>(),  saturate<T>(-39916800ll ));
+  STF_EQUAL(Valmin<T>(),  saturate<T>(-479001600ll));
 }
 
 STF_CASE_TPL (" saturate unsigned_uint16",  (uint16_t))
@@ -115,30 +116,30 @@ STF_CASE_TPL (" saturate unsigned_uint16",  (uint16_t))
   using bs::Valmax;
   using bs::Valmin;
   // specific values tests
-  STF_ULP_EQUAL(1u,           saturate<T>(1ull        ), 0);
-  STF_ULP_EQUAL(2u,           saturate<T>(2ull        ), 0);
-  STF_ULP_EQUAL(6u,           saturate<T>(6ull        ), 0);
-  STF_ULP_EQUAL(24u,          saturate<T>(24ull       ), 0);
-  STF_ULP_EQUAL(120u,         saturate<T>(120ull      ), 0);
-  STF_ULP_EQUAL(720u,         saturate<T>(720ull      ), 0);
-  STF_ULP_EQUAL(5040u,        saturate<T>(5040ull     ), 0);
-  STF_ULP_EQUAL(40320u,       saturate<T>(40320ull    ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(362880ull   ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(3628800ull  ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(39916800ull ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(479001600ull), 0);
-  STF_ULP_EQUAL(1,           saturate<T>(1ll        ), 0);
-  STF_ULP_EQUAL(2,           saturate<T>(2ll        ), 0);
-  STF_ULP_EQUAL(6,           saturate<T>(6ll        ), 0);
-  STF_ULP_EQUAL(24,          saturate<T>(24ll       ), 0);
-  STF_ULP_EQUAL(120,         saturate<T>(120ll      ), 0);
-  STF_ULP_EQUAL(720,         saturate<T>(720ll      ), 0);
-  STF_ULP_EQUAL(5040,        saturate<T>(5040ll     ), 0);
-  STF_ULP_EQUAL(40320,       saturate<T>(40320ll    ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(362880ll   ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(3628800ll  ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(39916800ll ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(479001600ll), 0);
+  STF_EQUAL(1u,           saturate<T>(1ull        ));
+  STF_EQUAL(2u,           saturate<T>(2ull        ));
+  STF_EQUAL(6u,           saturate<T>(6ull        ));
+  STF_EQUAL(24u,          saturate<T>(24ull       ));
+  STF_EQUAL(120u,         saturate<T>(120ull      ));
+  STF_EQUAL(720u,         saturate<T>(720ull      ));
+  STF_EQUAL(5040u,        saturate<T>(5040ull     ));
+  STF_EQUAL(40320u,       saturate<T>(40320ull    ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(362880ull   ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(3628800ull  ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(39916800ull ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(479001600ull));
+  STF_EQUAL(1,           saturate<T>(1ll        ));
+  STF_EQUAL(2,           saturate<T>(2ll        ));
+  STF_EQUAL(6,           saturate<T>(6ll        ));
+  STF_EQUAL(24,          saturate<T>(24ll       ));
+  STF_EQUAL(120,         saturate<T>(120ll      ));
+  STF_EQUAL(720,         saturate<T>(720ll      ));
+  STF_EQUAL(5040,        saturate<T>(5040ll     ));
+  STF_EQUAL(40320,       saturate<T>(40320ll    ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(362880ll   ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(3628800ll  ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(39916800ll ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(479001600ll));
 }
 
 STF_CASE_TPL (" saturate int8",  (int8_t))
@@ -149,42 +150,42 @@ STF_CASE_TPL (" saturate int8",  (int8_t))
   using bs::Valmin;
 
   // specific values tests
-  STF_ULP_EQUAL(1u,           saturate<T>(1ull        ), 0);
-  STF_ULP_EQUAL(2u,           saturate<T>(2ull        ), 0);
-  STF_ULP_EQUAL(6u,           saturate<T>(6ull        ), 0);
-  STF_ULP_EQUAL(24u,          saturate<T>(24ull       ), 0);
-  STF_ULP_EQUAL(120u,         saturate<T>(120ull      ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(720ull      ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(5040ull     ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(40320ull    ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(362880ull   ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(3628800ull  ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(39916800ull ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(479001600ull), 0);
-  STF_ULP_EQUAL(1,           saturate<T>(1ll        ), 0);
-  STF_ULP_EQUAL(2,           saturate<T>(2ll        ), 0);
-  STF_ULP_EQUAL(6,           saturate<T>(6ll        ), 0);
-  STF_ULP_EQUAL(24,          saturate<T>(24ll       ), 0);
-  STF_ULP_EQUAL(120,         saturate<T>(120ll      ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(720ll      ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(5040ll     ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(40320ll    ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(362880ll   ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(3628800ll  ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(39916800ll ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(479001600ll), 0);
-  STF_ULP_EQUAL(-1,           saturate<T>(-1ll        ), 0);
-  STF_ULP_EQUAL(-2,           saturate<T>(-2ll        ), 0);
-  STF_ULP_EQUAL(-6,           saturate<T>(-6ll        ), 0);
-  STF_ULP_EQUAL(-24,          saturate<T>(-24ll       ), 0);
-  STF_ULP_EQUAL(-120,         saturate<T>(-120ll      ), 0);
-  STF_ULP_EQUAL(Valmin<T>(),  saturate<T>(-720ll      ), 0);
-  STF_ULP_EQUAL(Valmin<T>(),  saturate<T>(-5040ll     ), 0);
-  STF_ULP_EQUAL(Valmin<T>(),  saturate<T>(-40320ll    ), 0);
-  STF_ULP_EQUAL(Valmin<T>(),  saturate<T>(-362880ll   ), 0);
-  STF_ULP_EQUAL(Valmin<T>(),  saturate<T>(-3628800ll  ), 0);
-  STF_ULP_EQUAL(Valmin<T>(),  saturate<T>(-39916800ll ), 0);
-  STF_ULP_EQUAL(Valmin<T>(),  saturate<T>(-479001600ll), 0);
+  STF_EQUAL(1u,           saturate<T>(1ull        ));
+  STF_EQUAL(2u,           saturate<T>(2ull        ));
+  STF_EQUAL(6u,           saturate<T>(6ull        ));
+  STF_EQUAL(24u,          saturate<T>(24ull       ));
+  STF_EQUAL(120u,         saturate<T>(120ull      ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(720ull      ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(5040ull     ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(40320ull    ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(362880ull   ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(3628800ull  ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(39916800ull ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(479001600ull));
+  STF_EQUAL(1,           saturate<T>(1ll        ));
+  STF_EQUAL(2,           saturate<T>(2ll        ));
+  STF_EQUAL(6,           saturate<T>(6ll        ));
+  STF_EQUAL(24,          saturate<T>(24ll       ));
+  STF_EQUAL(120,         saturate<T>(120ll      ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(720ll      ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(5040ll     ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(40320ll    ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(362880ll   ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(3628800ll  ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(39916800ll ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(479001600ll));
+  STF_EQUAL(-1,           saturate<T>(-1ll        ));
+  STF_EQUAL(-2,           saturate<T>(-2ll        ));
+  STF_EQUAL(-6,           saturate<T>(-6ll        ));
+  STF_EQUAL(-24,          saturate<T>(-24ll       ));
+  STF_EQUAL(-120,         saturate<T>(-120ll      ));
+  STF_EQUAL(Valmin<T>(),  saturate<T>(-720ll      ));
+  STF_EQUAL(Valmin<T>(),  saturate<T>(-5040ll     ));
+  STF_EQUAL(Valmin<T>(),  saturate<T>(-40320ll    ));
+  STF_EQUAL(Valmin<T>(),  saturate<T>(-362880ll   ));
+  STF_EQUAL(Valmin<T>(),  saturate<T>(-3628800ll  ));
+  STF_EQUAL(Valmin<T>(),  saturate<T>(-39916800ll ));
+  STF_EQUAL(Valmin<T>(),  saturate<T>(-479001600ll));
 }
 
 STF_CASE_TPL (" saturate unsigned_uint8",  (uint8_t))
@@ -195,40 +196,40 @@ STF_CASE_TPL (" saturate unsigned_uint8",  (uint8_t))
   using bs::Valmin;
 
   // specific values tests
-  STF_ULP_EQUAL(1u,           saturate<T>(1ull        ), 0);
-  STF_ULP_EQUAL(2u,           saturate<T>(2ull        ), 0);
-  STF_ULP_EQUAL(6u,           saturate<T>(6ull        ), 0);
-  STF_ULP_EQUAL(24u,          saturate<T>(24ull       ), 0);
-  STF_ULP_EQUAL(120u,         saturate<T>(120ull      ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(720ull      ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(5040ull     ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(40320ull    ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(362880ull   ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(3628800ull  ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(39916800ull ), 0);
-  STF_ULP_EQUAL(uint(Valmax<T>()), saturate<T>(479001600ull), 0);
-  STF_ULP_EQUAL(1,           saturate<T>(1ll        ), 0);
-  STF_ULP_EQUAL(2,           saturate<T>(2ll        ), 0);
-  STF_ULP_EQUAL(6,           saturate<T>(6ll        ), 0);
-  STF_ULP_EQUAL(24,          saturate<T>(24ll       ), 0);
-  STF_ULP_EQUAL(120,         saturate<T>(120ll      ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(720ll      ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(5040ll     ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(40320ll    ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(362880ll   ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(3628800ll  ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(39916800ll ), 0);
-  STF_ULP_EQUAL(Valmax<T>(), saturate<T>(479001600ll), 0);
-  STF_ULP_EQUAL(0, saturate<T>(-1ll        ), 0);
-  STF_ULP_EQUAL(0, saturate<T>(-2ll        ), 0);
-  STF_ULP_EQUAL(0, saturate<T>(-6ll        ), 0);
-  STF_ULP_EQUAL(0, saturate<T>(-24ll       ), 0);
-  STF_ULP_EQUAL(0, saturate<T>(-120ll      ), 0);
-  STF_ULP_EQUAL(0, saturate<T>(-720ll      ), 0);
-  STF_ULP_EQUAL(0, saturate<T>(-5040ll     ), 0);
-  STF_ULP_EQUAL(0, saturate<T>(-40320ll    ), 0);
-  STF_ULP_EQUAL(0, saturate<T>(-362880ll   ), 0);
-  STF_ULP_EQUAL(0, saturate<T>(-3628800ll  ), 0);
-  STF_ULP_EQUAL(0, saturate<T>(-39916800ll ), 0);
-  STF_ULP_EQUAL(0, saturate<T>(-479001600ll), 0);
+  STF_EQUAL(1u,           saturate<T>(1ull        ));
+  STF_EQUAL(2u,           saturate<T>(2ull        ));
+  STF_EQUAL(6u,           saturate<T>(6ull        ));
+  STF_EQUAL(24u,          saturate<T>(24ull       ));
+  STF_EQUAL(120u,         saturate<T>(120ull      ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(720ull      ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(5040ull     ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(40320ull    ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(362880ull   ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(3628800ull  ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(39916800ull ));
+  STF_EQUAL(base(Valmax<T>()), saturate<T>(479001600ull));
+  STF_EQUAL(1,           saturate<T>(1ll        ));
+  STF_EQUAL(2,           saturate<T>(2ll        ));
+  STF_EQUAL(6,           saturate<T>(6ll        ));
+  STF_EQUAL(24,          saturate<T>(24ll       ));
+  STF_EQUAL(120,         saturate<T>(120ll      ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(720ll      ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(5040ll     ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(40320ll    ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(362880ll   ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(3628800ll  ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(39916800ll ));
+  STF_EQUAL(Valmax<T>(), saturate<T>(479001600ll));
+  STF_EQUAL(0, saturate<T>(-1ll        ));
+  STF_EQUAL(0, saturate<T>(-2ll        ));
+  STF_EQUAL(0, saturate<T>(-6ll        ));
+  STF_EQUAL(0, saturate<T>(-24ll       ));
+  STF_EQUAL(0, saturate<T>(-120ll      ));
+  STF_EQUAL(0, saturate<T>(-720ll      ));
+  STF_EQUAL(0, saturate<T>(-5040ll     ));
+  STF_EQUAL(0, saturate<T>(-40320ll    ));
+  STF_EQUAL(0, saturate<T>(-362880ll   ));
+  STF_EQUAL(0, saturate<T>(-3628800ll  ));
+  STF_EQUAL(0, saturate<T>(-39916800ll ));
+  STF_EQUAL(0, saturate<T>(-479001600ll));
 }


### PR DESCRIPTION
Small fixes that prevent MSVC test to be readable due to preposterous amount of warnings
