### PR TITLE
sincos/d/pi lacked restricted version

### DIFF
--- a/include/boost/simd/arch/common/generic/function/sincos.hpp
+++ b/include/boost/simd/arch/common/generic/function/sincos.hpp
@@ -14,6 +14,7 @@
 
 
 #include <boost/simd/arch/common/detail/generic/trigo.hpp>
+#include <boost/simd/function/restricted.hpp>
 #include <boost/simd/meta/is_not_scalar.hpp>
 #include <boost/simd/detail/dispatch/function/overload.hpp>
 #include <boost/config.hpp>
@@ -30,13 +31,24 @@ namespace boost { namespace simd { namespace ext
                           , bd::generic_< bd::floating_<A0> >
                           )
   {
-    using result_t = std::pair<A0, A0>                     ;
-    BOOST_FORCEINLINE result_t operator() ( A0 const& a0) const
+    BOOST_FORCEINLINE std::pair<A0, A0> operator() ( A0 const& a0) const
     {
       return detail::trig_base <A0,tag::radian_tag,is_not_scalar_t<A0>,tag::big_tag>::sincosa(a0);
     }
   };
 
+  BOOST_DISPATCH_OVERLOAD ( sincos_
+                          , (typename A0)
+                          , bd::cpu_
+                          , bs::restricted_tag
+                          , bd::generic_< bd::floating_<A0> >
+                          )
+  {
+    BOOST_FORCEINLINE std::pair<A0, A0> operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    {
+      return detail::trig_base<A0, tag::radian_tag,is_not_scalar_t<A0>,tag::clipped_pio4_tag>::sincosa(a0);
+    }
+  };
 } } }
 
 

--- a/include/boost/simd/arch/common/generic/function/sincosd.hpp
+++ b/include/boost/simd/arch/common/generic/function/sincosd.hpp
@@ -38,6 +38,18 @@ namespace boost { namespace simd { namespace ext
     }
   };
 
+  BOOST_DISPATCH_OVERLOAD ( sincosd_
+                          , (typename A0)
+                          , bd::cpu_
+                          , bs::restricted_tag
+                          , bd::generic_< bd::floating_<A0> >
+                          )
+  {
+    BOOST_FORCEINLINE std::pair<A0, A0> operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    {
+      return detail::trig_base<A0, tag::degree_tag,is_not_scalar_t<A0>,tag::clipped_pio4_tag>::sincosa(a0);
+    }
+  };
 } } }
 
 

--- a/include/boost/simd/arch/common/generic/function/sincospi.hpp
+++ b/include/boost/simd/arch/common/generic/function/sincospi.hpp
@@ -14,6 +14,7 @@
 
 
 #include <boost/simd/arch/common/detail/generic/trigo.hpp>
+#include <boost/simd/function/restricted.hpp>
 #include <boost/simd/meta/is_not_scalar.hpp>
 #include <boost/simd/detail/dispatch/function/overload.hpp>
 #include <boost/config.hpp>
@@ -37,6 +38,18 @@ namespace boost { namespace simd { namespace ext
     }
   };
 
+  BOOST_DISPATCH_OVERLOAD ( sincospi_
+                          , (typename A0)
+                          , bd::cpu_
+                          , bs::restricted_tag
+                          , bd::generic_< bd::floating_<A0> >
+                          )
+  {
+    BOOST_FORCEINLINE std::pair<A0, A0> operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    {
+      return detail::trig_base<A0, tag::pi_tag,is_not_scalar_t<A0>,tag::clipped_pio4_tag>::sincosa(a0);
+    }
+  };
 } } }
 
 

--- a/test/function/scalar/sincos.cpp
+++ b/test/function/scalar/sincos.cpp
@@ -41,7 +41,10 @@ STF_CASE_TPL (" sincos",  STF_IEEE_TYPES)
       std::pair<T,T> p = sincos(a[i]);
       STF_IEEE_EQUAL(p.first,  bs::sin(a[i]));
       STF_IEEE_EQUAL(p.second, bs::cos(a[i]));
+      std::pair<T,T> q = bs::restricted_(bs::sincos)(a[i]);
+      STF_IEEE_EQUAL(q.first,  bs::restricted_(bs::sin)(a[i]));
+      STF_IEEE_EQUAL(q.second, bs::restricted_(bs::cos)(a[i]));
     }
-  }
+   }
 
 }

--- a/test/function/scalar/sincosd.cpp
+++ b/test/function/scalar/sincosd.cpp
@@ -41,7 +41,12 @@ STF_CASE_TPL (" sincosd",  STF_IEEE_TYPES)
       std::pair<T,T> p = sincosd(a[i]);
       STF_IEEE_EQUAL(p.first,  bs::sind(a[i]));
       STF_IEEE_EQUAL(p.second, bs::cosd(a[i]));
+      std::pair<T,T> q = bs::restricted_(sincosd)(a[i]);
+      STF_IEEE_EQUAL(q.first,  bs::restricted_(bs::sind)(a[i]));
+      STF_IEEE_EQUAL(q.second, bs::restricted_(bs::cosd)(a[i]));
     }
   }
-
 }
+
+
+

--- a/test/function/scalar/sincospi.cpp
+++ b/test/function/scalar/sincospi.cpp
@@ -41,6 +41,9 @@ STF_CASE_TPL (" sincospi",  STF_IEEE_TYPES)
       std::pair<T,T> p = sincospi(a[i]);
       STF_IEEE_EQUAL(p.first,  bs::sinpi(a[i]));
       STF_IEEE_EQUAL(p.second, bs::cospi(a[i]));
+      std::pair<T,T> q = bs::restricted_(sincospi)(a[i]);
+      STF_IEEE_EQUAL(q.first,  bs::restricted_(bs::sinpi)(a[i]));
+      STF_IEEE_EQUAL(q.second, bs::restricted_(bs::cospi)(a[i]));
     }
   }
 

--- a/test/function/simd/sincos.cpp
+++ b/test/function/simd/sincos.cpp
@@ -11,6 +11,7 @@
 #include <boost/simd/function/sincos.hpp>
 #include <boost/simd/pack.hpp>
 #include <boost/simd/function/std.hpp>
+#include <boost/simd/constant/pio_4.hpp>
 
 
 namespace bs = boost::simd;
@@ -44,5 +45,36 @@ STF_CASE_TPL("Check sincos on pack" , STF_IEEE_TYPES)
   test<T, N>($);
   test<T, N/2>($);
   test<T, N*2>($);
+}
+
+template <typename T, std::size_t N, typename Env>
+void testr(Env& $)
+{
+  using p_t = bs::pack<T, N>;
+
+  T a1[N], c[N], s[N];
+  for(std::size_t i = 0; i < N; ++i)
+  {
+    a1[i] = ((i%2) ? T(i) : -T(i))*bs::Pio_4<T>()/N;
+    std::tie(s[i], c[i])= bs::restricted_(bs::sincos)(a1[i]);
+  }
+
+  p_t aa1(&a1[0], &a1[0]+N);
+  p_t ss (&s[0], &s[0]+N);
+  p_t cc (&c[0], &c[0]+N);
+  p_t ss1, cc1;
+  std::tie(ss1, cc1)= bs::restricted_(bs::sincos)(aa1);
+
+  STF_ULP_EQUAL(ss1, ss,0.5);
+  STF_ULP_EQUAL(cc1, cc,0.5);
+}
+
+STF_CASE_TPL("Check restricted sincos on pack" , STF_IEEE_TYPES)
+{
+  static const std::size_t N = bs::pack<T>::static_size;
+
+  testr<T, N>($);
+  testr<T, N/2>($);
+  testr<T, N*2>($);
 }
 

--- a/test/function/simd/sincosd.cpp
+++ b/test/function/simd/sincosd.cpp
@@ -45,3 +45,34 @@ STF_CASE_TPL("Check sincosd on pack" , STF_IEEE_TYPES)
   test<T, N*2>($);
 }
 
+template <typename T, std::size_t N, typename Env>
+void testr(Env& $)
+{
+  using p_t = bs::pack<T, N>;
+
+  T a1[N], c[N], s[N];
+  for(std::size_t i = 0; i < N; ++i)
+  {
+    a1[i] = ((i%2) ? T(i) : -T(i))*T(45.0)/N;
+    std::tie(s[i], c[i])= bs::restricted_(bs::sincosd)(a1[i]);
+  }
+
+  p_t aa1(&a1[0], &a1[0]+N);
+  p_t ss (&s[0], &s[0]+N);
+  p_t cc (&c[0], &c[0]+N);
+  p_t ss1, cc1;
+  std::tie(ss1, cc1)= bs::restricted_(bs::sincosd)(aa1);
+
+  STF_ULP_EQUAL(ss1, ss,0.5);
+  STF_ULP_EQUAL(cc1, cc,0.5);
+}
+
+STF_CASE_TPL("Check restricted sincosd on pack" , STF_IEEE_TYPES)
+{
+  static const std::size_t N = bs::pack<T>::static_size;
+
+  testr<T, N>($);
+  testr<T, N/2>($);
+  testr<T, N*2>($);
+}
+

--- a/test/function/simd/sincospi.cpp
+++ b/test/function/simd/sincospi.cpp
@@ -45,3 +45,33 @@ STF_CASE_TPL("Check sincospi on pack" , STF_IEEE_TYPES)
   test<T, N*2>($);
 }
 
+template <typename T, std::size_t N, typename Env>
+void testr(Env& $)
+{
+  using p_t = bs::pack<T, N>;
+
+  T a1[N], c[N], s[N];
+  for(std::size_t i = 0; i < N; ++i)
+  {
+    a1[i] = ((i%2) ? T(i) : -T(i))*T(0.25)/N;
+    std::tie(s[i], c[i])= bs::restricted_(bs::sincospi)(a1[i]);
+  }
+
+  p_t aa1(&a1[0], &a1[0]+N);
+  p_t ss (&s[0], &s[0]+N);
+  p_t cc (&c[0], &c[0]+N);
+  p_t ss1, cc1;
+  std::tie(ss1, cc1)= bs::restricted_(bs::sincospi)(aa1);
+
+  STF_ULP_EQUAL(ss1, ss,0.5);
+  STF_ULP_EQUAL(cc1, cc,0.5);
+}
+
+STF_CASE_TPL("Check restricted sincospi on pack" , STF_IEEE_TYPES)
+{
+  static const std::size_t N = bs::pack<T>::static_size;
+
+  testr<T, N>($);
+  testr<T, N/2>($);
+  testr<T, N*2>($);
+}


### PR DESCRIPTION
restricted_(sincos) 3cpe sse4.2 for both sin and cos in [-pi/4 pi/4] 
