### PR TITLE
Fix #167 - Implement runtime ISA detection

### DIFF
--- a/include/boost/simd/arch/ppc/vmx/tags.hpp
+++ b/include/boost/simd/arch/ppc/vmx/tags.hpp
@@ -36,11 +36,7 @@ namespace boost { namespace simd
   {
     using parent = simd_;
 
-    vmx_() : support(detect()) {}
-
-    bool is_supported() const { return support; }
-
-    static bool detect()
+    vmx_()
     {
       #if BOOST_ARCH_PPC
         #if BOOST_OS_MACOS
@@ -51,14 +47,16 @@ namespace boost { namespace simd
           {
             hasAltiVec = ( 1 << gestaltPowerPCHasVectorInstructions) & cpuAttributes;
           }
-          return hasAltiVec;
+          support = hasAltiVec;
         #else
-          return detail::hwcap() & PPC_FEATURE_HAS_ALTIVEC;
+          support = detail::hwcap() & PPC_FEATURE_HAS_ALTIVEC;
         #endif
       #else
-        return false;
+        support = false;
       #endif
     }
+
+    bool is_supported() const { return support; }
 
     private:
     bool support;

--- a/include/boost/simd/arch/ppc/vmx/tags.hpp
+++ b/include/boost/simd/arch/ppc/vmx/tags.hpp
@@ -2,8 +2,6 @@
 /*!
   @file
 
-  Aggregates SIMD extension tags for PowerPC
-
   @copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
@@ -14,6 +12,17 @@
 #define BOOST_SIMD_ARCH_PPC_VMX_TAGS_HPP_INCLUDED
 
 #include <boost/simd/arch/common/tags.hpp>
+#include <boost/predef/architecture.h>
+#include <boost/predef/os.h>
+
+#if BOOST_ARCH_PPC
+  #if BOOST_OS_MACOS
+    #include <Gestalt.h>
+  #else
+    #include <boost/simd/detail/auxv.hpp>
+    #include <asm/cputable.h>
+  #endif
+#endif
 
 namespace boost { namespace simd
 {
@@ -23,7 +32,43 @@ namespace boost { namespace simd
 
     This tag represent architectures implementing the VMX SIMD instructions set.
   **/
-  struct vmx_ : simd_ { using parent = simd_; };
+  struct vmx_ : simd_
+  {
+    using parent = simd_;
+
+    vmx_() : support(detect()) {}
+
+    bool is_supported() const { return support; }
+
+    static bool detect()
+    {
+      #if BOOST_ARCH_PPC
+        #if BOOST_OS_MACOS
+          long cpuAttributes;
+          bool hasAltiVec = false;
+          OSErr err = Gestalt( gestaltPowerPCProcessorFeatures, &cpuAttributes );
+          if( noErr == err )
+          {
+            hasAltiVec = ( 1 << gestaltPowerPCHasVectorInstructions) & cpuAttributes;
+          }
+          return hasAltiVec;
+        #else
+          return detail::hwcap() & PPC_FEATURE_HAS_ALTIVEC;
+        #endif
+      #else
+        return false;
+      #endif
+    }
+
+    private:
+    bool support;
+  };
+
+  /*!
+    @ingroup  group-api
+    Global object for accessing VMX support informations
+  **/
+  static vmx_ const vmx = {};
 } }
 
 #endif

--- a/include/boost/simd/arch/x86/avx/tags.hpp
+++ b/include/boost/simd/arch/x86/avx/tags.hpp
@@ -2,8 +2,6 @@
 /*!
   @file
 
-  Aggregates SIMD extension tags for Intel X86 and AMD
-
   @copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
@@ -24,7 +22,33 @@ namespace boost { namespace simd
 
     This tag represent architectures implementing the Intel AVX SIMD instructions set.
   **/
-  struct avx_     : sse4_2_ { using parent = sse4_2_; };
+  struct avx_     : sse4_2_
+  {
+    using parent = sse4_2_;
+
+    avx_() : support(detect()) {}
+
+    bool is_supported() const { return support; }
+
+    static bool detect()
+    {
+      #if BOOST_ARCH_X86
+      return      detect_feature(28, 0x00000001, detail::ecx)
+              &&  detect_feature(27, 0x00000001, detail::ecx);
+      #else
+      return false;
+      #endif
+    }
+
+    private:
+    bool support;
+  };
+
+  /*!
+    @ingroup  group-api
+    Global object for accessing AVX support informations
+  **/
+  static avx_ const avx = {};
 
 } }
 

--- a/include/boost/simd/arch/x86/avx/tags.hpp
+++ b/include/boost/simd/arch/x86/avx/tags.hpp
@@ -26,19 +26,17 @@ namespace boost { namespace simd
   {
     using parent = sse4_2_;
 
-    avx_() : support(detect()) {}
-
-    bool is_supported() const { return support; }
-
-    static bool detect()
+    avx_()
     {
       #if BOOST_ARCH_X86
-      return      detect_feature(28, 0x00000001, detail::ecx)
-              &&  detect_feature(27, 0x00000001, detail::ecx);
+      support =     detect_feature(28, 0x00000001, detail::ecx)
+                &&  detect_feature(27, 0x00000001, detail::ecx);
       #else
-      return false;
+      support = false;
       #endif
     }
+
+    bool is_supported() const { return support; }
 
     private:
     bool support;

--- a/include/boost/simd/arch/x86/avx2/tags.hpp
+++ b/include/boost/simd/arch/x86/avx2/tags.hpp
@@ -28,19 +28,17 @@ namespace boost { namespace simd
   {
     using parent = fma3_;
 
-    avx2_() : support(detect()) {}
-
-    bool is_supported() const { return support; }
-
-    static bool detect()
+    avx2_()
     {
       #if BOOST_ARCH_X86
-      return      detect_features( (1<< 5)|(1<< 3)|(1<< 8), 0x00000007, detail::ebx)
+      support =   detect_features( (1<< 5)|(1<< 3)|(1<< 8), 0x00000007, detail::ebx)
               &&  detect_features( (1<<27)|(1<<22)|(1<<12), 0x00000001, detail::ecx);
       #else
-      return false;
+      support = false;
       #endif
     }
+
+    bool is_supported() const { return support; }
 
     private:
     bool support;

--- a/include/boost/simd/arch/x86/avx2/tags.hpp
+++ b/include/boost/simd/arch/x86/avx2/tags.hpp
@@ -24,7 +24,33 @@ namespace boost { namespace simd
 
     This tag represent architectures implementing the Intel AVX2 SIMD instructions set.
   **/
-  struct avx2_  : fma3_ { using parent = fma3_; };
+  struct avx2_  : fma3_
+  {
+    using parent = fma3_;
+
+    avx2_() : support(detect()) {}
+
+    bool is_supported() const { return support; }
+
+    static bool detect()
+    {
+      #if BOOST_ARCH_X86
+      return      detect_features( (1<< 5)|(1<< 3)|(1<< 8), 0x00000007, detail::ebx)
+              &&  detect_features( (1<<27)|(1<<22)|(1<<12), 0x00000001, detail::ecx);
+      #else
+      return false;
+      #endif
+    }
+
+    private:
+    bool support;
+  };
+
+  /*!
+    @ingroup  group-api
+    Global object for accessing AVX2 support informations
+  **/
+  static avx2_ const avx2 = {};
 
 } }
 

--- a/include/boost/simd/arch/x86/fma3/tags.hpp
+++ b/include/boost/simd/arch/x86/fma3/tags.hpp
@@ -21,7 +21,9 @@
 namespace boost { namespace simd
 {
 #ifdef BOOST_HW_SIMD_X86_AMD_AVAILABLE
-  struct fma3_ : xop_ { using parent = xop_; };
+  struct fma3_ : xop_
+  {
+    using parent = xop_;
 #else
   /*!
     @ingroup group-hierarchy
@@ -29,9 +31,34 @@ namespace boost { namespace simd
 
     This tag represent architectures implementing the AMD FMA3 SIMD instructions set.
   **/
-  struct fma3_ : avx_ { using parent = avx_; };
+  struct fma3_ : avx_
+  {
+    using parent = avx_;
 #endif
 
+    fma3_() : support(detect()) {}
+
+    bool is_supported() const { return support; }
+
+    static bool detect()
+    {
+      #if BOOST_ARCH_X86
+      return      detect_feature(12, 0x00000001, detail::ecx)
+              &&  detect_feature(27, 0x00000001, detail::ecx);
+      #else
+      return false;
+      #endif
+    }
+
+    private:
+    bool support;
+  };
+
+  /*!
+    @ingroup  group-api
+    Global object for accessing FMA3 support informations
+  **/
+  static fma3_ const fma3 = {};
 } }
 
 #endif

--- a/include/boost/simd/arch/x86/fma3/tags.hpp
+++ b/include/boost/simd/arch/x86/fma3/tags.hpp
@@ -36,19 +36,17 @@ namespace boost { namespace simd
     using parent = avx_;
 #endif
 
-    fma3_() : support(detect()) {}
-
-    bool is_supported() const { return support; }
-
-    static bool detect()
+    fma3_()
     {
       #if BOOST_ARCH_X86
-      return      detect_feature(12, 0x00000001, detail::ecx)
+      support =   detect_feature(12, 0x00000001, detail::ecx)
               &&  detect_feature(27, 0x00000001, detail::ecx);
       #else
-      return false;
+      support = false;
       #endif
     }
+
+    bool is_supported() const { return support; }
 
     private:
     bool support;

--- a/include/boost/simd/arch/x86/fma4/tags.hpp
+++ b/include/boost/simd/arch/x86/fma4/tags.hpp
@@ -24,7 +24,33 @@ namespace boost { namespace simd
 
     This tag represent architectures implementing the Intel FMA4 SIMD instructions set.
   **/
-  struct fma4_    : avx_    { using parent = avx_ ;   };
+  struct fma4_    : avx_
+  {
+    using parent = avx_ ;
+
+    fma4_() : support(detect()) {}
+
+    bool is_supported() const { return support; }
+
+    static bool detect()
+    {
+      #if BOOST_ARCH_X86
+      return      detect_feature(16, 0x80000001, detail::ecx)
+              &&  detect_feature(27, 0x80000001, detail::ecx);
+      #else
+      return false;
+      #endif
+    }
+
+    private:
+    bool support;
+  };
+
+  /*!
+    @ingroup  group-api
+    Global object for accessing FMA4 support informations
+  **/
+  static fma4_ const fma4 = {};
 
 } }
 

--- a/include/boost/simd/arch/x86/fma4/tags.hpp
+++ b/include/boost/simd/arch/x86/fma4/tags.hpp
@@ -28,19 +28,17 @@ namespace boost { namespace simd
   {
     using parent = avx_ ;
 
-    fma4_() : support(detect()) {}
-
-    bool is_supported() const { return support; }
-
-    static bool detect()
+    fma4_()
     {
       #if BOOST_ARCH_X86
-      return      detect_feature(16, 0x80000001, detail::ecx)
+      support =   detect_feature(16, 0x80000001, detail::ecx)
               &&  detect_feature(27, 0x80000001, detail::ecx);
       #else
-      return false;
+      support = false;
       #endif
     }
+
+    bool is_supported() const { return support; }
 
     private:
     bool support;

--- a/include/boost/simd/arch/x86/sse1/tags.hpp
+++ b/include/boost/simd/arch/x86/sse1/tags.hpp
@@ -2,8 +2,6 @@
 /*!
   @file
 
-  Aggregates SIMD extension tags for Intel X86 and AMD
-
   @copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
@@ -15,6 +13,7 @@
 #define BOOST_SIMD_ARCH_X86_SSE1_TAGS_HPP_INCLUDED
 
 #include <boost/simd/arch/common/tags.hpp>
+#include <boost/simd/detail/cpuid.hpp>
 
 namespace boost { namespace simd
 {
@@ -32,7 +31,32 @@ namespace boost { namespace simd
 
     This tag represent architectures implementing the Intel SSE1 SIMD instructions set.
   **/
-  struct sse1_   : simd_native_ { using parent = simd_native_; };
+  struct sse1_   : simd_native_
+  {
+    using parent = simd_native_;
+
+    sse1_() : support(detect()) {}
+
+    bool is_supported() const { return support; }
+
+    static bool detect()
+    {
+      #if BOOST_ARCH_X86
+      return detect_feature(25, 0x00000001, detail::edx);
+      #else
+      return false;
+      #endif
+    }
+
+    private:
+    bool support;
+  };
+
+  /*!
+    @ingroup  group-api
+    Global object for accessing SSE1 support informations
+  **/
+  static sse1_ const sse1 = {};
 } }
 
 #endif

--- a/include/boost/simd/arch/x86/sse1/tags.hpp
+++ b/include/boost/simd/arch/x86/sse1/tags.hpp
@@ -35,18 +35,16 @@ namespace boost { namespace simd
   {
     using parent = simd_native_;
 
-    sse1_() : support(detect()) {}
-
-    bool is_supported() const { return support; }
-
-    static bool detect()
+    sse1_()
     {
       #if BOOST_ARCH_X86
-      return detect_feature(25, 0x00000001, detail::edx);
+      support =  detect_feature(25, 0x00000001, detail::edx);
       #else
-      return false;
+      support = false;
       #endif
     }
+
+    bool is_supported() const { return support; }
 
     private:
     bool support;

--- a/include/boost/simd/arch/x86/sse2/tags.hpp
+++ b/include/boost/simd/arch/x86/sse2/tags.hpp
@@ -2,8 +2,6 @@
 /*!
   @file
 
-  Aggregates SIMD extension tags for Intel X86 and AMD
-
   @copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
@@ -15,6 +13,7 @@
 #define BOOST_SIMD_ARCH_X86_SSE2_TAGS_HPP_INCLUDED
 
 #include <boost/simd/arch/x86/sse1/tags.hpp>
+#include <boost/simd/detail/cpuid.hpp>
 
 namespace boost { namespace simd
 {
@@ -24,8 +23,32 @@ namespace boost { namespace simd
 
     This tag represent architectures implementing the Intel SSE2 SIMD instructions set.
   **/
-  struct sse2_  : sse1_  { using parent = sse1_ ; };
+  struct sse2_ : sse1_
+  {
+    using parent = sse1_ ;
 
+    sse2_() : support(detect()) {}
+
+    bool is_supported() const { return support; }
+
+    static bool detect()
+    {
+      #if BOOST_ARCH_X86
+      return detect_feature(26, 0x00000001, detail::edx);
+      #else
+      return false;
+      #endif
+    }
+
+    private:
+    bool support;
+  };
+
+  /*!
+    @ingroup  group-api
+    Global object for accessing SSE2 support informations
+  **/
+  static sse2_ const sse2 = {};
 
 } }
 

--- a/include/boost/simd/arch/x86/sse2/tags.hpp
+++ b/include/boost/simd/arch/x86/sse2/tags.hpp
@@ -27,18 +27,16 @@ namespace boost { namespace simd
   {
     using parent = sse1_ ;
 
-    sse2_() : support(detect()) {}
-
-    bool is_supported() const { return support; }
-
-    static bool detect()
+    sse2_()
     {
       #if BOOST_ARCH_X86
-      return detect_feature(26, 0x00000001, detail::edx);
+      support =  detect_feature(26, 0x00000001, detail::edx);
       #else
-      return false;
+      support =  false;
       #endif
     }
+
+    bool is_supported() const { return support; }
 
     private:
     bool support;

--- a/include/boost/simd/arch/x86/sse3/tags.hpp
+++ b/include/boost/simd/arch/x86/sse3/tags.hpp
@@ -2,8 +2,6 @@
 /*!
   @file
 
-  Aggregates SIMD extension tags for Intel X86 and AMD
-
   @copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
@@ -15,6 +13,7 @@
 #define BOOST_SIMD_ARCH_X86_SSE3_TAGS_HPP_INCLUDED
 
 #include <boost/simd/arch/x86/sse2/tags.hpp>
+#include <boost/simd/detail/cpuid.hpp>
 
 namespace boost { namespace simd
 {
@@ -24,7 +23,32 @@ namespace boost { namespace simd
 
     This tag represent architectures implementing the Intel SSE3 SIMD instructions set.
   **/
-  struct sse3_  : sse2_ { using parent = sse2_; };
+  struct sse3_  : sse2_
+  {
+    using parent = sse2_;
+
+    sse3_() : support(detect()) {}
+
+    bool is_supported() const { return support; }
+
+    static bool detect()
+    {
+      #if BOOST_ARCH_X86
+      return detect_feature(0, 0x00000001, detail::ecx);
+      #else
+      return false;
+      #endif
+    }
+
+    private:
+    bool support;
+  };
+
+  /*!
+    @ingroup  group-api
+    Global object for accessing SSE3 support informations
+  **/
+  static sse3_ const sse3 = {};
 
 } }
 

--- a/include/boost/simd/arch/x86/sse3/tags.hpp
+++ b/include/boost/simd/arch/x86/sse3/tags.hpp
@@ -27,18 +27,16 @@ namespace boost { namespace simd
   {
     using parent = sse2_;
 
-    sse3_() : support(detect()) {}
-
-    bool is_supported() const { return support; }
-
-    static bool detect()
+    sse3_()
     {
       #if BOOST_ARCH_X86
-      return detect_feature(0, 0x00000001, detail::ecx);
+      support =  detect_feature(0, 0x00000001, detail::ecx);
       #else
-      return false;
+      support =  false;
       #endif
     }
+
+    bool is_supported() const { return support; }
 
     private:
     bool support;

--- a/include/boost/simd/arch/x86/sse4_1/tags.hpp
+++ b/include/boost/simd/arch/x86/sse4_1/tags.hpp
@@ -2,8 +2,6 @@
 /*!
   @file
 
-  Aggregates SIMD extension tags for Intel X86 and AMD
-
   @copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
@@ -20,23 +18,44 @@
 
 namespace boost { namespace simd
 {
+  /*!
+    @ingroup group-hierarchy
+    @brief Intel SSE 4.1 SIMD architecture hierarchy tag
+
+    This tag represent architectures implementing the Intel SSE 4.1 SIMD instructions set.
+  **/
 #ifdef BOOST_HW_SIMD_X86_AMD_AVAILABLE
-  /*!
-    @ingroup group-hierarchy
-    @brief Intel SSE 4.1 SIMD architecture hierarchy tag
-
-    This tag represent architectures implementing the Intel SSE 4.1 SIMD instructions set.
-  **/
-  struct sse4_1_  : sse4a_  { using parent = sse4a_;  };
+    struct  sse4_1_ : sse4a_
+    {
+      using parent = sse4a_;
 #else
-  /*!
-    @ingroup group-hierarchy
-    @brief Intel SSE 4.1 SIMD architecture hierarchy tag
-
-    This tag represent architectures implementing the Intel SSE 4.1 SIMD instructions set.
-  **/
-  struct sse4_1_  : ssse3_  { using parent = ssse3_;  };
+    struct  sse4_1_ : ssse3_
+    {
+      using parent = ssse3_;
 #endif
+
+    sse4_1_() : support(detect()) {}
+
+    bool is_supported() const { return support; }
+
+    static bool detect()
+    {
+      #if BOOST_ARCH_X86
+      return detect_feature(19, 0x00000001, detail::ecx);
+      #else
+      return false;
+      #endif
+    }
+
+    private:
+    bool support;
+  };
+
+  /*!
+    @ingroup  group-api
+    Global object for accessing SSE4.1 support informations
+  **/
+  static sse4_1_ const sse4_1 = {};
 
 } }
 

--- a/include/boost/simd/arch/x86/sse4_1/tags.hpp
+++ b/include/boost/simd/arch/x86/sse4_1/tags.hpp
@@ -34,18 +34,16 @@ namespace boost { namespace simd
       using parent = ssse3_;
 #endif
 
-    sse4_1_() : support(detect()) {}
-
-    bool is_supported() const { return support; }
-
-    static bool detect()
+    sse4_1_()
     {
       #if BOOST_ARCH_X86
-      return detect_feature(19, 0x00000001, detail::ecx);
+      support =  detect_feature(19, 0x00000001, detail::ecx);
       #else
-      return false;
+      support =  false;
       #endif
     }
+
+    bool is_supported() const { return support; }
 
     private:
     bool support;

--- a/include/boost/simd/arch/x86/sse4_2/tags.hpp
+++ b/include/boost/simd/arch/x86/sse4_2/tags.hpp
@@ -2,8 +2,6 @@
 /*!
   @file
 
-  Aggregates SIMD extension tags for Intel X86 and AMD
-
   @copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
@@ -15,6 +13,7 @@
 #define BOOST_SIMD_ARCH_X86_SSE4_2_TAGS_HPP_INCLUDED
 
 #include <boost/simd/arch/x86/sse4_1/tags.hpp>
+#include <boost/simd/detail/cpuid.hpp>
 
 namespace boost { namespace simd
 {
@@ -24,7 +23,32 @@ namespace boost { namespace simd
 
     This tag represent architectures implementing the Intel SSE 4.2 SIMD instructions set.
   **/
-  struct sse4_2_  : sse4_1_ { using parent = sse4_1_; };
+  struct sse4_2_  : sse4_1_
+  {
+    using parent = sse4_1_;
+
+    sse4_2_() : support(detect()) {}
+
+    bool is_supported() const { return support; }
+
+    static bool detect()
+    {
+      #if BOOST_ARCH_X86
+      return detect_feature(20, 0x00000001, detail::ecx);
+      #else
+      return false;
+      #endif
+    }
+
+    private:
+    bool support;
+  };
+
+  /*!
+    @ingroup  group-api
+    Global object for accessing SSE4.2 support informations
+  **/
+  static sse4_2_ const sse4_2 = {};
 
 } }
 

--- a/include/boost/simd/arch/x86/sse4_2/tags.hpp
+++ b/include/boost/simd/arch/x86/sse4_2/tags.hpp
@@ -27,18 +27,16 @@ namespace boost { namespace simd
   {
     using parent = sse4_1_;
 
-    sse4_2_() : support(detect()) {}
-
-    bool is_supported() const { return support; }
-
-    static bool detect()
+    sse4_2_()
     {
       #if BOOST_ARCH_X86
-      return detect_feature(20, 0x00000001, detail::ecx);
+      support =  detect_feature(20, 0x00000001, detail::ecx);
       #else
-      return false;
+      support =  false;
       #endif
     }
+
+    bool is_supported() const { return support; }
 
     private:
     bool support;

--- a/include/boost/simd/arch/x86/sse4a/tags.hpp
+++ b/include/boost/simd/arch/x86/sse4a/tags.hpp
@@ -2,8 +2,6 @@
 /*!
   @file
 
-  Aggregates SIMD extension tags for Intel X86 and AMD
-
   @copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
@@ -15,6 +13,7 @@
 #define BOOST_SIMD_ARCH_X86_SSE4A_TAGS_HPP_INCLUDED
 
 #include <boost/simd/arch/x86/ssse3/tags.hpp>
+#include <boost/simd/detail/cpuid.hpp>
 
 namespace boost { namespace simd
 {
@@ -24,7 +23,32 @@ namespace boost { namespace simd
 
     This tag represent architectures implementing the AMD SSE 4A SIMD instructions set.
   **/
-  struct sse4a_ : ssse3_ { using parent = ssse3_; };
+  struct sse4a_ : ssse3_
+  {
+    using parent = ssse3_;
+
+    sse4a_() : support(detect()) {}
+
+    bool is_supported() const { return support; }
+
+    static bool detect()
+    {
+      #if BOOST_ARCH_X86
+      return detect_feature(6, 0x80000001, detail::ecx);
+      #else
+      return false;
+      #endif
+    }
+
+    private:
+    bool support;
+  };
+
+  /*!
+    @ingroup  group-api
+    Global object for accessing SSE4a support informations
+  **/
+  static sse4a_ const sse4a = {};
 
 } }
 

--- a/include/boost/simd/arch/x86/sse4a/tags.hpp
+++ b/include/boost/simd/arch/x86/sse4a/tags.hpp
@@ -27,18 +27,16 @@ namespace boost { namespace simd
   {
     using parent = ssse3_;
 
-    sse4a_() : support(detect()) {}
-
-    bool is_supported() const { return support; }
-
-    static bool detect()
+    sse4a_()
     {
       #if BOOST_ARCH_X86
-      return detect_feature(6, 0x80000001, detail::ecx);
+      support =  detect_feature(6, 0x80000001, detail::ecx);
       #else
-      return false;
+      support =  false;
       #endif
     }
+
+    bool is_supported() const { return support; }
 
     private:
     bool support;

--- a/include/boost/simd/arch/x86/ssse3/tags.hpp
+++ b/include/boost/simd/arch/x86/ssse3/tags.hpp
@@ -2,8 +2,6 @@
 /*!
   @file
 
-  Aggregates SIMD extension tags for Intel X86 and AMD
-
   @copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
@@ -15,6 +13,7 @@
 #define BOOST_SIMD_ARCH_X86_SSSE3_TAGS_HPP_INCLUDED
 
 #include <boost/simd/arch/x86/sse3/tags.hpp>
+#include <boost/simd/detail/cpuid.hpp>
 
 namespace boost { namespace simd
 {
@@ -24,7 +23,32 @@ namespace boost { namespace simd
 
     This tag represent architectures implementing the Intel Supplemental SSE3 SIMD instructions set.
   **/
-  struct ssse3_ : sse3_  { using parent = sse3_;  };
+  struct ssse3_ : sse3_
+  {
+    using parent = sse3_;
+
+    ssse3_() : support(detect()) {}
+
+    bool is_supported() const { return support; }
+
+    static bool detect()
+    {
+      #if BOOST_ARCH_X86
+      return detect_feature(9, 0x00000001, detail::ecx);
+      #else
+      return false;
+      #endif
+    }
+
+    private:
+    bool support;
+  };
+
+  /*!
+    @ingroup  group-api
+    Global object for accessing SSSE3 support informations
+  **/
+  static ssse3_ const ssse3 = {};
 
 } }
 

--- a/include/boost/simd/arch/x86/ssse3/tags.hpp
+++ b/include/boost/simd/arch/x86/ssse3/tags.hpp
@@ -27,18 +27,16 @@ namespace boost { namespace simd
   {
     using parent = sse3_;
 
-    ssse3_() : support(detect()) {}
-
-    bool is_supported() const { return support; }
-
-    static bool detect()
+    ssse3_()
     {
       #if BOOST_ARCH_X86
-      return detect_feature(9, 0x00000001, detail::ecx);
+      support =  detect_feature(9, 0x00000001, detail::ecx);
       #else
-      return false;
+      support =  false;
       #endif
     }
+
+    bool is_supported() const { return support; }
 
     private:
     bool support;

--- a/include/boost/simd/arch/x86/xop/tags.hpp
+++ b/include/boost/simd/arch/x86/xop/tags.hpp
@@ -24,8 +24,33 @@ namespace boost { namespace simd
 
     This tag represent architectures implementing the AMD XOP SIMD instructions set.
   **/
-  struct xop_     : fma4_   { using parent = fma4_;   };
+  struct xop_ : fma4_
+  {
+    using parent = fma4_;
 
+    xop_() : support(detect()) {}
+
+    bool is_supported() const { return support; }
+
+    static bool detect()
+    {
+      #if BOOST_ARCH_X86
+      return      detect_feature(11, 0x80000001, detail::ebx)
+              &&  detect_feature(27, 0x80000001, detail::ecx);
+      #else
+      return false;
+      #endif
+    }
+
+    private:
+    bool support;
+  };
+
+  /*!
+    @ingroup  group-api
+    Global object for accessing XOP support informations
+  **/
+  static xop_ const xop = {};
 } }
 
 #endif

--- a/include/boost/simd/arch/x86/xop/tags.hpp
+++ b/include/boost/simd/arch/x86/xop/tags.hpp
@@ -28,19 +28,17 @@ namespace boost { namespace simd
   {
     using parent = fma4_;
 
-    xop_() : support(detect()) {}
-
-    bool is_supported() const { return support; }
-
-    static bool detect()
+    xop_()
     {
       #if BOOST_ARCH_X86
-      return      detect_feature(11, 0x80000001, detail::ebx)
+      support =   detect_feature(11, 0x80000001, detail::ebx)
               &&  detect_feature(27, 0x80000001, detail::ecx);
       #else
-      return false;
+      support = false;
       #endif
     }
+
+    bool is_supported() const { return support; }
 
     private:
     bool support;

--- a/include/boost/simd/detail/auxv.hpp
+++ b/include/boost/simd/detail/auxv.hpp
@@ -1,0 +1,44 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_DETAIL_AUXV_HPP_INCLUDED
+#define BOOST_SIMD_DETAIL_AUXV_HPP_INCLUDED
+
+#include <boost/predef/os.h>
+#include <boost/cstdint.hpp>
+#include <linux/auxvec.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+namespace boost { namespace simd { namespace detail
+{
+  inline uintptr_t auxv(uintptr_t type)
+  {
+    int fd;
+    uintptr_t auxv[2];
+
+    fd = open("/proc/self/auxv", O_RDONLY);
+    if (fd >= 0)
+    {
+      while(read(fd, &auxv, sizeof(auxv)) == sizeof(auxv))
+      {
+        if (auxv[0] == type)
+        {
+          close(fd);
+          return auxv[1];
+        }
+      }
+      close(fd);
+    }
+    return 0;
+  }
+
+  inline unsigned int hwcap() { return auxv(AT_HWCAP); }
+} } }
+
+#endif

--- a/include/boost/simd/detail/cpuid.hpp
+++ b/include/boost/simd/detail/cpuid.hpp
@@ -1,0 +1,67 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_DETAIL_CPUID_HPP_INCLUDED
+#define BOOST_SIMD_DETAIL_CPUID_HPP_INCLUDED
+
+#include <boost/predef/architecture.h>
+#include <boost/predef/compiler.h>
+
+#if BOOST_ARCH_X86
+
+#if BOOST_COMP_GNUC || BOOST_COMP_CLANG
+#include <cpuid.h>
+#else
+#include <intrin.h>
+#endif
+
+namespace boost { namespace simd { namespace detail
+{
+#if BOOST_COMP_GNUC || BOOST_COMP_CLANG
+  using register_type = unsigned int;
+#else
+  using register_type = int;
+#endif
+
+  enum registerID { eax=0, ebx=1, ecx=2, edx=3 };
+
+  void cpuid(register_type pRegisters[4], int function) {
+#if BOOST_COMP_GNUC || BOOST_COMP_CLANG
+    __cpuid (function, pRegisters[eax], pRegisters[ebx], pRegisters[ecx], pRegisters[edx]);
+#else
+  __cpuid(pRegisters, function);
+#endif
+  }
+
+  void cpuidex(register_type pRegisters[4], int function, int subfunction) {
+#if BOOST_COMP_GNUC || BOOST_COMP_CLANG
+    __cpuid_count ( function, subfunction
+                  , pRegisters[eax], pRegisters[ebx], pRegisters[ecx], pRegisters[edx]
+                  );
+#else
+  __cpuidex(pRegisters, function, subfunction);
+#endif
+  }
+
+  bool detect_feature(int bit, int function, int register_id)
+  {
+    register_type regs_x86[4] = {0x00000000, 0x00000000, 0x00000000, 0x00000000};
+    cpuidex(regs_x86, function, 0);
+    return (regs_x86[register_id] & (1 << bit)) != 0;
+  }
+
+  bool detect_features(int bits, int function, int register_id)
+  {
+    register_type regs_x86[4] = {0x00000000, 0x00000000, 0x00000000, 0x00000000};
+    cpuidex(regs_x86, function, 0);
+    return (regs_x86[register_id] & bits) != 0;
+  }
+} } }
+#endif
+
+#endif

--- a/test/architecture/tags.cpp
+++ b/test/architecture/tags.cpp
@@ -10,6 +10,31 @@
 #include <boost/simd/arch/tags.hpp>
 #include <simd_test.hpp>
 
+STF_CASE( "Check for SIMD tag support facility" )
+{
+  std::cout << "---------------------\n";
+  std::cout << "X86 Extensions\n";
+  std::cout << "---------------------\n";
+  std::cout << "SSE1   support: " << std::boolalpha << boost::simd::sse1.is_supported()   << "\n";
+  std::cout << "SSE2   support: " << std::boolalpha << boost::simd::sse2.is_supported()   << "\n";
+  std::cout << "SSE3   support: " << std::boolalpha << boost::simd::sse3.is_supported()   << "\n";
+  std::cout << "SSSE3  support: " << std::boolalpha << boost::simd::ssse3.is_supported()  << "\n";
+  std::cout << "SSE4a  support: " << std::boolalpha << boost::simd::sse4a.is_supported()  << "\n";
+  std::cout << "SSE4.1 support: " << std::boolalpha << boost::simd::sse4_1.is_supported() << "\n";
+  std::cout << "SSE4.2 support: " << std::boolalpha << boost::simd::sse4_2.is_supported() << "\n";
+  std::cout << "AVX    support: " << std::boolalpha << boost::simd::avx.is_supported()    << "\n";
+  std::cout << "AVX2   support: " << std::boolalpha << boost::simd::avx2.is_supported()   << "\n";
+  std::cout << "FMA3   support: " << std::boolalpha << boost::simd::fma3.is_supported()   << "\n";
+  std::cout << "FMA4   support: " << std::boolalpha << boost::simd::fma4.is_supported()   << "\n";
+  std::cout << "XOP    support: " << std::boolalpha << boost::simd::xop.is_supported()    << "\n";
+  std::cout << "---------------------\n";
+  std::cout << "PPC Extensions\n";
+  std::cout << "---------------------\n";
+  std::cout << "VMX    support: " << std::boolalpha << boost::simd::vmx.is_supported()    << "\n";
+
+  STF_PASS("Support detection from architecture object.");
+}
+
 STF_CASE( "Check for basic SIMD tag parent" )
 {
   STF_TYPE_IS( boost::simd::simd_::parent          , boost::dispatch::cpu_ );
@@ -17,7 +42,6 @@ STF_CASE( "Check for basic SIMD tag parent" )
   STF_TYPE_IS( boost::simd::simd_native_::parent   , boost::simd::simd_    );
 }
 
-#ifdef BOOST_ARCH_X86_AVAILABLE
 STF_CASE( "Check for architectural tag parent for X86/AMD" )
 {
   STF_TYPE_IS( boost::simd::sse1_::parent   , boost::simd::simd_native_ );
@@ -48,11 +72,8 @@ STF_CASE( "Check for architectural tag parent for X86/AMD" )
 
   STF_TYPE_IS( boost::simd::avx2_::parent, boost::simd::fma3_ );
 }
-#endif
 
-#ifdef BOOST_ARCH_PPC_AVAILABLE
 STF_CASE( "Check for architectural tag parent for PowerPC" )
 {
   STF_TYPE_IS( boost::simd::vmx_::parent , boost::simd::simd_  );
 }
-#endif


### PR DESCRIPTION
This patch implements a portable layer on top of various specific detection schme so one can, at runtime, ask if a given SIMD instruction set is supported by using a small global object named after the instructions set.

Sample code : 

```
if(boost::simd::avx.is_supported())       avx_f();
else if(boost::simd::sse2.is_supported()) sse2_f();
else scalar_f();
```
