### PR TITLE
Silence GCC 6 warnings about attributes

### DIFF
--- a/include/boost/simd/arch/x86/avx/pack_traits.hpp
+++ b/include/boost/simd/arch/x86/avx/pack_traits.hpp
@@ -14,6 +14,11 @@
 #include <boost/simd/detail/brigand.hpp>
 #include <boost/simd/detail/pack_traits.hpp>
 
+#if defined __GNUC__ && __GNUC__>=6
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"
+#endif
+
 namespace boost { namespace simd
 {
   namespace detail
@@ -54,5 +59,9 @@ namespace boost { namespace simd
     };
   }
 } }
+
+#if defined __GNUC__ && __GNUC__>=6
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/include/boost/simd/arch/x86/sse1/pack_traits.hpp
+++ b/include/boost/simd/arch/x86/sse1/pack_traits.hpp
@@ -19,6 +19,11 @@
 #include <boost/simd/detail/pack_traits.hpp>
 #include <boost/simd/arch/common/simd/abi_of.hpp>
 
+#if defined __GNUC__ && __GNUC__>=6
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"
+#endif
+
 namespace boost { namespace simd
 {
   namespace detail
@@ -34,5 +39,9 @@ namespace boost { namespace simd
     };
   }
 } }
+
+#if defined __GNUC__ && __GNUC__>=6
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/include/boost/simd/arch/x86/sse2/pack_traits.hpp
+++ b/include/boost/simd/arch/x86/sse2/pack_traits.hpp
@@ -19,6 +19,11 @@
 #include <boost/simd/detail/pack_traits.hpp>
 #include <type_traits>
 
+#if defined __GNUC__ && __GNUC__>=6
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"
+#endif
+
 namespace boost { namespace simd
 {
   namespace detail
@@ -53,5 +58,9 @@ namespace boost { namespace simd
     };
   }
 } }
+
+#if defined __GNUC__ && __GNUC__>=6
+#pragma GCC diagnostic pop
+#endif
 
 #endif


### PR DESCRIPTION
GCC 6 emits warning about the fact that passing __m128/256{i/d} types as template parameters discards attributes. Those warnings cause noise in our case and had been locally disabled.
