### PR TITLE
Reduce boost version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The developer mode includes the following features:
 ## Getting started with the build process (on linux)
 
 NOTE:
-> `boost.simd` *MUST* be used with the current develop version of `boost` (aka 1.62)
+> `boost.simd` *MUST* be used with the current version of `boost` (aka 1.61)
 
 You must create a build directory where all temporary building files will be located.
 

--- a/include/boost/simd/arch/common/simd/function/aligned_load/mask.hpp
+++ b/include/boost/simd/arch/common/simd/function/aligned_load/mask.hpp
@@ -34,7 +34,7 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE
     target_t operator()(Pointer const& p, Target const&) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(target_t::alignment, p.get())
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p.get(),target_t::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer"
                       );
 

--- a/include/boost/simd/arch/common/simd/function/aligned_load/misaligned.hpp
+++ b/include/boost/simd/arch/common/simd/function/aligned_load/misaligned.hpp
@@ -44,7 +44,7 @@ namespace boost { namespace simd { namespace ext
       static const std::size_t                        card = target_t::static_size;
       static const typename Misalignment::value_type  unalignment = Misalignment::value % card;
 
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(target_t::alignment, p-Misalignment::value)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p-Misalignment::value,target_t::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer"
                       );
 

--- a/include/boost/simd/arch/common/simd/function/aligned_load/regular.hpp
+++ b/include/boost/simd/arch/common/simd/function/aligned_load/regular.hpp
@@ -35,7 +35,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target_t operator()(Pointer p, Target const&) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(target_t::alignment, p)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p,target_t::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer"
                       );
 

--- a/include/boost/simd/arch/common/simd/function/aligned_store.hpp
+++ b/include/boost/simd/arch/common/simd/function/aligned_store.hpp
@@ -31,7 +31,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE void operator()(const A0& a0, A1  a1) const BOOST_NOEXCEPT
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(A0::alignment, a1)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(a1,A0::alignment)
                       , "boost::simd::aligned_store was performed on an unaligned pointer of integer"
                       );
       bs::store(a0, a1);

--- a/include/boost/simd/arch/ppc/vmx/simd/function/aligned_load.hpp
+++ b/include/boost/simd/arch/ppc/vmx/simd/function/aligned_load.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
     using target = typename Target::type;
     BOOST_FORCEINLINE target operator()(Pointer p, Target const&) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(target::alignment, p)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p,target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of double"
                       );
 

--- a/include/boost/simd/arch/ppc/vmx/simd/function/aligned_store.hpp
+++ b/include/boost/simd/arch/ppc/vmx/simd/function/aligned_store.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE void operator()(const Src& s, Pointer p) const BOOST_NOEXCEPT
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(Src::alignment, p)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, Src::alignment)
                       , "boost::simd::aligned_store was performed on an unaligned pointer"
                       );
 

--- a/include/boost/simd/arch/x86/avx/simd/function/aligned_load.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/aligned_load.hpp
@@ -37,7 +37,7 @@ namespace boost { namespace simd { namespace ext
     using target = typename Target::type;
     BOOST_FORCEINLINE target operator()(Pointer p, Target const&) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(target::alignment, p)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of integer"
                       );
 
@@ -57,7 +57,7 @@ namespace boost { namespace simd { namespace ext
     using target = typename Target::type;
     BOOST_FORCEINLINE target operator()(Pointer p, Target const&) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(target::alignment, p)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of double"
                       );
 
@@ -78,7 +78,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator() ( Pointer p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(target::alignment, p)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of float"
                       );
 
@@ -130,7 +130,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Pointer const& p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(target::alignment, p)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned masked pointer of float"
                       );
       __m256i msk = _mm256_castps_si256(bs::as_logical_t<target>(p.mask()).storage());
@@ -149,7 +149,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Pointer const& p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(target::alignment, p)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned masked pointer of float"
                       );
       auto const& msk = p.mask();
@@ -173,7 +173,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Pointer const& p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(target::alignment, p)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned masked pointer of double"
                       );
       __m256i msk = _mm256_castpd_si256(bs::as_logical_t<target>(p.mask()).storage());
@@ -192,7 +192,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Pointer const& p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(target::alignment, p)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned masked pointer of float"
                       );
       auto const& msk = p.mask();

--- a/include/boost/simd/arch/x86/avx/simd/function/aligned_store.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/aligned_store.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE void operator() (const Vec& a0, Pointer a1) const BOOST_NOEXCEPT
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(Vec::alignment, a1)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(a1, Vec::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of double"
                       );
       _mm256_store_pd(a1,a0);
@@ -44,7 +44,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE void operator() (const Vec& a0, Pointer a1) const BOOST_NOEXCEPT
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(Vec::alignment, a1)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(a1, Vec::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of float"
                       );
       _mm256_store_ps(a1,a0);
@@ -60,7 +60,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE void operator() (const Vec& a0, Pointer a1) const BOOST_NOEXCEPT
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(Vec::alignment, a1)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(a1, Vec::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of integer"
                       );
        _mm256_store_si256(reinterpret_cast<__m256i*>(a1), a0);

--- a/include/boost/simd/arch/x86/avx2/simd/function/aligned_load.hpp
+++ b/include/boost/simd/arch/x86/avx2/simd/function/aligned_load.hpp
@@ -34,7 +34,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Pointer const& p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(target::alignment, p)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an "
                         "unaligned masked pointer of 32 bits integers"
                       );
@@ -56,7 +56,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Pointer const& p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(target::alignment, p)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an "
                         "unaligned masked pointer of 32 bits integers"
                       );
@@ -82,7 +82,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Pointer const& p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(target::alignment, p)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an "
                         "unaligned masked pointer of 64 bits integers"
                       );
@@ -104,7 +104,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Pointer const& p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(target::alignment, p)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an "
                         "unaligned masked pointer of 64 bits integers"
                       );

--- a/include/boost/simd/arch/x86/sse1/simd/function/aligned_load.hpp
+++ b/include/boost/simd/arch/x86/sse1/simd/function/aligned_load.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Pointer p, Target const&) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(target::alignment, p)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of float"
                       );
 

--- a/include/boost/simd/arch/x86/sse1/simd/function/aligned_store.hpp
+++ b/include/boost/simd/arch/x86/sse1/simd/function/aligned_store.hpp
@@ -29,7 +29,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE void operator() (const Vec& a0, Pointer a1) const BOOST_NOEXCEPT
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(Vec::alignment, a1)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(a1, Vec::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of integer"
                       );
       _mm_store_ps(a1,a0);

--- a/include/boost/simd/arch/x86/sse2/simd/function/aligned_load.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/aligned_load.hpp
@@ -34,7 +34,7 @@ namespace boost { namespace simd { namespace ext
     using target = typename Target::type;
     BOOST_FORCEINLINE target operator()(Pointer p, Target const&) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(target::alignment, p)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of double"
                       );
 
@@ -56,7 +56,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator() ( Pointer p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(target::alignment, p)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of integer"
                       );
 

--- a/include/boost/simd/arch/x86/sse2/simd/function/aligned_store.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/aligned_store.hpp
@@ -29,7 +29,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE void operator() (const Vec& a0, Pointer a1) const BOOST_NOEXCEPT
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(Vec::alignment, a1)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(a1, Vec::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of integer"
                       );
       _mm_store_pd(reinterpret_cast<double*>(a1),a0);
@@ -46,7 +46,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE void operator() (const Vec& a0, Pointer a1) const BOOST_NOEXCEPT
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(Vec::alignment, a1)
+      BOOST_ASSERT_MSG( boost::alignment::is_aligned(a1, Vec::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of integer"
                       );
        _mm_store_si128(reinterpret_cast<__m128i*>(a1), a0);


### PR DESCRIPTION
Fix boost::alignment use to fit the 1.61+ version. ALso 1.61 is definitevely enough.
