### PR TITLE
Add support for 8-bits HMSB on AVX2

### DIFF
--- a/include/boost/simd/arch/x86/avx/simd/function/hmsb.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/hmsb.hpp
@@ -13,7 +13,6 @@
 #include <boost/simd/function/slice.hpp>
 #include <boost/simd/function/bitwise_cast.hpp>
 #include <boost/simd/detail/dispatch/meta/as_floating.hpp>
-#include <iostream>
 
 namespace boost { namespace simd { namespace ext
 {

--- a/include/boost/simd/arch/x86/avx2/simd/function/hmsb.hpp
+++ b/include/boost/simd/arch/x86/avx2/simd/function/hmsb.hpp
@@ -1,0 +1,32 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_X86_AVX2_SIMD_FUNCTION_HMSB_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_X86_AVX2_SIMD_FUNCTION_HMSB_HPP_INCLUDED
+
+#include <boost/simd/detail/overload.hpp>
+
+namespace boost { namespace simd { namespace ext
+{
+   namespace bd = boost::dispatch;
+   namespace bs = boost::simd;
+
+   BOOST_DISPATCH_OVERLOAD( hmsb_
+                          , (typename A0)
+                          , bs::avx_
+                          , bs::pack_<bd::ints8_<A0>, bs::avx_>
+                          )
+   {
+     BOOST_FORCEINLINE std::size_t operator()(A0 const& a0) const
+      {
+        return _mm256_movemask_epi8(a0);
+      }
+   };
+} } }
+
+#endif

--- a/include/boost/simd/arch/x86/avx2/simd/function/hmsb.hpp
+++ b/include/boost/simd/arch/x86/avx2/simd/function/hmsb.hpp
@@ -18,7 +18,7 @@ namespace boost { namespace simd { namespace ext
 
    BOOST_DISPATCH_OVERLOAD( hmsb_
                           , (typename A0)
-                          , bs::avx_
+                          , bs::avx2_
                           , bs::pack_<bd::ints8_<A0>, bs::avx_>
                           )
    {

--- a/include/boost/simd/function/simd/hmsb.hpp
+++ b/include/boost/simd/function/simd/hmsb.hpp
@@ -27,6 +27,9 @@
 #  if BOOST_HW_SIMD_X86_OR_AMD >= BOOST_HW_SIMD_X86_AVX_VERSION
 #    include <boost/simd/arch/x86/avx/simd/function/hmsb.hpp>
 #  endif
+#  if BOOST_HW_SIMD_X86_OR_AMD >= BOOST_HW_SIMD_X86_AVX2_VERSION
+#    include <boost/simd/arch/x86/avx2/simd/function/hmsb.hpp>
+#  endif
 #endif
 
 #endif


### PR DESCRIPTION
Wrapping for _mm256_movmask_epi8 was missing.
