### PR TITLE
Fix #219  - Optimize split return type

### DIFF
--- a/include/boost/simd/arch/common/detail/simd/trig_reduction.hpp
+++ b/include/boost/simd/arch/common/detail/simd/trig_reduction.hpp
@@ -279,18 +279,19 @@ namespace boost { namespace simd
         // all of x are in [0, 2^18*pi],  conversion to double is used to reduce
         using uA0 = bd::upgrade_t<A0>;
         using aux_reduc_t = trig_reduction< uA0, tag::radian_tag,  tag::simd_type, mode, double>;
-        uA0 ux1, ux2, uxr1, uxr2;
-        std::tie(ux1, ux2) = split(x);
-        auto n1 = aux_reduc_t::reduce(ux1, uxr1);
-        auto n2 = aux_reduc_t::reduce(ux2, uxr2);
-        xr = group(uxr1, uxr2);
-        std::tie(ux1, ux2) = split(xr);
+
+        auto uxs = split(x);
+        uA0  uxr1, uxr2;
+
+        auto n1 = aux_reduc_t::reduce(uxs[0], uxr1);
+        auto n2 = aux_reduc_t::reduce(uxs[1], uxr2);
+
+          xr = group(uxr1, uxr2);
         return group(n1, n2);
       }
     };
 
   }
 } }
-
 
 #endif

--- a/include/boost/simd/arch/common/simd/function/correct_fma.hpp
+++ b/include/boost/simd/arch/common/simd/function/correct_fma.hpp
@@ -1,39 +1,28 @@
 //==================================================================================================
-/*!
-  @file
-
-  @copyright 2016 NumScale SAS
-  @copyright 2016 J.T. Lapreste
+/**
+  Copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #ifndef BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_CORRECT_FMA_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_CORRECT_FMA_HPP_INCLUDED
-#include <boost/simd/detail/overload.hpp>
 
-#include <boost/simd/meta/hierarchy/simd.hpp>
+#include <boost/simd/detail/overload.hpp>
 #include <boost/simd/function/simd/bitwise_cast.hpp>
 #include <boost/simd/function/simd/group.hpp>
-#include <boost/simd/function/simd/multiplies.hpp>
-#include <boost/simd/function/simd/plus.hpp>
 #include <boost/simd/function/simd/split.hpp>
 #include <boost/simd/function/simd/two_add.hpp>
 #include <boost/simd/function/simd/two_prod.hpp>
 #include <boost/simd/detail/dispatch/meta/as_integer.hpp>
-#include <boost/simd/detail/dispatch/meta/upgrade.hpp>
 #include <boost/simd/function/conformant.hpp>
-#include <tuple>
-#include <utility>
 
 #ifndef BOOST_SIMD_DONT_CARE_FMA_OVERFLOW
 #include <boost/simd/function/simd/exponent.hpp>
 #include <boost/simd/function/simd/ldexp.hpp>
 #include <boost/simd/function/simd/maxmag.hpp>
 #include <boost/simd/function/simd/minmag.hpp>
-#include <boost/simd/function/simd/shift_right.hpp>
-#include <boost/simd/function/simd/unary_minus.hpp>
 #endif
 
 namespace boost { namespace simd { namespace ext
@@ -53,12 +42,10 @@ namespace boost { namespace simd { namespace ext
       BOOST_FORCEINLINE A0 operator()( const conformant_tag &
                                      , const A0& a0, const A0& a1, const A0& a2) const BOOST_NOEXCEPT
       {
-        using ivtype = bd::upgrade_t<A0>;
-        ivtype a0l, a0h, a1l, a1h, a2l, a2h;
-        std::tie(a0l, a0h) = split(a0);
-        std::tie(a1l, a1h) = split(a1);
-        std::tie(a2l, a2h) = split(a2);
-        return group(a0l*a1l+a2l, a0h*a1h+a2h);
+        auto s0 = split(a0);
+        auto s1 = split(a1);
+        auto s2 = split(a2);
+        return group(s0[0]*s1[0]+s2[0], s0[1]*s1[1]+s2[1]);
       }
    };
 
@@ -129,9 +116,6 @@ namespace boost { namespace simd { namespace ext
         return a0*a1+a2;
       }
    };
-
 } } }
 
-
 #endif
-

--- a/include/boost/simd/arch/common/simd/function/divceil.hpp
+++ b/include/boost/simd/arch/common/simd/function/divceil.hpp
@@ -1,28 +1,22 @@
 //==================================================================================================
-/*!
-  @file
-
-  @copyright 2016 NumScale SAS
-  @copyright 2016 J.T. Lapreste
+/**
+  Copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #ifndef BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_DIVCEIL_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_DIVCEIL_HPP_INCLUDED
-#include <boost/simd/detail/overload.hpp>
 
+#include <boost/simd/detail/overload.hpp>
 #include <boost/simd/meta/hierarchy/simd.hpp>
 #include <boost/simd/function/simd/ceil.hpp>
-#include <boost/simd/function/simd/divides.hpp>
 #include <boost/simd/function/simd/group.hpp>
 #include <boost/simd/function/simd/split.hpp>
 #include <boost/simd/function/simd/tofloat.hpp>
 #include <boost/simd/function/simd/toint.hpp>
 #include <boost/simd/function/simd/touint.hpp>
-#include <boost/simd/detail/dispatch/meta/upgrade.hpp>
-#include <utility>
 
 namespace boost { namespace simd { namespace ext
 {
@@ -41,12 +35,10 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE A0 operator()( bd::functor<bs::tag::ceil_> const&
                                    , const A0& a0, const A0& a1) const BOOST_NOEXCEPT
     {
-      using ivtype = bd::upgrade_t<A0>;
-      ivtype a0l, a0h, a1l, a1h;
-      std::tie(a0l, a0h) = bs::split(a0);
-      std::tie(a1l, a1h) = bs::split(a1);
-      ivtype d0 = saturated_(toint)(div(ceil, tofloat(a0l), tofloat(a1l)));
-      ivtype d1 = saturated_(toint)(div(ceil, tofloat(a0h), tofloat(a1h)));
+      auto s0 = bs::split(a0);
+      auto s1 = bs::split(a1);
+      auto d0 = saturated_(toint)(div(ceil, tofloat(s0[0]), tofloat(s1[0])));
+      auto d1 = saturated_(toint)(div(ceil, tofloat(s0[1]), tofloat(s1[1])));
       return saturated_(group)(d0, d1);
     }
   };
@@ -63,12 +55,10 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE A0 operator()( bd::functor<bs::tag::ceil_> const&
                                    , const A0& a0, const A0& a1) const BOOST_NOEXCEPT
     {
-      using ivtype = bd::upgrade_t<A0>;
-      ivtype a0l, a0h, a1l, a1h;
-      std::tie(a0l, a0h) = bs::split(a0);
-      std::tie(a1l, a1h) = bs::split(a1);
-      ivtype d0 = saturated_(touint)(div(ceil, tofloat(a0l), tofloat(a1l)));
-      ivtype d1 = saturated_(touint)(div(ceil, tofloat(a0h), tofloat(a1h)));
+      auto s0 = bs::split(a0);
+      auto s1 = bs::split(a1);
+      auto d0 = saturated_(touint)(div(ceil, tofloat(s0[0]), tofloat(s1[0])));
+      auto d1 = saturated_(touint)(div(ceil, tofloat(s0[1]), tofloat(s1[1])));
       return saturated_(group)(d0, d1);
     }
   };
@@ -84,12 +74,10 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE A0 operator()( bd::functor<bs::tag::ceil_> const&
                                    , const A0& a0, const A0& a1) const BOOST_NOEXCEPT
     {
-      using ivtype = bd::upgrade_t<A0>;
-      ivtype a0l, a0h, a1l, a1h;
-      std::tie(a0l, a0h) = bs::split(a0);
-      std::tie(a1l, a1h) = bs::split(a1);
-      ivtype d0 = div(ceil, a0l, a1l);
-      ivtype d1 = div(ceil, a0h, a1h);
+      auto s0 = bs::split(a0);
+      auto s1 = bs::split(a1);
+      auto d0 = div(ceil, s0[0], s1[0]);
+      auto d1 = div(ceil, s0[1], s1[1]);
       return saturated_(group)(d0, d1);
     }
   };
@@ -108,8 +96,6 @@ namespace boost { namespace simd { namespace ext
       return bs::ceil(a0/a1);
     }
   };
-
 } } }
 
 #endif
-

--- a/include/boost/simd/arch/common/simd/function/divfix.hpp
+++ b/include/boost/simd/arch/common/simd/function/divfix.hpp
@@ -1,28 +1,22 @@
 //==================================================================================================
-/*!
-  @file
-
-  @copyright 2016 NumScale SAS
-  @copyright 2016 J.T. Lapreste
+/**
+  Copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #ifndef BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_DIVFIX_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_DIVFIX_HPP_INCLUDED
-#include <boost/simd/detail/overload.hpp>
 
+#include <boost/simd/detail/overload.hpp>
 #include <boost/simd/meta/hierarchy/simd.hpp>
-#include <boost/simd/function/simd/divides.hpp>
 #include <boost/simd/function/simd/group.hpp>
 #include <boost/simd/function/simd/split.hpp>
 #include <boost/simd/function/simd/tofloat.hpp>
 #include <boost/simd/function/simd/toint.hpp>
 #include <boost/simd/function/simd/touint.hpp>
 #include <boost/simd/function/simd/fix.hpp>
-#include <boost/simd/detail/dispatch/meta/upgrade.hpp>
-#include <utility>
 
 namespace boost { namespace simd { namespace ext
 {
@@ -39,12 +33,10 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE A0 operator()( const A0& a0, const A0& a1) const BOOST_NOEXCEPT
     {
-      using ivtype = bd::upgrade_t<A0>;
-      ivtype a0l, a0h, a1l, a1h;
-      std::tie(a0l, a0h) = bs::split(a0);
-      std::tie(a1l, a1h) = bs::split(a1);
-      ivtype d0 = saturated_(toint)(div(fix, tofloat(a0l), tofloat(a1l)));
-      ivtype d1 = saturated_(toint)(div(fix, tofloat(a0h), tofloat(a1h)));
+      auto s0 = bs::split(a0);
+      auto s1 = bs::split(a1);
+      auto d0 = saturated_(toint)(div(fix, tofloat(s0[0]), tofloat(s1[0])));
+      auto d1 = saturated_(toint)(div(fix, tofloat(s0[1]), tofloat(s1[1])));
       return saturated_(group)(d0, d1);
     }
   };
@@ -59,12 +51,10 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE A0 operator()( const A0& a0, const A0& a1) const BOOST_NOEXCEPT
     {
-      using ivtype = bd::upgrade_t<A0>;
-      ivtype a0l, a0h, a1l, a1h;
-      std::tie(a0l, a0h) = bs::split(a0);
-      std::tie(a1l, a1h) = bs::split(a1);
-      ivtype d0 = saturated_(touint)(div(fix, tofloat(a0l), tofloat(a1l)));
-      ivtype d1 = saturated_(touint)(div(fix, tofloat(a0h), tofloat(a1h)));
+      auto s0 = bs::split(a0);
+      auto s1 = bs::split(a1);
+      auto d0 = saturated_(touint)(div(fix, tofloat(s0[0]), tofloat(s1[0])));
+      auto d1 = saturated_(touint)(div(fix, tofloat(s0[1]), tofloat(s1[1])));
       return saturated_(group)(d0, d1);
     }
   };
@@ -78,12 +68,10 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE A0 operator()( const A0& a0, const A0& a1) const BOOST_NOEXCEPT
     {
-      using ivtype = bd::upgrade_t<A0>;
-      ivtype a0l, a0h, a1l, a1h;
-      std::tie(a0l, a0h) = bs::split(a0);
-      std::tie(a1l, a1h) = bs::split(a1);
-      ivtype d0 = div(fix, a0l, a1l);
-      ivtype d1 = div(fix, a0h, a1h);
+      auto s0 = bs::split(a0);
+      auto s1 = bs::split(a1);
+      auto d0 = div(fix, s0[0], s1[0]);
+      auto d1 = div(fix, s0[1], s1[1]);
       return saturated_(group)(d0, d1);
     }
   };
@@ -102,8 +90,6 @@ namespace boost { namespace simd { namespace ext
       return bs::trunc(a0/a1);
     }
   };
-
 } } }
 
 #endif
-

--- a/include/boost/simd/arch/common/simd/function/divfloor.hpp
+++ b/include/boost/simd/arch/common/simd/function/divfloor.hpp
@@ -1,28 +1,21 @@
 //==================================================================================================
-/*!
-  @file
-
-  @copyright 2016 NumScale SAS
-  @copyright 2016 J.T. Lapreste
+/**
+  Copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #ifndef BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_DIVFLOOR_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_DIVFLOOR_HPP_INCLUDED
-#include <boost/simd/detail/overload.hpp>
 
-#include <boost/simd/meta/hierarchy/simd.hpp>
-#include <boost/simd/function/simd/divides.hpp>
+#include <boost/simd/detail/overload.hpp>
 #include <boost/simd/function/simd/floor.hpp>
 #include <boost/simd/function/simd/group.hpp>
 #include <boost/simd/function/simd/split.hpp>
 #include <boost/simd/function/simd/tofloat.hpp>
 #include <boost/simd/function/simd/toint.hpp>
 #include <boost/simd/function/simd/touint.hpp>
-#include <boost/simd/detail/dispatch/meta/upgrade.hpp>
-#include <utility>
 
 namespace boost { namespace simd { namespace ext
 {
@@ -41,12 +34,10 @@ namespace boost { namespace simd { namespace ext
      BOOST_FORCEINLINE A0 operator()( bd::functor<bs::tag::floor_> const&
                                     ,  const A0& a0, const A0& a1) const BOOST_NOEXCEPT
      {
-       using ivtype = bd::upgrade_t<A0>;
-       ivtype a0l, a0h, a1l, a1h;
-       std::tie(a0l, a0h) = bs::split(a0);
-       std::tie(a1l, a1h) = bs::split(a1);
-       ivtype d0 = saturated_(toint)(div(floor,tofloat(a0l), tofloat(a1l)));
-       ivtype d1 = saturated_(toint)(div(floor,tofloat(a0h), tofloat(a1h)));
+       auto s0 = bs::split(a0);
+       auto s1 = bs::split(a1);
+       auto d0 = saturated_(toint)(div(floor,tofloat(s0[0]), tofloat(s1[0])));
+       auto d1 = saturated_(toint)(div(floor,tofloat(s0[1]), tofloat(s1[1])));
        return saturated_(group)(d0, d1);
      }
    };
@@ -63,12 +54,10 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE A0 operator()( bd::functor<bs::tag::floor_> const&
                                    ,  const A0& a0, const A0& a1) const BOOST_NOEXCEPT
     {
-      using ivtype = bd::upgrade_t<A0>;
-      ivtype a0l, a0h, a1l, a1h;
-      std::tie(a0l, a0h) = bs::split(a0);
-      std::tie(a1l, a1h) = bs::split(a1);
-      ivtype d0 = saturated_(touint)(div(floor,tofloat(a0l), tofloat(a1l)));
-      ivtype d1 =saturated_(touint)(div(floor,tofloat(a0h), tofloat(a1h)));
+      auto s0 = bs::split(a0);
+      auto s1 = bs::split(a1);
+      auto d0 = saturated_(touint)(div(floor,tofloat(s0[0]), tofloat(s1[0])));
+      auto d1 =saturated_(touint)(div(floor,tofloat(s0[1]), tofloat(s1[1])));
       return saturated_(group)(d0, d1);
     }
   };
@@ -84,12 +73,10 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE A0 operator()( bd::functor<bs::tag::floor_> const&
                                    ,  const A0& a0, const A0& a1) const BOOST_NOEXCEPT
     {
-      using ivtype = bd::upgrade_t<A0>;
-      ivtype a0l, a0h, a1l, a1h;
-      std::tie(a0l, a0h) = bs::split(a0);
-      std::tie(a1l, a1h) = bs::split(a1);
-      ivtype d0 = div(floor,a0l, a1l);
-      ivtype d1 = div(floor,a0h, a1h);
+      auto s0 = bs::split(a0);
+      auto s1 = bs::split(a1);
+      auto d0 = div(floor,s0[0], s1[0]);
+      auto d1 = div(floor,s0[1], s1[1]);
       return saturated_(group)(d0, d1);
     }
   };
@@ -108,8 +95,6 @@ namespace boost { namespace simd { namespace ext
       return bs::floor(a0/a1);
     }
   };
-
 } } }
 
 #endif
-

--- a/include/boost/simd/arch/common/simd/function/divnearbyint.hpp
+++ b/include/boost/simd/arch/common/simd/function/divnearbyint.hpp
@@ -1,52 +1,27 @@
 //==================================================================================================
-/*!
-  @file
-
-  @copyright 2016 NumScale SAS
-  @copyright 2016 J.T. Lapreste
+/**
+  Copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #ifndef BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_DIVNEARBYINT_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_DIVNEARBYINT_HPP_INCLUDED
-#include <boost/simd/detail/overload.hpp>
 
-#include <boost/simd/meta/hierarchy/simd.hpp>
-#include <boost/simd/function/simd/divides.hpp>
+#include <boost/simd/detail/overload.hpp>
 #include <boost/simd/function/simd/group.hpp>
 #include <boost/simd/function/simd/nearbyint.hpp>
 #include <boost/simd/function/simd/split.hpp>
 #include <boost/simd/function/simd/tofloat.hpp>
 #include <boost/simd/function/simd/toint.hpp>
 #include <boost/simd/function/simd/touint.hpp>
-#include <boost/simd/detail/dispatch/meta/upgrade.hpp>
-#include <utility>
 
 namespace boost { namespace simd { namespace ext
 {
   namespace bd = boost::dispatch;
   namespace bs = boost::simd;
-  BOOST_DISPATCH_OVERLOAD(div_
-                         , (typename A0, typename X)
-                         , bd::cpu_
-                         , bs::tag::nearbyint_
-                         , bs::pack_<bd::arithmetic_<A0>, X>
-                         , bs::pack_<bd::arithmetic_<A0>, X>
-                         )
-  {
-    BOOST_FORCEINLINE A0 operator()( bd::functor<bs::tag::nearbyint_> const&
-                                   , const A0& a0, const A0& a1) const BOOST_NOEXCEPT
-    {
-      A0 r;
-      for(unsigned int i=0; i <A0::static_size ; i++)
-      {
-        r[i] = div(nearbyint, a0[i], a1[i]);
-      }
-      return r;
-    }
-  };
+
   BOOST_DISPATCH_OVERLOAD_IF(div_
                             , (typename A0, typename X)
                             , (bd::is_upgradable<A0>)
@@ -59,12 +34,10 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE A0 operator()(  bd::functor<bs::tag::nearbyint_> const&
                                    ,  const A0& a0, const A0& a1) const BOOST_NOEXCEPT
     {
-      using ivtype = bd::upgrade_t<A0>;
-      ivtype a0l, a0h, a1l, a1h;
-      std::tie(a0l, a0h) = bs::split(a0);
-      std::tie(a1l, a1h) = bs::split(a1);
-      ivtype d0 = saturated_(toint)(div(nearbyint, tofloat(a0l), tofloat(a1l)));
-      ivtype d1 = saturated_(toint)(div(nearbyint, tofloat(a0h), tofloat(a1h)));
+      auto s0 = bs::split(a0);
+      auto s1 = bs::split(a1);
+      auto d0 = saturated_(toint)(div(nearbyint, tofloat(s0[0]), tofloat(s1[0])));
+      auto d1 = saturated_(toint)(div(nearbyint, tofloat(s0[1]), tofloat(s1[1])));
       return saturated_(group)(d0, d1);
     }
   };
@@ -81,12 +54,15 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE A0 operator()(  bd::functor<bs::tag::nearbyint_> const&
                                    ,  const A0& a0, const A0& a1) const BOOST_NOEXCEPT
     {
-      using ivtype = bd::upgrade_t<A0>;
-      ivtype a0l, a0h, a1l, a1h;
-      std::tie(a0l, a0h) = bs::split(a0);
-      std::tie(a1l, a1h) = bs::split(a1);
-      ivtype d0 = saturated_(touint)(div(nearbyint, tofloat(a0l), tofloat(a1l)));
-      ivtype d1 = saturated_(touint)(div(nearbyint, tofloat(a0h), tofloat(a1h)));
+      // This version generated better code on MSVC
+      auto s0 = bs::split_low(a0);
+      auto s1 = bs::split_low(a1);
+      auto d0 = saturated_(touint)(div(nearbyint, tofloat(s0), tofloat(s1)));
+
+      s0 = bs::split_high(a0);
+      s1 = bs::split_high(a1);
+      auto d1 = saturated_(touint)(div(nearbyint, tofloat(s0), tofloat(s1)));
+
       return saturated_(group)(d0, d1);
     }
   };
@@ -102,12 +78,10 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE A0 operator()(  bd::functor<bs::tag::nearbyint_> const&
                                    ,   const A0& a0, const A0& a1) const BOOST_NOEXCEPT
     {
-      using ivtype = bd::upgrade_t<A0>;
-      ivtype a0l, a0h, a1l, a1h;
-      std::tie(a0l, a0h) = bs::split(a0);
-      std::tie(a1l, a1h) = bs::split(a1);
-      ivtype d0 = div(nearbyint, a0l, a1l);
-      ivtype d1 = div(nearbyint, a0h, a1h);
+      auto s0 = bs::split(a0);
+      auto s1 = bs::split(a1);
+      auto d0 = div(nearbyint, s0[0], s1[0]);
+      auto d1 = div(nearbyint, s0[1], s1[1]);
       return saturated_(group)(d0, d1);
     }
   };
@@ -126,8 +100,6 @@ namespace boost { namespace simd { namespace ext
       return bs::nearbyint(a0/a1);
     }
   };
-
 } } }
 
 #endif
-

--- a/include/boost/simd/arch/common/simd/function/divround.hpp
+++ b/include/boost/simd/arch/common/simd/function/divround.hpp
@@ -1,52 +1,26 @@
 //==================================================================================================
-/*!
-  @file
-
-  @copyright 2016 NumScale SAS
-  @copyright 2016 J.T. Lapreste
+/**
+  Copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #ifndef BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_DIVROUND_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_DIVROUND_HPP_INCLUDED
-#include <boost/simd/detail/overload.hpp>
 
-#include <boost/simd/meta/hierarchy/simd.hpp>
-#include <boost/simd/function/simd/divides.hpp>
+#include <boost/simd/detail/overload.hpp>
 #include <boost/simd/function/simd/group.hpp>
 #include <boost/simd/function/simd/round.hpp>
 #include <boost/simd/function/simd/split.hpp>
 #include <boost/simd/function/simd/tofloat.hpp>
 #include <boost/simd/function/simd/toint.hpp>
 #include <boost/simd/function/simd/touint.hpp>
-#include <boost/simd/detail/dispatch/meta/upgrade.hpp>
-#include <utility>
 
 namespace boost { namespace simd { namespace ext
 {
   namespace bd = boost::dispatch;
   namespace bs = boost::simd;
-  BOOST_DISPATCH_OVERLOAD(div_
-                         , (typename A0, typename X)
-                         , bd::cpu_
-                         , bs::tag::round_
-                         , bs::pack_<bd::arithmetic_<A0>, X>
-                         , bs::pack_<bd::arithmetic_<A0>, X>
-                         )
-  {
-    BOOST_FORCEINLINE A0 operator()( bd::functor<bs::tag::round_> const&
-                                   , const A0& a0, const A0& a1) const BOOST_NOEXCEPT
-    {
-      A0 r;
-      for(unsigned int i=0; i <A0::static_size ; i++)
-      {
-        r[i] = div(round, a0[i], a1[i]);
-      }
-      return r;
-    }
-  };
 
   BOOST_DISPATCH_OVERLOAD_IF(div_
                             , (typename A0, typename X)
@@ -60,12 +34,10 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE A0 operator()( bd::functor<bs::tag::round_> const&
                                    ,  const A0& a0, const A0& a1) const BOOST_NOEXCEPT
     {
-      using ivtype = bd::upgrade_t<A0>;
-      ivtype a0l, a0h, a1l, a1h;
-      std::tie(a0l, a0h) = bs::split(a0);
-      std::tie(a1l, a1h) = bs::split(a1);
-      ivtype d0 = saturated_(toint)(div(round, tofloat(a0l), tofloat(a1l)));
-      ivtype d1 = saturated_(toint)(div(round, tofloat(a0h), tofloat(a1h)));
+      auto s0 = bs::split(a0);
+      auto s1 = bs::split(a1);
+      auto d0 = saturated_(toint)(div(round, tofloat(s0[0]), tofloat(s1[0])));
+      auto d1 = saturated_(toint)(div(round, tofloat(s0[1]), tofloat(s1[1])));
       return saturated_(group)(d0, d1);
     }
   };
@@ -82,12 +54,10 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE A0 operator()( bd::functor<bs::tag::round_> const&
                                    ,  const A0& a0, const A0& a1) const BOOST_NOEXCEPT
     {
-      using ivtype = bd::upgrade_t<A0>;
-      ivtype a0l, a0h, a1l, a1h;
-      std::tie(a0l, a0h) = bs::split(a0);
-      std::tie(a1l, a1h) = bs::split(a1);
-      ivtype d0 = saturated_(touint)(div(round, tofloat(a0l), tofloat(a1l)));
-      ivtype d1 = saturated_(touint)(div(round, tofloat(a0h), tofloat(a1h)));
+      auto s0 = bs::split(a0);
+      auto s1 = bs::split(a1);
+      auto d0 = saturated_(touint)(div(round, tofloat(s0[0]), tofloat(s1[0])));
+      auto d1 = saturated_(touint)(div(round, tofloat(s0[1]), tofloat(s1[1])));
       return saturated_(group)(d0, d1);
     }
   };
@@ -103,12 +73,10 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE A0 operator()( bd::functor<bs::tag::round_> const&
                                    ,  const A0& a0, const A0& a1) const BOOST_NOEXCEPT
     {
-      using ivtype = bd::upgrade_t<A0>;
-      ivtype a0l, a0h, a1l, a1h;
-      std::tie(a0l, a0h) = bs::split(a0);
-      std::tie(a1l, a1h) = bs::split(a1);
-      ivtype d0 = div(round, a0l, a1l);
-      ivtype d1 = div(round, a0h, a1h);
+      auto s0 = bs::split(a0);
+      auto s1 = bs::split(a1);
+      auto d0 = div(round, s0[0], s1[0]);
+      auto d1 = div(round, s0[1], s1[1]);
       return saturated_(group)(d0, d1);
     }
   };
@@ -127,9 +95,6 @@ namespace boost { namespace simd { namespace ext
       return simd::round(a0/a1);
     }
   };
-
 } } }
 
-
 #endif
-

--- a/include/boost/simd/arch/common/simd/function/split.hpp
+++ b/include/boost/simd/arch/common/simd/function/split.hpp
@@ -13,7 +13,7 @@
 #include <boost/simd/detail/overload.hpp>
 #include <boost/simd/function/simd/split_high.hpp>
 #include <boost/simd/function/simd/split_low.hpp>
-#include <utility>
+#include <array>
 
 namespace boost { namespace simd { namespace ext
 {
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                             , bs::pack_<bd::unspecified_<A0>, X>
                             )
   {
-    using result_t = std::pair<bd::upgrade_t<A0>,bd::upgrade_t<A0>>;
+    using result_t = std::array<bd::upgrade_t<A0>,2>;
 
     BOOST_FORCEINLINE result_t operator()(A0 const& a) const BOOST_NOEXCEPT
     {

--- a/include/boost/simd/arch/common/simd/function/split_multiplies.hpp
+++ b/include/boost/simd/arch/common/simd/function/split_multiplies.hpp
@@ -1,7 +1,6 @@
 //==================================================================================================
 /**
   Copyright 2016 NumScale SAS
-  Copyright 2016 J.T. Lapreste
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
@@ -11,10 +10,7 @@
 #define BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_SPLIT_MULTIPLIES_HPP_INCLUDED
 
 #include <boost/simd/detail/overload.hpp>
-#include <boost/simd/function/multiplies.hpp>
 #include <boost/simd/function/split.hpp>
-#include <boost/simd/detail/dispatch/meta/upgrade.hpp>
-#include <utility>
 
 namespace boost { namespace simd { namespace ext
 {
@@ -36,7 +32,7 @@ namespace boost { namespace simd { namespace ext
       auto s0 = split(a0);
       auto s1 = split(a1);
 
-      return { s0.first*s1.first, s0.second*s1.second };
+      return { s0[0]*s1[0], s0[1]*s1[1] };
     }
   };
 } } }

--- a/include/boost/simd/arch/x86/avx/simd/function/split_high.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/split_high.hpp
@@ -35,7 +35,7 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE bd::upgrade_t<A0> operator()(const A0 & a0) const BOOST_NOEXCEPT
     {
       auto half = split(slice_high(a0));
-      return combine(half.first,half.second);
+      return combine(half[0],half[1]);
     }
   };
 } } }

--- a/include/boost/simd/arch/x86/avx/simd/function/split_low.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/split_low.hpp
@@ -37,7 +37,7 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE bd::upgrade_t<A0> operator()(const A0 & a0) const BOOST_NOEXCEPT
     {
       auto half = split(slice_low(a0));
-      return combine(half.first,half.second);
+      return combine(half[0],half[1]);
     }
   };
 } } }

--- a/include/boost/simd/arch/x86/avx2/simd/function/group.hpp
+++ b/include/boost/simd/arch/x86/avx2/simd/function/group.hpp
@@ -12,7 +12,7 @@
 #include <boost/simd/detail/overload.hpp>
 #include <boost/simd/constant/constant.hpp>
 #include <boost/simd/function/simd/bitwise_cast.hpp>
-#include <boost/simd/function/simd/shift_right.hpp>
+#include <boost/simd/function/simd/shr.hpp>
 #include <boost/simd/function/saturated.hpp>
 #include <boost/simd/detail/dispatch/meta/downgrade.hpp>
 
@@ -47,8 +47,8 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE bd::downgrade_t<A0>
     operator()(const saturated_tag &,const A0 & a0, const A0 & a1 ) const BOOST_NOEXCEPT
     {
-      return _mm256_permute4x64_epi64(_mm256_packus_epi16( (a0 & 0x7FFF) | shri(a0 & 0xF000, 1)
-                                                         , (a1 & 0x7FFF) | shri(a1 & 0xF000, 1)
+      return _mm256_permute4x64_epi64(_mm256_packus_epi16( (a0 & 0x7FFF) | shr(a0 & 0xF000, 1)
+                                                         , (a1 & 0x7FFF) | shr(a1 & 0xF000, 1)
                                                          )
                                      , 0xD8
                                      );
@@ -81,8 +81,8 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE bd::downgrade_t<A0>
     operator()(const saturated_tag &,const A0 & a0, const A0 & a1 ) const BOOST_NOEXCEPT
     {
-      return _mm256_permute4x64_epi64(_mm256_packus_epi32( (a0 & 0x7FFFFFFF) | shri(a0 & 0xF0000000, 1)
-                                                         , (a1 & 0x7FFFFFFF) | shri(a1 & 0xF0000000, 1)
+      return _mm256_permute4x64_epi64(_mm256_packus_epi32( (a0 & 0x7FFFFFFF) | shr(a0 & 0xF0000000, 1)
+                                                         , (a1 & 0x7FFFFFFF) | shr(a1 & 0xF0000000, 1)
                                                          )
                                      , 0xD8
                                      );

--- a/include/boost/simd/arch/x86/sse2/simd/function/ilogb.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/ilogb.hpp
@@ -94,11 +94,8 @@ namespace boost { namespace simd { namespace ext
     using result = bd::as_integer_t<A0>;
     BOOST_FORCEINLINE result operator() ( const A0 & a0)
     {
-      using up_t = detail::make_dependent_t<uint32_t,A0>;
-      using gen_t = pack<up_t, A0::static_size/2>;
-      gen_t a0h, a0l;
-      std::tie(a0l, a0h) = split(a0);
-      return bitwise_cast<result>(group(ilogb(a0l), ilogb(a0h)));
+      auto s0 = split(a0);
+      return bitwise_cast<result>(group(ilogb(s0[0]), ilogb(s0[1])));
     }
   };
   BOOST_DISPATCH_OVERLOAD ( ilogb_

--- a/include/boost/simd/arch/x86/sse2/simd/function/shift_right.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/shift_right.hpp
@@ -131,7 +131,7 @@ namespace boost { namespace simd { namespace ext
     {
       BOOST_ASSERT_MSG(assert_good_shift<A0>(a1), "shift_right sse2 int8: a shift is out of range");
       auto s = split(a0);
-      return bitwise_cast<A0>(group(shift_right(s.first, a1), shift_right(s.second, a1)));
+      return bitwise_cast<A0>(group(shift_right(s[0], a1), shift_right(s[1], a1)));
     }
   };
 

--- a/include/boost/simd/function/split.hpp
+++ b/include/boost/simd/function/split.hpp
@@ -17,13 +17,14 @@ namespace boost { namespace simd
     @ingroup group-swar
     Function object implementing split capabilities
 
-    SIMD register type-based split
+    Split a SIMD register @c x in two SIMD registers of half the
+    cardinal of @c x containing the same value than @c x but converted to
+    their associated upgraded type.
 
-    @c split splits a SIMD register @c x in two SIMD registers of half the
-    cardinal of @c x containing the same value than @c x but transtyped to
-    their associated scalar type.
+    @param v0 Value to split
+    @return An array containing the two upgraded part of its argument.
   **/
-  Value split(Value const & v0);
+  std::array<upgrade_t<Value>,2> split(Value const & v0);
 #endif
 } }
 

--- a/test/function/simd/split/arithmetic.pair.cpp
+++ b/test/function/simd/split/arithmetic.pair.cpp
@@ -33,10 +33,10 @@ void test( Env& $, std::true_type const& )
   bd::upgrade_t<bs::pack<T,N>>  refl  (&dref[0]     , &dref[0]+N/2  );
   bd::upgrade_t<bs::pack<T,N>>  refh  (&dref[0]+N/2 , &dref[0]+N    );
 
-  std::tie(valuel,valueh) = bs::split(value);
+  auto values = bs::split(value);
 
-  STF_EQUAL( valuel , refl);
-  STF_EQUAL( valueh , refh);
+  STF_EQUAL( values[0] , refl);
+  STF_EQUAL( values[1] , refh);
 }
 
 STF_CASE_TPL("split pack<T,N> into a pair of pack<T*2,N/2>", STF_NUMERIC_TYPES)

--- a/test/function/simd/split/logical.pair.cpp
+++ b/test/function/simd/split/logical.pair.cpp
@@ -34,10 +34,10 @@ void test( Env& $, std::true_type const& )
   bd::upgrade_t<bs::pack<bs::logical<T>,N>>  refl  (&dref[0]     , &dref[0]+N/2  );
   bd::upgrade_t<bs::pack<bs::logical<T>,N>>  refh  (&dref[0]+N/2 , &dref[0]+N    );
 
-  std::tie(valuel,valueh) = bs::split(value);
+  auto values = bs::split(value);
 
-  STF_EQUAL( valuel , refl);
-  STF_EQUAL( valueh , refh);
+  STF_EQUAL( values[0] , refl);
+  STF_EQUAL( values[1] , refh);
 }
 
 STF_CASE_TPL("split pack<T,N> into a pair of pack<T*2,N/2>", STF_NUMERIC_TYPES)


### PR DESCRIPTION
By making split return an array of 2 upgraded values, it can be used in a simpler way to buy aggregate registers. This patch also correct all usage of split and fix related issues.
