### PR TITLE
COrrect codegen for some stores

### DIFF
--- a/include/boost/simd/arch/common/scalar/function/store.hpp
+++ b/include/boost/simd/arch/common/scalar/function/store.hpp
@@ -1,12 +1,10 @@
 //==================================================================================================
-/*!
-  @file
-
-  @copyright 2016 J.T. Lapreste
+/**
+  Copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #ifndef BOOST_SIMD_ARCH_COMMON_SCALAR_FUNCTION_STORE_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_SCALAR_FUNCTION_STORE_HPP_INCLUDED
@@ -19,7 +17,7 @@ namespace boost { namespace simd { namespace ext
 {
   namespace bd = boost::dispatch;
   namespace bs = boost::simd;
-  /// INTERNAL ONLY - Scalar store and store are equivalent
+
   BOOST_DISPATCH_OVERLOAD ( store_
                           , (typename A0, typename A1, typename A2)
                           , bd::cpu_
@@ -28,13 +26,12 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::integer_<A2>>
                           )
   {
-    BOOST_FORCEINLINE void operator() ( A0 const& a0, A1 a1,  A2 const & a2) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE void operator()(A0 const& a0, A1 a1, A2 const & a2) const BOOST_NOEXCEPT
     {
       *(a1+a2) = a0;
     }
   };
 
-  /// INTERNAL ONLY - Scalar store and store are equivalent
   BOOST_DISPATCH_OVERLOAD ( store_
                           , (typename A0, typename A1)
                           , bd::cpu_
@@ -42,13 +39,11 @@ namespace boost { namespace simd { namespace ext
                           , bd::pointer_<bd::scalar_<bd::unspecified_<A1>>,1u>
                           )
   {
-    BOOST_FORCEINLINE void operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE void operator()(A0 a0, A1 a1) const BOOST_NOEXCEPT
     {
       *a1 = a0;
     }
   };
-
 } } }
-
 
 #endif

--- a/include/boost/simd/arch/common/simd/function/aligned_store.hpp
+++ b/include/boost/simd/arch/common/simd/function/aligned_store.hpp
@@ -1,23 +1,19 @@
 //==================================================================================================
-/*!
-  @file
-
-  @copyright 2015 NumScale SAS
+/**
+  Copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #ifndef BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_ALIGNED_STORE_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_ALIGNED_STORE_HPP_INCLUDED
-#include <boost/simd/meta/hierarchy/simd.hpp>
+
 #include <boost/simd/detail/overload.hpp>
-#include <boost/simd/detail/dispatch/function/overload.hpp>
 #include <boost/simd/detail/dispatch/adapted/common/pointer.hpp>
 #include <boost/simd/function/store.hpp>
 #include <boost/align/is_aligned.hpp>
 #include <boost/config.hpp>
-#include <tuple>
 
 namespace boost { namespace simd { namespace ext
 {
@@ -25,25 +21,22 @@ namespace boost { namespace simd { namespace ext
   namespace bs = ::boost::simd;
 
   //------------------------------------------------------------------------------------------------
-  /// INTERNAL ONLY - SIMD aligned_store in simd emulation without offset
+  // aligned_store is generally check + calling store
   BOOST_DISPATCH_OVERLOAD ( aligned_store_
-                          , (typename A0, typename A1)
+                          , (typename A0, typename A1, typename X)
                           , bs::simd_
-                          , bs::pack_<bd::unspecified_<A0>,bs::simd_emulation_>
+                          , bs::pack_<bd::unspecified_<A0>,X>
                           , bd::pointer_<bd::scalar_<bd::unspecified_<A1>>,1u>
                           )
   {
-
     BOOST_FORCEINLINE void operator()(const A0& a0, A1  a1) const BOOST_NOEXCEPT
     {
       BOOST_ASSERT_MSG( boost::alignment::is_aligned(A0::alignment, a1)
-                      , "boost::simd::aligned_load was performed on an unaligned pointer of integer"
+                      , "boost::simd::aligned_store was performed on an unaligned pointer of integer"
                       );
       bs::store(a0, a1);
     }
   };
-
-
 } } }
 
 #endif

--- a/include/boost/simd/arch/common/simd/function/store.hpp
+++ b/include/boost/simd/arch/common/simd/function/store.hpp
@@ -1,24 +1,19 @@
 //==================================================================================================
-/*!
-  @file
-
-  @copyright 2015 NumScale SAS
+/**
+  Copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #ifndef BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_STORE_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_STORE_HPP_INCLUDED
 
 #include <boost/simd/detail/overload.hpp>
-#include <boost/simd/meta/hierarchy/simd.hpp>
-#include <boost/simd/detail/dispatch/function/overload.hpp>
 #include <boost/simd/detail/dispatch/adapted/common/pointer.hpp>
 #include <boost/simd/function/extract.hpp>
-#include <boost/simd/function/insert.hpp>
+#include <boost/simd/function/slice.hpp>
 #include <boost/config.hpp>
-#include <tuple>
 
 namespace boost { namespace simd { namespace ext
 {
@@ -26,40 +21,43 @@ namespace boost { namespace simd { namespace ext
   namespace bs = ::boost::simd;
 
   //------------------------------------------------------------------------------------------------
-  /// INTERNAL ONLY - SIMD store without offset
+  // Whenever we have no clue how to store
   BOOST_DISPATCH_OVERLOAD ( store_
-                          , (typename Src, typename Pointer)
+                          , (typename Src, typename Pointer, typename X)
                           , bs::simd_
-                          , bs::pack_<bd::unspecified_<Src>,bs::simd_emulation_>
+                          , bs::pack_<bd::unspecified_<Src>, X>
                           , bd::pointer_<bd::scalar_<bd::unspecified_<Pointer>>,1u>
                           )
   {
     using storage_t = typename Src::storage_type;
     using value_t   = typename storage_t::value_type;
     using s_t       = typename boost::pointee<Pointer>::type;
-    // How many elements does each store stores ?
-    template<typename I>
-    using rsize_t = std::integral_constant<std::size_t,I::value*Src::traits::element_size>;
 
-    BOOST_FORCEINLINE void operator()(const Src& s, Pointer p) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE void operator()(const Src& s, Pointer p) const
     {
-      do_(s, p, brigand::range<std::size_t,0,rsize_t<std::tuple_size<storage_t>>::value>{} );
+      do_(s, p, typename Src::storage_kind{}, typename Src::traits::element_range{} );
     }
 
-    template < typename I>
-    static BOOST_FORCEINLINE void sto_(const Src& s, Pointer  p) BOOST_NOEXCEPT
+    // aggregate pack are calling store twice
+    template<typename... N> static BOOST_FORCEINLINE
+    void do_( Src const & s, Pointer p, aggregate_storage const&, brigand::list<N...> const&)
     {
-      p[I::value] = static_cast<s_t>(s[I::value]);
+      store(slice_low(s) , p);
+      store(slice_high(s), p+Src::traits::element_size);
     }
 
-    template<typename... N>
-    static inline void do_(Src const & s, Pointer p, brigand::list<N...> const&)
+    // other pack are calling store N times
+    template<typename I> static BOOST_FORCEINLINE void sto_(const Src& s, Pointer  p)
     {
-      (void)std::initializer_list<bool>{(sto_<N>(s,p),true)...};
+      p[I::value] = static_cast<s_t>(extract<I::value>(s));
+    }
+
+    template<typename K, typename... N>
+    static BOOST_FORCEINLINE void do_(Src const & s, Pointer p, K const&, brigand::list<N...> const&)
+    {
+      (void)(std::initializer_list<bool>{(sto_<N>(s,p),true)...});
     }
   };
-
-
 } } }
 
 #endif

--- a/include/boost/simd/arch/x86/avx2/simd/function/store.hpp
+++ b/include/boost/simd/arch/x86/avx2/simd/function/store.hpp
@@ -10,22 +10,25 @@
 #define BOOST_SIMD_ARCH_X86_AVX2_SIMD_FUNCTION_STORE_HPP_INCLUDED
 
 #include <boost/simd/detail/overload.hpp>
+#include <boost/simd/meta/is_pointing_to.hpp>
+#include <boost/simd/detail/dispatch/adapted/common/pointer.hpp>
 
 namespace boost { namespace simd { namespace ext
 {
   namespace bd = boost::dispatch;
   namespace bs = boost::simd;
 
-  BOOST_DISPATCH_OVERLOAD ( store_
-                          , (typename Vec, typename Pointer)
-                          , bs::avx2_
-                          , bs::pack_<bd::integer_<Vec>, bs::avx_>
-                          , bd::pointer_<bd::scalar_<bd::integer_<Pointer>>,1u>
-                          )
+  BOOST_DISPATCH_OVERLOAD_IF( store_
+                            , (typename Vec, typename Pointer)
+                            , (bs::is_pointing_to<Pointer,typename Vec::value_type>)
+                            , bs::avx2_
+                            , bs::pack_<bd::integer_<Vec>, bs::avx_>
+                            , bd::pointer_<bd::scalar_<bd::integer_<Pointer>>,1u>
+                            )
   {
     BOOST_FORCEINLINE void operator() (const Vec& a0, Pointer a1) const BOOST_NOEXCEPT
     {
-       _mm256_storeu_si256(reinterpret_cast<__m256i*>(a1), a0);
+      _mm256_storeu_si256(reinterpret_cast<__m256i*>(a1), a0);
     }
   };
 } } }

--- a/include/boost/simd/arch/x86/sse2/simd/function/aligned_store.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/aligned_store.hpp
@@ -1,20 +1,18 @@
 //==================================================================================================
-/*!
-  @file
-
-  @copyright 2016 NumScale SAS
+/**
+  Copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #ifndef BOOST_SIMD_ARCH_X86_SSE2_SIMD_FUNCTION_ALIGNED_STORE_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_X86_SSE2_SIMD_FUNCTION_ALIGNED_STORE_HPP_INCLUDED
 
 #include <boost/simd/detail/overload.hpp>
 #include <boost/simd/detail/dispatch/adapted/common/pointer.hpp>
+#include <boost/simd/meta/is_pointing_to.hpp>
 #include <boost/align/is_aligned.hpp>
-#include <boost/simd/detail/aliasing.hpp>
 
 namespace boost { namespace simd { namespace ext
 {
@@ -38,12 +36,13 @@ namespace boost { namespace simd { namespace ext
     }
   };
 
-  BOOST_DISPATCH_OVERLOAD ( aligned_store_
-                          , (typename Vec, typename Pointer)
-                          , bs::sse2_
-                          , bs::pack_ < bd::integer_ < Vec>, bs::sse_>
-                          , bd::pointer_<bd::scalar_<bd::integer_<Pointer>>,1u>
-                          )
+  BOOST_DISPATCH_OVERLOAD_IF( aligned_store_
+                            , (typename Vec, typename Pointer)
+                            , (bs::is_pointing_to<Pointer,typename Vec::value_type>)
+                            , bs::sse2_
+                            , bs::pack_ < bd::integer_ < Vec>, bs::sse_>
+                            , bd::pointer_<bd::scalar_<bd::integer_<Pointer>>,1u>
+                            )
   {
     BOOST_FORCEINLINE void operator() (const Vec& a0, Pointer a1) const BOOST_NOEXCEPT
     {
@@ -53,7 +52,6 @@ namespace boost { namespace simd { namespace ext
        _mm_store_si128(reinterpret_cast<__m128i*>(a1), a0);
     }
   };
-
 } } }
 
 #endif

--- a/include/boost/simd/arch/x86/sse2/simd/function/store.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/store.hpp
@@ -1,28 +1,27 @@
 //==================================================================================================
-/*!
-  @file
-
-  @copyright 2016 NumScale SAS
+/**
+  Copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #ifndef BOOST_SIMD_ARCH_X86_SSE2_SIMD_FUNCTION_STORE_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_X86_SSE2_SIMD_FUNCTION_STORE_HPP_INCLUDED
 
 #include <boost/simd/detail/overload.hpp>
+#include <boost/simd/meta/is_pointing_to.hpp>
+#include <boost/simd/detail/dispatch/adapted/common/pointer.hpp>
 
 namespace boost { namespace simd { namespace ext
 {
   namespace bd = boost::dispatch;
   namespace bs = boost::simd;
 
-
   BOOST_DISPATCH_OVERLOAD ( store_
                           , (typename Vec, typename Pointer)
                           , bs::sse2_
-                          , bs::pack_ < bd::double_ < Vec>, bs::sse_>
+                          , bs::pack_<bd::double_<Vec>, bs::sse_>
                           , bd::pointer_<bd::scalar_<bd::double_<Pointer>>,1u>
                           )
   {
@@ -32,12 +31,13 @@ namespace boost { namespace simd { namespace ext
     }
   };
 
-  BOOST_DISPATCH_OVERLOAD ( store_
-                          , (typename Vec, typename Pointer)
-                          , bs::sse2_
-                          , bs::pack_ < bd::integer_ < Vec>, bs::sse_>
-                          , bd::pointer_<bd::scalar_<bd::integer_<Pointer>>,1u>
-                          )
+  BOOST_DISPATCH_OVERLOAD_IF( store_
+                            , (typename Vec, typename Pointer)
+                            , (bs::is_pointing_to<Pointer,typename Vec::value_type>)
+                            , bs::sse2_
+                            , bs::pack_< bd::integer_<Vec>, bs::sse_>
+                            , bd::pointer_<bd::scalar_<bd::integer_<Pointer>>,1u>
+                            )
   {
     BOOST_FORCEINLINE void operator() (const Vec& a0, Pointer a1) const BOOST_NOEXCEPT
     {

--- a/test/function/simd/aligned_store.cpp
+++ b/test/function/simd/aligned_store.cpp
@@ -12,15 +12,15 @@
 #include <boost/align/aligned_alloc.hpp>
 #include <simd_test.hpp>
 
+namespace ba = boost::alignment;
+namespace bs = boost::simd;
+
 template <typename T, std::size_t N, typename Env>
 void test(Env& $)
 {
-  namespace ba = boost::alignment;
-  namespace bs = boost::simd;
   using p_t = bs::pack<T, N>;
 
   std::size_t alg = p_t::alignment;
-
 
   T* a1 = static_cast<T*>(ba::aligned_alloc(alg, (sizeof(T)) * N));
   T* a2 = static_cast<T*>(ba::aligned_alloc(alg, (sizeof(T)) * N));
@@ -34,19 +34,16 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   bs::aligned_store(aa1, &a2[0]);
 
-  for(std::size_t i=0; i <N ; ++i)
-  {
-    STF_IEEE_EQUAL(a1[i], a2[i]);
-  }
+  for(std::size_t i=0; i <N ; ++i) STF_EQUAL(a1[i], a2[i]);
+
   ba::aligned_free(a1);
   ba::aligned_free(a2);
 }
 
 STF_CASE_TPL( "Check aligned_store behavior with all types", STF_NUMERIC_TYPES )
 {
-  namespace bs = boost::simd;
-  using p_t = bs::pack<T>;
-  static const std::size_t N = p_t::static_size;
+  static const std::size_t N = bs::pack<T>::static_size;
+
   test<T, N>($);
   test<T, N/2>($);
   test<T, N*2>($);

--- a/test/function/simd/aligned_store.cpp
+++ b/test/function/simd/aligned_store.cpp
@@ -1,15 +1,15 @@
 //==================================================================================================
-/*!
-
-  Copyright 2015 NumScale SAS
+/**
+  Copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
-#include <boost/simd/pack.hpp>
 #include <boost/simd/function/aligned_store.hpp>
-#include <boost/align/aligned_alloc.hpp>
+#include <boost/simd/pack.hpp>
+#include <boost/align/aligned_allocator.hpp>
+#include <vector>
 #include <simd_test.hpp>
 
 namespace ba = boost::alignment;
@@ -20,10 +20,8 @@ void test(Env& $)
 {
   using p_t = bs::pack<T, N>;
 
-  std::size_t alg = p_t::alignment;
-
-  T* a1 = static_cast<T*>(ba::aligned_alloc(alg, (sizeof(T)) * N));
-  T* a2 = static_cast<T*>(ba::aligned_alloc(alg, (sizeof(T)) * N));
+  std::vector<T,ba::aligned_allocator<T,p_t::alignment>> a1(N);
+  std::vector<T,ba::aligned_allocator<T,p_t::alignment>> a2(N);
 
   for(std::size_t i = 0; i < N; ++i)
   {
@@ -34,10 +32,7 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   bs::aligned_store(aa1, &a2[0]);
 
-  for(std::size_t i=0; i <N ; ++i) STF_EQUAL(a1[i], a2[i]);
-
-  ba::aligned_free(a1);
-  ba::aligned_free(a2);
+  STF_EQUAL(a1, a2);
 }
 
 STF_CASE_TPL( "Check aligned_store behavior with all types", STF_NUMERIC_TYPES )

--- a/test/function/simd/store.cpp
+++ b/test/function/simd/store.cpp
@@ -1,24 +1,23 @@
 //==================================================================================================
-/*!
-
-  Copyright 2015 NumScale SAS
+/**
+  Copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #include <boost/simd/pack.hpp>
 #include <boost/simd/function/store.hpp>
 #include <simd_test.hpp>
 
+namespace bs = boost::simd;
+
 template <typename T, std::size_t N, typename Env>
 void test(Env& $)
 {
-  namespace bs = boost::simd;
   using p_t = bs::pack<T, N>;
 
-
-  T a1[N], a2[N];
+  std::array<T,N> a1, a2;
   for(std::size_t i = 0; i < N; ++i)
   {
     a1[i] = T(i+1);
@@ -28,18 +27,14 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   bs::store(aa1, &a2[0]);
 
-  for(std::size_t i=0; i <N ; ++i)
-  {
-    STF_IEEE_EQUAL(a1[i], a2[i]);
-  }
+  STF_ALL_EQUAL(a1, a2);
 }
 
 STF_CASE_TPL( "Check store behavior with all types", STF_NUMERIC_TYPES )
 {
-  namespace bs = boost::simd;
-  using p_t = bs::pack<T>;
-  static const std::size_t N = p_t::static_size;
-   test<T, N>($);
-   test<T, N/2>($);
-   test<T, N*2>($);
+  static const std::size_t N = bs::pack<T>::static_size;
+
+  test<T, N>($);
+  test<T, N/2>($);
+  test<T, N*2>($);
 }


### PR DESCRIPTION
- use storage_kind for store
- check for integral/pointer types in typed version
