### PR TITLE
improving rol/r simd and adding tests

### DIFF
--- a/include/boost/simd/arch/common/scalar/function/rol.hpp
+++ b/include/boost/simd/arch/common/scalar/function/rol.hpp
@@ -45,16 +45,13 @@ namespace boost { namespace simd { namespace ext
                           , (typename A0, typename A1)
                           , bd::cpu_
                           , bd::scalar_< bd::arithmetic_<A0> >
-                          , bd::scalar_< bd::arithmetic_<A1> >
+                          , bd::scalar_< bd::integer_<A1> >
   )
   {
     BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1 ) const
     {
       using i_t = bd::as_integer_t<A0, unsigned>;
-      return bitwise_cast<A0>( rol ( bitwise_cast<i_t>(a0)
-                                   , i_t(a1)
-                                   )
-                             );
+      return bitwise_cast<A0>( rol ( bitwise_cast<i_t>(a0), i_t(a1)));
     }
   };
 

--- a/include/boost/simd/arch/common/scalar/function/rol.hpp
+++ b/include/boost/simd/arch/common/scalar/function/rol.hpp
@@ -15,15 +15,8 @@
 #include <boost/simd/meta/cardinal_of.hpp>
 #include <boost/simd/detail/assert_utils.hpp>
 #include <boost/simd/function/bitwise_cast.hpp>
-#include <boost/simd/function/bitwise_or.hpp>
-#include <boost/simd/function/dec.hpp>
-#include <boost/simd/function/minus.hpp>
-#include <boost/simd/function/shift_left.hpp>
-#include <boost/simd/function/shift_right.hpp>
-#include <boost/simd/function/splat.hpp>
 #include <boost/simd/detail/dispatch/function/overload.hpp>
 #include <boost/simd/detail/dispatch/meta/as_integer.hpp>
-#include <boost/simd/detail/dispatch/meta/scalar_of.hpp>
 #include <boost/config.hpp>
 
 namespace boost { namespace simd { namespace ext
@@ -34,34 +27,28 @@ namespace boost { namespace simd { namespace ext
   BOOST_DISPATCH_OVERLOAD ( rol_
                           , (typename A0, typename A1)
                           , bd::cpu_
-                          , bd::scalar_< bd::integer_<A0> >
-                          , bd::scalar_< bd::integer_<A1> >
+                          , bd::scalar_< bd::unsigned_<A0> >
+                          , bd::scalar_< bd::unsigned_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1
-//TODO                                     , typename std::enable_if<bs::cardinal_of<A1>::value
-//                                      == bs::cardinal_of<A0>::value, int>::type* = 0
-      ) const
+    BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const
     {
-      using s_t = bd::scalar_of_t<A0>;
       BOOST_ASSERT_MSG(assert_good_shift<A0>(a1), "rol : rotation is out of range");
 
-      s_t const width = sizeof(s_t)*CHAR_BIT;
-      return shift_left(a0, a1) | shift_right(a0, (width-a1) & (dec(width))); //seems odd to me JTL
+      static const A0 width = sizeof(A0)*CHAR_BIT-1;
+      A0 n = A0(a1);
+      return (a0 << n) | (a0 >> (-n&width));
     }
   };
 
   BOOST_DISPATCH_OVERLOAD ( rol_
                           , (typename A0, typename A1)
                           , bd::cpu_
-                          , bd::scalar_< bd::floating_<A0> >
-                          , bd::scalar_< bd::integer_<A1> >
+                          , bd::scalar_< bd::arithmetic_<A0> >
+                          , bd::scalar_< bd::arithmetic_<A1> >
   )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1
-//  TODO                                   , typename std::enable_if<bs::cardinal_of<A1>::value
-//                                      == bs::cardinal_of<A0>::value, int>::type* = 0
-                                    ) const
+    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1 ) const
     {
       using i_t = bd::as_integer_t<A0, unsigned>;
       return bitwise_cast<A0>( rol ( bitwise_cast<i_t>(a0)
@@ -70,6 +57,7 @@ namespace boost { namespace simd { namespace ext
                              );
     }
   };
+
 } } }
 
 

--- a/include/boost/simd/arch/common/scalar/function/ror.hpp
+++ b/include/boost/simd/arch/common/scalar/function/ror.hpp
@@ -15,14 +15,8 @@
 #include <boost/simd/meta/cardinal_of.hpp>
 #include <boost/simd/detail/assert_utils.hpp>
 #include <boost/simd/function/bitwise_cast.hpp>
-#include <boost/simd/function/bitwise_or.hpp>
-#include <boost/simd/function/minus.hpp>
-#include <boost/simd/function/shift_left.hpp>
-#include <boost/simd/function/shr.hpp>
-#include <boost/simd/function/splat.hpp>
 #include <boost/simd/detail/dispatch/function/overload.hpp>
 #include <boost/simd/detail/dispatch/meta/as_integer.hpp>
-#include <boost/simd/detail/dispatch/meta/scalar_of.hpp>
 #include <boost/config.hpp>
 
 namespace boost { namespace simd { namespace ext
@@ -33,34 +27,28 @@ namespace boost { namespace simd { namespace ext
   BOOST_DISPATCH_OVERLOAD ( ror_
                           , (typename A0, typename A1)
                           , bd::cpu_
-                          , bd::scalar_< bd::integer_<A0> >
-                          , bd::scalar_< bd::integer_<A1> >
+                          , bd::scalar_< bd::unsigned_<A0> >
+                          , bd::scalar_< bd::unsigned_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1
-//  TODO                                   , typename std::enable_if<bs::cardinal_of<A1>::value
-//                                      == bs::cardinal_of<A0>::value>::type* = 0
-                                    ) const
+    BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const
     {
-      using s_t = bd::scalar_of_t<A0>;
       BOOST_ASSERT_MSG(assert_good_shift<A0>(a1), "ror : rotation is out of range");
 
-      s_t const width = sizeof(s_t)*CHAR_BIT;
-      return shr(a0, a1) | shift_left(a0, (width-splat<A0>(a1)) & (width-1));
+      static const A0 width = sizeof(A0)*CHAR_BIT-1;
+      A0 n = A0(a1);
+      return (a0 >>  n) | (a0 << (-n&width));
     }
   };
 
   BOOST_DISPATCH_OVERLOAD ( ror_
                           , (typename A0, typename A1)
                           , bd::cpu_
-                          , bd::scalar_< bd::floating_<A0> >
-                          , bd::scalar_< bd::integer_<A1> >
+                          , bd::scalar_< bd::arithmetic_<A0> >
+                          , bd::scalar_< bd::arithmetic_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1
-//   TODO                                  , typename std::enable_if<bs::cardinal_of<A1>::value
-//                                      == bs::cardinal_of<A0>::value>::type* = 0
-                                    ) const
+    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1) const
     {
       using i_t = bd::as_integer_t<A0, unsigned>;
       return bitwise_cast<A0>( ror ( bitwise_cast<i_t>(a0)
@@ -69,6 +57,7 @@ namespace boost { namespace simd { namespace ext
                                       );
     }
   };
+
 } } }
 
 

--- a/include/boost/simd/arch/common/scalar/function/ror.hpp
+++ b/include/boost/simd/arch/common/scalar/function/ror.hpp
@@ -45,16 +45,13 @@ namespace boost { namespace simd { namespace ext
                           , (typename A0, typename A1)
                           , bd::cpu_
                           , bd::scalar_< bd::arithmetic_<A0> >
-                          , bd::scalar_< bd::arithmetic_<A1> >
+                          , bd::scalar_< bd::integer_<A1> >
                           )
   {
     BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1) const
     {
       using i_t = bd::as_integer_t<A0, unsigned>;
-      return bitwise_cast<A0>( ror ( bitwise_cast<i_t>(a0)
-                                            , splat<i_t>(a1)
-                                            )
-                                      );
+      return bitwise_cast<A0>( ror (bitwise_cast<i_t>(a0), i_t(a1)) );
     }
   };
 

--- a/include/boost/simd/arch/common/simd/function/rol.hpp
+++ b/include/boost/simd/arch/common/simd/function/rol.hpp
@@ -40,11 +40,11 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A0 a1) const
     {
       BOOST_ASSERT_MSG(assert_good_shift<A0>(a1), "rol : rotation is out of range");
-      using s_t = bd::scalar_of_t<A0>;
 
-      static const A0 width = sizeof(s_t)*CHAR_BIT-1;
-      A0 n = A0(a1);
-      return (a0 << n) | (a0 >> (-n&width));
+      using s_t = bd::scalar_of_t<A0>;
+      static const A1 width = sizeof(s_t)*CHAR_BIT-1;
+      A1 n(a1);
+      return (shift_left(a0, n)) | (shift_right(a0, (-n&width)));
     }
   };
 
@@ -52,13 +52,13 @@ namespace boost { namespace simd { namespace ext
                           , (typename A0, typename A1, typename X)
                           , bd::cpu_
                           , bs::pack_< bd::arithmetic_<A0>, X>
-                          , bd::scalar_< bd::arithmetic_<A1> >
+                          , bd::scalar_< bd::integer_<A1> >
   )
   {
     BOOST_FORCEINLINE A0 operator() ( A0 const&  a0, A1 a1 ) const
     {
-      using i_t = bd::as_integer_t<A0, unsigned>;
-      using is_t = bd::scalar_of_t<s_t>;
+      using i_t  = bd::as_integer_t<A0, unsigned>;
+      using is_t = bd::as_integer_t<i_t, unsigned>;
       return bitwise_cast<A0>( rol ( bitwise_cast<i_t>(a0)
                                    , is_t(a1)
                                    )
@@ -66,12 +66,13 @@ namespace boost { namespace simd { namespace ext
     }
   };
 
+
   BOOST_DISPATCH_OVERLOAD_IF ( rol_
                           , (typename A0, typename A1, typename X)
                           , (detail::is_native<X>)
                           , bd::cpu_
-                          , bs::pack_< bd::integer_<A0>, X>
-                          , bs::pack_< bd::integer_<A1>, X>
+                          , bs::pack_< bd::unsigned_<A0>, X>
+                          , bs::pack_< bd::unsigned_<A1>, X>
                           )
   {
     BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 const& a1 ) const
@@ -88,7 +89,7 @@ namespace boost { namespace simd { namespace ext
                           , (typename A0, typename A1, typename X)
                           , (detail::is_native<X>)
                           , bd::cpu_
-                          , bs::pack_< bd::floating_<A0>, X>
+                          , bs::pack_< bd::arithmetic_<A0>, X>
                           , bs::pack_< bd::integer_<A1>, X>
   )
   {

--- a/include/boost/simd/arch/common/simd/function/rol.hpp
+++ b/include/boost/simd/arch/common/simd/function/rol.hpp
@@ -11,6 +11,7 @@
 #ifndef BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_ROL_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_ROL_HPP_INCLUDED
 
+#include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/meta/cardinal_of.hpp>
 #include <boost/simd/detail/assert_utils.hpp>
 #include <boost/simd/function/simd/bitwise_cast.hpp>
@@ -37,7 +38,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::unsigned_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A0 a1) const
+    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 a1) const
     {
       BOOST_ASSERT_MSG(assert_good_shift<A0>(a1), "rol : rotation is out of range");
 
@@ -68,26 +69,34 @@ namespace boost { namespace simd { namespace ext
 
 
   BOOST_DISPATCH_OVERLOAD_IF ( rol_
-                          , (typename A0, typename A1, typename X)
-                          , (detail::is_native<X>)
-                          , bd::cpu_
-                          , bs::pack_< bd::unsigned_<A0>, X>
-                          , bs::pack_< bd::unsigned_<A1>, X>
-                          )
+                             , (typename A0, typename A1, typename X)
+                             , ( brigand::and_<
+                                 detail::is_native<X>,
+                                 brigand::bool_<bs::cardinal_of<A0>::value == bs::cardinal_of<A1>::value>
+                                 >
+                               )
+                             , bd::cpu_
+                             , bs::pack_< bd::unsigned_<A0>, X>
+                             , bs::pack_< bd::unsigned_<A1>, X>
+                             )
   {
     BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 const& a1 ) const
     {
       using s_t = bd::scalar_of_t<A0>;
       BOOST_ASSERT_MSG(assert_good_shift<A0>(a1), "rol : rotation is out of range");
 
-      s_t const width = sizeof(s_t)*CHAR_BIT;
-      return shift_left(a0, a1) | shift_right(a0, (width-a1) & (dec(width)));
+      s_t static const width = sizeof(s_t)*CHAR_BIT;
+      return shift_left(a0, a1) | shift_right(a0, (width-a1) & (width-1));
     }
   };
 
   BOOST_DISPATCH_OVERLOAD_IF ( rol_
                           , (typename A0, typename A1, typename X)
-                          , (detail::is_native<X>)
+                          , ( brigand::and_<
+                              detail::is_native<X>,
+                              brigand::bool_<bs::cardinal_of<A0>::value == bs::cardinal_of<A1>::value>
+                              >
+                             )
                           , bd::cpu_
                           , bs::pack_< bd::arithmetic_<A0>, X>
                           , bs::pack_< bd::integer_<A1>, X>

--- a/include/boost/simd/arch/common/simd/function/ror.hpp
+++ b/include/boost/simd/arch/common/simd/function/ror.hpp
@@ -29,6 +29,42 @@ namespace boost { namespace simd { namespace ext
   namespace bd = boost::dispatch;
   namespace bs = boost::simd;
 
+  BOOST_DISPATCH_OVERLOAD ( ror_
+                          , (typename A0, typename A1, typename X)
+                          , bd::cpu_
+                          , bs::pack_< bd::unsigned_<A0>, X>
+                          , bd::scalar_< bd::unsigned_<A1> >
+                          )
+  {
+    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A0 a1) const
+    {
+      BOOST_ASSERT_MSG(assert_good_shift<A0>(a1), "rol : rotation is out of range");
+      using s_t = bd::scalar_of_t<A0>;
+
+      static const A0 width = sizeof(s_t)*CHAR_BIT-1;
+      A0 n = A0(a1);
+      return (a0 >> n) | (a0 << (-n&width));
+    }
+  };
+
+  BOOST_DISPATCH_OVERLOAD ( ror_
+                          , (typename A0, typename A1, typename X)
+                          , bd::cpu_
+                          , bs::pack_< bd::arithmetic_<A0>, X>
+                          , bd::scalar_< bd::arithmetic_<A1> >
+  )
+  {
+    BOOST_FORCEINLINE A0 operator() ( A0 const&  a0, A1 a1 ) const
+    {
+      using i_t = bd::as_integer_t<A0, unsigned>;
+      using is_t = bd::scalar_of_t<s_t>;
+      return bitwise_cast<A0>( ror ( bitwise_cast<i_t>(a0)
+                                   , is_t(a1)
+                                   )
+                             );
+    }
+  };
+
   BOOST_DISPATCH_OVERLOAD_IF ( ror_
                           , (typename A0, typename A1, typename X)
                           , (detail::is_native<X>)
@@ -37,16 +73,13 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::integer_<A1>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A0 const& a1
-//  TODO                                   , typename std::enable_if<bs::cardinal_of<A1>::value
-//                                      == bs::cardinal_of<A0>::value>::type* = 0
-                                    ) const
+    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A0 const& a1) const
     {
       using s_t = bd::scalar_of_t<A0>;
       BOOST_ASSERT_MSG(assert_good_shift<A0>(a1), "ror : rotation is out of range");
 
       s_t const width = sizeof(s_t)*CHAR_BIT;
-      return shr(a0, a1) | shift_left(a0, (width-splat<A0>(a1)) & (width-1));
+      return shr(a0, a1) | shift_left(a0, (width-bitwise_cast<A0>(a1)) & (width-1));
     }
   };
 
@@ -58,16 +91,13 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::integer_<A1>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 const& a1
-//   TODO                                  , typename std::enable_if<bs::cardinal_of<A1>::value
-//                                      == bs::cardinal_of<A0>::value>::type* = 0
-                                    ) const
+    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 const& a1) const
     {
       using i_t = bd::as_integer_t<A0, unsigned>;
       return bitwise_cast<A0>( ror ( bitwise_cast<i_t>(a0)
-                                            , splat<i_t>(a1)
-                                            )
-                                      );
+                                   , bitwise_cast<i_t>(a1)
+                                   )
+                             );
     }
   };
 } } }

--- a/include/boost/simd/arch/common/simd/function/ror.hpp
+++ b/include/boost/simd/arch/common/simd/function/ror.hpp
@@ -41,9 +41,9 @@ namespace boost { namespace simd { namespace ext
       BOOST_ASSERT_MSG(assert_good_shift<A0>(a1), "rol : rotation is out of range");
       using s_t = bd::scalar_of_t<A0>;
 
-      static const A0 width = sizeof(s_t)*CHAR_BIT-1;
-      A0 n = A0(a1);
-      return (a0 >> n) | (a0 << (-n&width));
+      static const A1 width = sizeof(s_t)*CHAR_BIT-1;
+      A1 n(a1);
+      return (shift_right(a0, n)) | (shift_left(a0, (-n&width)));
     }
   };
 
@@ -51,13 +51,13 @@ namespace boost { namespace simd { namespace ext
                           , (typename A0, typename A1, typename X)
                           , bd::cpu_
                           , bs::pack_< bd::arithmetic_<A0>, X>
-                          , bd::scalar_< bd::arithmetic_<A1> >
+                          , bd::scalar_< bd::integer_<A1> >
   )
   {
     BOOST_FORCEINLINE A0 operator() ( A0 const&  a0, A1 a1 ) const
     {
       using i_t = bd::as_integer_t<A0, unsigned>;
-      using is_t = bd::scalar_of_t<s_t>;
+      using is_t = bd::as_integer_t<i_t, unsigned>;
       return bitwise_cast<A0>( ror ( bitwise_cast<i_t>(a0)
                                    , is_t(a1)
                                    )
@@ -69,8 +69,8 @@ namespace boost { namespace simd { namespace ext
                           , (typename A0, typename A1, typename X)
                           , (detail::is_native<X>)
                           , bd::cpu_
-                          , bs::pack_< bd::integer_<A0>, X>
-                          , bs::pack_< bd::integer_<A1>, X>
+                          , bs::pack_< bd::unsigned_<A0>, X>
+                          , bs::pack_< bd::unsigned_<A1>, X>
                           )
   {
     BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A0 const& a1) const
@@ -79,7 +79,7 @@ namespace boost { namespace simd { namespace ext
       BOOST_ASSERT_MSG(assert_good_shift<A0>(a1), "ror : rotation is out of range");
 
       s_t const width = sizeof(s_t)*CHAR_BIT;
-      return shr(a0, a1) | shift_left(a0, (width-bitwise_cast<A0>(a1)) & (width-1));
+      return shr(a0, a1) | shift_left(a0, (width-a1) & (width-1));
     }
   };
 
@@ -87,7 +87,7 @@ namespace boost { namespace simd { namespace ext
                           , (typename A0, typename A1, typename X)
                           , (detail::is_native<X>)
                           , bd::cpu_
-                          , bs::pack_< bd::floating_<A0>, X>
+                          , bs::pack_< bd::arithmetic_<A0>, X>
                           , bs::pack_< bd::integer_<A1>, X>
                           )
   {

--- a/include/boost/simd/arch/common/simd/function/ror.hpp
+++ b/include/boost/simd/arch/common/simd/function/ror.hpp
@@ -36,7 +36,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::unsigned_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A0 a1) const
+    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 a1) const
     {
       BOOST_ASSERT_MSG(assert_good_shift<A0>(a1), "rol : rotation is out of range");
       using s_t = bd::scalar_of_t<A0>;
@@ -66,30 +66,38 @@ namespace boost { namespace simd { namespace ext
   };
 
   BOOST_DISPATCH_OVERLOAD_IF ( ror_
-                          , (typename A0, typename A1, typename X)
-                          , (detail::is_native<X>)
-                          , bd::cpu_
-                          , bs::pack_< bd::unsigned_<A0>, X>
-                          , bs::pack_< bd::unsigned_<A1>, X>
-                          )
+                             , (typename A0, typename A1, typename X)
+                             , ( brigand::and_<
+                                 detail::is_native<X>,
+                                 brigand::bool_<bs::cardinal_of<A0>::value == bs::cardinal_of<A1>::value>
+                                 >
+                               )
+                             , bd::cpu_
+                             , bs::pack_< bd::unsigned_<A0>, X>
+                             , bs::pack_< bd::unsigned_<A1>, X>
+                             )
   {
     BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A0 const& a1) const
     {
       using s_t = bd::scalar_of_t<A0>;
       BOOST_ASSERT_MSG(assert_good_shift<A0>(a1), "ror : rotation is out of range");
 
-      s_t const width = sizeof(s_t)*CHAR_BIT;
+      s_t static const width = sizeof(s_t)*CHAR_BIT;
       return shr(a0, a1) | shift_left(a0, (width-a1) & (width-1));
     }
   };
 
   BOOST_DISPATCH_OVERLOAD_IF ( ror_
-                          , (typename A0, typename A1, typename X)
-                          , (detail::is_native<X>)
-                          , bd::cpu_
-                          , bs::pack_< bd::arithmetic_<A0>, X>
-                          , bs::pack_< bd::integer_<A1>, X>
-                          )
+                             , (typename A0, typename A1, typename X)
+                             , ( brigand::and_<
+                                 detail::is_native<X>,
+                                 brigand::bool_<bs::cardinal_of<A0>::value == bs::cardinal_of<A1>::value>
+                                 >
+                               )
+                               , bd::cpu_
+                               , bs::pack_< bd::arithmetic_<A0>, X>
+                               , bs::pack_< bd::integer_<A1>, X>
+                               )
   {
     BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 const& a1) const
     {

--- a/include/boost/simd/function/simd/rol.hpp
+++ b/include/boost/simd/function/simd/rol.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/simd/function/scalar/rol.hpp>
 #include <boost/simd/arch/common/generic/function/autodispatcher.hpp>
+#include <boost/simd/arch/common/simd/function/rol.hpp>
 
 #if defined(BOOST_HW_SIMD_X86_OR_AMD_AVAILABLE)
 #  if BOOST_HW_SIMD_X86_OR_AMD >= BOOST_HW_SIMD_X86_SSE_VERSION

--- a/include/boost/simd/function/simd/ror.hpp
+++ b/include/boost/simd/function/simd/ror.hpp
@@ -12,6 +12,8 @@
 
 #include <boost/simd/function/scalar/ror.hpp>
 #include <boost/simd/arch/common/generic/function/autodispatcher.hpp>
+#include <boost/simd/arch/common/simd/function/ror.hpp>
+
 
 #if defined(BOOST_HW_SIMD_X86_OR_AMD_AVAILABLE)
 #  if BOOST_HW_SIMD_X86_OR_AMD >= BOOST_HW_SIMD_X86_SSE_VERSION

--- a/test/function/scalar/rol.cpp
+++ b/test/function/scalar/rol.cpp
@@ -23,7 +23,6 @@ STF_CASE_TPL (" rol integer", STF_INTEGRAL_TYPES)
 
   for(T i=0;i<w;++i)
   {
-    std::cout << int(i) << " -> ";
     STF_EQUAL(rol(T(1),T(i)), T(T(1)<<i) );
   }
 

--- a/test/function/simd/CMakeLists.txt
+++ b/test/function/simd/CMakeLists.txt
@@ -277,6 +277,8 @@ repeat_lower_half.cpp
 repeat_upper_half.cpp
 reversebits.cpp
 reverse.cpp
+rol.cpp
+ror.cpp
 round.cpp
 nearbyint.cpp
 rsqrt.cpp

--- a/test/function/simd/rol.cpp
+++ b/test/function/simd/rol.cpp
@@ -9,7 +9,7 @@
 */
 //==================================================================================================
 #include <boost/simd/pack.hpp>
-#include <boost/simd/function/rol.hpp>
+#include <boost/simd/function/simd/rol.hpp>
 #include <boost/simd/meta/cardinal_of.hpp>
 #include <simd_test.hpp>
 

--- a/test/function/simd/rol.cpp
+++ b/test/function/simd/rol.cpp
@@ -18,6 +18,7 @@ void test(Env& $)
 {
   namespace bs = boost::simd;
   using p_t = bs::pack<T, N>;
+  int M =  sizeof(T)*8-1;
 
   namespace bs = boost::simd;
   namespace bd = boost::dispatch;
@@ -27,16 +28,53 @@ void test(Env& $)
   {
      a1[i] = (i%2) ? T(i) : T(-i);
      b[i] = bs::rol(a1[i], 1);
-     c[i] = bs::rol(a1[i], N/2);
-     d[i] = bs::rol(a1[i], N-1);
+     c[i] = bs::rol(a1[i], M/2);
+     d[i] = bs::rol(a1[i], M-1);
    }
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb(&b[0], &b[0]+N);
   p_t cc(&c[0], &c[0]+N);
   p_t dd(&d[0], &d[0]+N);
   STF_IEEE_EQUAL(bs::rol(aa1, 1), bb);
-  STF_IEEE_EQUAL(bs::rol(aa1, N/2), cc);
-  STF_IEEE_EQUAL(bs::rol(aa1, N-1), dd);
+  STF_IEEE_EQUAL(bs::rol(aa1, M/2), cc);
+  STF_IEEE_EQUAL(bs::rol(aa1, M-1), dd);
+}
+
+STF_CASE_TPL("Check rol on pack and scalar" , STF_NUMERIC_TYPES)
+{
+  namespace bs = boost::simd;
+  using p_t = bs::pack<T>;
+  static const std::size_t N = bs::cardinal_of<p_t>::value;
+  test<T, N>($);
+  test<T, N/2>($);
+  test<T, N*2>($);
+}
+template <typename T, std::size_t N, typename Env>
+void tests(Env& $)
+{
+  namespace bs = boost::simd;
+  namespace bd = boost::dispatch;
+  using p_t = bs::pack<T, N>;
+  int M =  sizeof(T)*8-1;
+  using iT =  bd::as_integer_t<p_t, unsigned>;
+  namespace bs = boost::simd;
+  namespace bd = boost::dispatch;
+
+  T a1[N], b[N], c[N], d[N];
+  for(std::size_t i = 0; i < N; ++i)
+  {
+     a1[i] = (i%2) ? T(i) : T(-i);
+     b[i] = bs::rol(a1[i],1);
+     c[i] = bs::rol(a1[i], M/2);
+     d[i] = bs::rol(a1[i], M-1);
+   }
+  p_t aa1(&a1[0], &a1[0]+N);
+  p_t bb(&b[0], &b[0]+N);
+  p_t cc(&c[0], &c[0]+N);
+  p_t dd(&d[0], &d[0]+N);
+  STF_IEEE_EQUAL(bs::rol(aa1, iT(1)), bb);
+  STF_IEEE_EQUAL(bs::rol(aa1, iT(M/2)), cc);
+  STF_IEEE_EQUAL(bs::rol(aa1, iT(M-1)), dd);
 }
 
 STF_CASE_TPL("Check rol on pack" , STF_NUMERIC_TYPES)
@@ -44,7 +82,7 @@ STF_CASE_TPL("Check rol on pack" , STF_NUMERIC_TYPES)
   namespace bs = boost::simd;
   using p_t = bs::pack<T>;
   static const std::size_t N = bs::cardinal_of<p_t>::value;
-  test<T, N>($);
-//  test<T, N/2>($);
-//  test<T, Nx2>($);
+  tests<T, N>($);
+  tests<T, N/2>($);
+  tests<T, N*2>($);
 }

--- a/test/function/simd/ror.cpp
+++ b/test/function/simd/ror.cpp
@@ -13,38 +13,77 @@
 #include <boost/simd/meta/cardinal_of.hpp>
 #include <simd_test.hpp>
 
-// template <typename T, std::size_t N, typename Env>
-// void test(Env& $)
-// {
-//   namespace bs = boost::simd;
-//   using p_t = bs::pack<T, N>;
+template <typename T, std::size_t N, typename Env>
+void test(Env& $)
+{
+  namespace bs = boost::simd;
+  using p_t = bs::pack<T, N>;
+  int M =  sizeof(T)*8-1;
 
-//   namespace bs = boost::simd;
-//   namespace bd = boost::dispatch;
+  namespace bs = boost::simd;
+  namespace bd = boost::dispatch;
 
-//   T a1[N], b[N], c[N], d[N];
-//   for(std::size_t i = 0; i < N; ++i)
-//   {
-//      a1[i] = (i%2) ? T(i) : T(-i);
-//      b[i] = bs::ror(a1[i], 1);
-//      c[i] = bs::ror(a1[i], N/2);
-//      d[i] = bs::ror(a1[i], N-1);
-//    }
-//   p_t aa1(&a1[0], &a1[0]+N);
-//   p_t bb(&b[0], &b[0]+N);
-//   p_t cc(&c[0], &c[0]+N);
-//   p_t dd(&d[0], &d[0]+N);
-//   STF_IEEE_EQUAL(bs::ror(aa1, 1), bb);
-//   STF_IEEE_EQUAL(bs::ror(aa1, N/2), cc);
-//   STF_IEEE_EQUAL(bs::ror(aa1, N-1), dd);
-// }
+  T a1[N], b[N], c[N], d[N];
+  for(std::size_t i = 0; i < N; ++i)
+  {
+     a1[i] = (i%2) ? T(i) : T(-i);
+     b[i] = bs::ror(a1[i], 1);
+     c[i] = bs::ror(a1[i], M/2);
+     d[i] = bs::ror(a1[i], M-1);
+   }
+  p_t aa1(&a1[0], &a1[0]+N);
+  p_t bb(&b[0], &b[0]+N);
+  p_t cc(&c[0], &c[0]+N);
+  p_t dd(&d[0], &d[0]+N);
+  STF_IEEE_EQUAL(bs::ror(aa1, 1), bb);
+  STF_IEEE_EQUAL(bs::ror(aa1, M/2), cc);
+  STF_IEEE_EQUAL(bs::ror(aa1, M-1), dd);
+}
 
-// STF_CASE_TPL("Check ror on pack" , STF_NUMERIC_TYPES)
-// {
-//   namespace bs = boost::simd;
-//   using p_t = bs::pack<T>;
-//   static const std::size_t N = bs::cardinal_of<p_t>::value;
-//   test<T, N>($);
-// //  test<T, N/2>($);
-// //  test<T, Nx2>($);
-// }
+
+STF_CASE_TPL("Check ror on pack and scalar" , STF_NUMERIC_TYPES)
+{
+  namespace bs = boost::simd;
+  using p_t = bs::pack<T>;
+  static const std::size_t N = bs::cardinal_of<p_t>::value;
+  test<T, N>($);
+  test<T, N/2>($);
+  test<T, N*2>($);
+}
+template <typename T, std::size_t N, typename Env>
+void tests(Env& $)
+{
+  namespace bs = boost::simd;
+  namespace bd = boost::dispatch;
+  using p_t = bs::pack<T, N>;
+  int M =  sizeof(T)*8-1;
+  using iT =  bd::as_integer_t<p_t, unsigned>;
+  namespace bs = boost::simd;
+  namespace bd = boost::dispatch;
+
+  T a1[N], b[N], c[N], d[N];
+  for(std::size_t i = 0; i < N; ++i)
+  {
+     a1[i] = (i%2) ? T(i) : T(-i);
+     b[i] = bs::ror(a1[i],1);
+     c[i] = bs::ror(a1[i], M/2);
+     d[i] = bs::ror(a1[i], M-1);
+   }
+  p_t aa1(&a1[0], &a1[0]+N);
+  p_t bb(&b[0], &b[0]+N);
+  p_t cc(&c[0], &c[0]+N);
+  p_t dd(&d[0], &d[0]+N);
+  STF_IEEE_EQUAL(bs::ror(aa1, iT(1)), bb);
+  STF_IEEE_EQUAL(bs::ror(aa1, iT(M/2)), cc);
+  STF_IEEE_EQUAL(bs::ror(aa1, iT(M-1)), dd);
+}
+
+STF_CASE_TPL("Check ror on pack" , STF_NUMERIC_TYPES)
+{
+  namespace bs = boost::simd;
+  using p_t = bs::pack<T>;
+  static const std::size_t N = bs::cardinal_of<p_t>::value;
+  tests<T, N>($);
+  tests<T, N/2>($);
+  tests<T, N*2>($);
+}

--- a/test/function/simd/ror.cpp
+++ b/test/function/simd/ror.cpp
@@ -40,7 +40,6 @@ void test(Env& $)
   STF_IEEE_EQUAL(bs::ror(aa1, M-1), dd);
 }
 
-
 STF_CASE_TPL("Check ror on pack and scalar" , STF_NUMERIC_TYPES)
 {
   namespace bs = boost::simd;


### PR DESCRIPTION
This to answer issue #116.

Now g++ generate rol and ror opcodes for scalar calls to boost::simd::ror/l when available
