### PR TITLE
Add deinterleave function

### DIFF
--- a/include/boost/simd/arch/common/simd/function/deinterleave.hpp
+++ b/include/boost/simd/arch/common/simd/function/deinterleave.hpp
@@ -1,0 +1,40 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_DEINTERLEAVE_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_DEINTERLEAVE_HPP_INCLUDED
+
+#include <boost/simd/detail/overload.hpp>
+#include <boost/simd/function/deinterleave_first.hpp>
+#include <boost/simd/function/deinterleave_second.hpp>
+#include <array>
+
+namespace boost { namespace simd { namespace ext
+{
+  namespace bd = boost::dispatch;
+  namespace bs = boost::simd;
+
+  BOOST_DISPATCH_OVERLOAD ( deinterleave_
+                          , (typename T, typename X)
+                          , bd::cpu_
+                          , bs::pack_< bd::unspecified_<T>, X >
+                          , bs::pack_< bd::unspecified_<T>, X >
+                          )
+  {
+    static_assert ( T::static_size >= 2
+                  , "deinterleave_first requires at least two elements"
+                  );
+
+    BOOST_FORCEINLINE std::array<T,2> operator()(T const& x, T const& y) const BOOST_NOEXCEPT
+    {
+      return { deinterleave_first(x,y), deinterleave_second(x,y) };
+    }
+  };
+} } }
+
+#endif

--- a/include/boost/simd/arch/common/simd/function/deinterleave_first.hpp
+++ b/include/boost/simd/arch/common/simd/function/deinterleave_first.hpp
@@ -38,9 +38,9 @@ namespace boost { namespace simd { namespace ext
       return make<T>( bs::extract<N::value*2>(x)..., bs::extract<N::value*2>(y)... );
     }
 
-    template<typename... N> static BOOST_FORCEINLINE
+    template<typename N0, typename N1, typename... Ns> static BOOST_FORCEINLINE
     typename T::storage_type
-    do_( T const& x, T const& y, aggregate_storage const&, br::list<N...> const&) BOOST_NOEXCEPT
+    do_( T const& x, T const& y, aggregate_storage const&, br::list<N0,N1,Ns...> const&) BOOST_NOEXCEPT
     {
       return  { { deinterleave_first(x.storage()[0],x.storage()[1])
                 , deinterleave_first(y.storage()[0],y.storage()[1])

--- a/include/boost/simd/arch/common/simd/function/deinterleave_second.hpp
+++ b/include/boost/simd/arch/common/simd/function/deinterleave_second.hpp
@@ -36,9 +36,9 @@ namespace boost { namespace simd { namespace ext
       return make<T>( bs::extract<N::value*2+1>(x)..., bs::extract<N::value*2+1>(y)... );
     }
 
-    template<typename... N> static BOOST_FORCEINLINE
+    template<typename N0, typename N1, typename... Ns> static BOOST_FORCEINLINE
     typename T::storage_type
-    do_( T const& x, T const& y, aggregate_storage const&, br::list<N...> const&) BOOST_NOEXCEPT
+    do_( T const& x, T const& y, aggregate_storage const&, br::list<N0,N1,Ns...> const&) BOOST_NOEXCEPT
     {
       return  { { deinterleave_second(x.storage()[0],x.storage()[1])
                 , deinterleave_second(y.storage()[0],y.storage()[1])

--- a/include/boost/simd/arch/x86/avx/simd/function/deinterleave.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/deinterleave.hpp
@@ -1,0 +1,90 @@
+//==================================================================================================
+/**
+  Copyright 2016 Numscale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_X86_AVX_SIMD_FUNCTION_DEINTERLEAVE_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_X86_AVX_SIMD_FUNCTION_DEINTERLEAVE_HPP_INCLUDED
+
+#include <boost/simd/detail/overload.hpp>
+#include <boost/simd/function/bitwise_cast.hpp>
+#include <boost/simd/function/slice.hpp>
+#include <boost/simd/function/combine.hpp>
+#include <boost/simd/function/deinterleave_first.hpp>
+#include <boost/simd/function/deinterleave_second.hpp>
+#include <boost/simd/detail/dispatch/meta/as_floating.hpp>
+#include <array>
+
+namespace boost { namespace simd { namespace ext
+{
+  namespace bd =  boost::dispatch;
+  namespace bs =  boost::simd;
+
+  BOOST_DISPATCH_OVERLOAD ( deinterleave_
+                          , (typename A0)
+                          , bs::avx_
+                          , bs::pack_<bd::type64_<A0>, bs::avx_>
+                          , bs::pack_<bd::type64_<A0>, bs::avx_>
+                         )
+  {
+    BOOST_FORCEINLINE std::array<A0,2> operator()(A0 const& a0, A0 const& a1 ) const BOOST_NOEXCEPT
+    {
+      auto b0 = bitwise_cast<bd::as_floating_t<A0>>(a0);
+      auto b1 = bitwise_cast<bd::as_floating_t<A0>>(a1);
+      auto p0 = _mm256_permute2f128_pd(b0,b1,0x20);
+      auto p1 = _mm256_permute2f128_pd(b0,b1,0x31);
+
+      A0 f = bitwise_cast<A0>( _mm256_unpacklo_pd( p0, p1 ) );
+      A0 s = bitwise_cast<A0>( _mm256_unpackhi_pd( p0, p1 ) );
+
+      return {f,s};
+    }
+  };
+
+  BOOST_DISPATCH_OVERLOAD ( deinterleave_
+                          , (typename A0)
+                          , bs::avx_
+                          , bs::pack_<bd::type32_<A0>, bs::avx_>
+                          , bs::pack_<bd::type32_<A0>, bs::avx_>
+                         )
+  {
+    BOOST_FORCEINLINE std::array<A0,2> operator()(A0 const& a0, A0 const& a1 ) const BOOST_NOEXCEPT
+    {
+      auto b0 = bitwise_cast<bd::as_floating_t<A0>>(a0);
+      auto b1 = bitwise_cast<bd::as_floating_t<A0>>(a1);
+      auto x  = _mm256_permute2f128_ps(b0,b1,0x20);
+      auto y  = _mm256_permute2f128_ps(b0,b1,0x31);
+      auto u0 = _mm256_unpacklo_ps(x,y);
+      auto u1 = _mm256_unpackhi_ps(x,y);
+
+      A0 f = bitwise_cast<A0>( _mm256_unpacklo_ps( u0, u1 ) );
+      A0 s = bitwise_cast<A0>( _mm256_unpackhi_ps( u0, u1 ) );
+
+      return {f,s};
+    }
+  };
+
+  BOOST_DISPATCH_OVERLOAD ( deinterleave_
+                          , (typename A0)
+                          , bs::avx_
+                          , bs::pack_<bd::integer_<A0>, bs::avx_>
+                          , bs::pack_<bd::integer_<A0>, bs::avx_>
+                         )
+  {
+    BOOST_FORCEINLINE std::array<A0,2> operator()(A0 const& a0, A0 const& a1 ) const BOOST_NOEXCEPT
+    {
+      auto s00 = slice_low(a0), s01 = slice_high(a0);
+      auto s10 = slice_low(a1), s11 = slice_high(a1);
+
+      auto f = combine(deinterleave_first (s00,s01), deinterleave_first (s10,s11));
+      auto s = combine(deinterleave_second(s00,s01), deinterleave_second(s10,s11));
+
+      return {f,s};
+    }
+  };
+} } }
+
+#endif

--- a/include/boost/simd/arch/x86/avx2/simd/function/deinterleave.hpp
+++ b/include/boost/simd/arch/x86/avx2/simd/function/deinterleave.hpp
@@ -1,0 +1,47 @@
+//==================================================================================================
+/**
+  Copyright 2016 Numscale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_X86_AVX2_SIMD_FUNCTION_DEINTERLEAVE_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_X86_AVX2_SIMD_FUNCTION_DEINTERLEAVE_HPP_INCLUDED
+
+#include <boost/simd/detail/overload.hpp>
+#include <boost/simd/function/deinterleave_first.hpp>
+#include <boost/simd/function/deinterleave_second.hpp>
+#include <array>
+
+namespace boost { namespace simd { namespace ext
+{
+  namespace bd =  boost::dispatch;
+  namespace bs =  boost::simd;
+
+  BOOST_DISPATCH_OVERLOAD ( deinterleave_
+                          , (typename A0)
+                          , bs::avx2_
+                          , bs::pack_<bd::ints16_<A0>, bs::avx_>
+                          , bs::pack_<bd::ints16_<A0>, bs::avx_>
+                         )
+  {
+    BOOST_FORCEINLINE std::array<A0,2> operator()(A0 const& a0, A0 const& a1) const BOOST_NOEXCEPT
+    {
+      auto lo = _mm256_unpacklo_epi16(a0,a1);
+      auto hi = _mm256_unpackhi_epi16(a0,a1);
+
+      auto u0 = _mm256_unpacklo_epi16(lo,hi);
+      auto u1 = _mm256_unpackhi_epi16(lo,hi);
+
+      lo = _mm256_unpacklo_epi16(u0, u1);
+      hi = _mm256_unpackhi_epi16(u0, u1);
+
+      return  { _mm256_permute4x64_epi64(lo, 0xD8 )
+              , _mm256_permute4x64_epi64(hi, 0xD8 )
+              };
+    }
+  };
+} } }
+
+#endif

--- a/include/boost/simd/function/definition/deinterleave.hpp
+++ b/include/boost/simd/function/definition/deinterleave.hpp
@@ -1,0 +1,32 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_FUNCTION_DEFINITION_DEINTERLEAVE_HPP_INCLUDED
+#define BOOST_SIMD_FUNCTION_DEFINITION_DEINTERLEAVE_HPP_INCLUDED
+
+#include <boost/simd/config.hpp>
+#include <boost/simd/detail/dispatch/function/make_callable.hpp>
+#include <boost/simd/detail/dispatch/hierarchy/functions.hpp>
+#include <boost/simd/detail/dispatch.hpp>
+
+namespace boost { namespace simd
+{
+  namespace tag
+  {
+    BOOST_DISPATCH_MAKE_TAG(ext, deinterleave_, boost::dispatch::abstract_<deinterleave_>);
+  }
+
+  namespace ext
+  {
+    BOOST_DISPATCH_FUNCTION_DECLARATION(tag, deinterleave_);
+  }
+
+  BOOST_DISPATCH_CALLABLE_DEFINITION(tag::deinterleave_,deinterleave);
+} }
+
+#endif

--- a/include/boost/simd/function/deinterleave.hpp
+++ b/include/boost/simd/function/deinterleave.hpp
@@ -1,0 +1,44 @@
+//==================================================================================================
+/*!
+  @file
+
+  @copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#ifndef BOOST_SIMD_FUNCTION_DEINTERLEAVE_HPP_INCLUDED
+#define BOOST_SIMD_FUNCTION_DEINTERLEAVE_HPP_INCLUDED
+
+namespace boost { namespace simd
+{
+
+#if defined(DOXYGEN_ONLY)
+  /*!
+    @ingroup group-swar
+    Function object implementing deinterleave capabilities
+
+    Evaluates the two deinterleaved data extracted from its arguments
+    while minimizing redundant computations.
+
+    @par Semantic:
+
+    For every parameters @c x and @c y of type @c T :
+    @code
+    std::array<T,2> r = deinterleave(x,y);
+    @endcode
+
+    is equivalent to :
+
+    @code
+    std::array<T,2> r = { deinterleave_first(x,y), deinterleave_second(x,y) };
+    @endcode
+  **/
+  std::array<Value,2> deinterleave(Value const& v0, Value const& v1);
+#endif
+} }
+
+#include <boost/simd/function/simd/deinterleave.hpp>
+
+#endif

--- a/include/boost/simd/function/simd/deinterleave.hpp
+++ b/include/boost/simd/function/simd/deinterleave.hpp
@@ -1,0 +1,27 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+
+#ifndef BOOST_SIMD_FUNCTION_SIMD_DEINTERLEAVE_HPP_INCLUDED
+#define BOOST_SIMD_FUNCTION_SIMD_DEINTERLEAVE_HPP_INCLUDED
+
+#include <boost/simd/function/definition/deinterleave.hpp>
+#include <boost/simd/arch/common/generic/function/autodispatcher.hpp>
+#include <boost/simd/arch/common/simd/function/deinterleave.hpp>
+#include <boost/simd/arch/common/simd/function/shuffle/deinterleave.hpp>
+
+#if defined(BOOST_HW_SIMD_X86_OR_AMD_AVAILABLE)
+#  if BOOST_HW_SIMD_X86_OR_AMD >= BOOST_HW_SIMD_X86_AVX_VERSION
+#    include <boost/simd/arch/x86/avx/simd/function/deinterleave.hpp>
+#  endif
+#  if BOOST_HW_SIMD_X86_OR_AMD >= BOOST_HW_SIMD_X86_AVX2_VERSION
+#    include <boost/simd/arch/x86/avx2/simd/function/deinterleave.hpp>
+#  endif
+#endif
+
+#endif

--- a/test/function/simd/CMakeLists.txt
+++ b/test/function/simd/CMakeLists.txt
@@ -100,6 +100,7 @@ cumprod.cpp
 cumsum.cpp
 dec.cpp
 dec_s.cpp
+deinterleave.cpp
 deinterleave_first.cpp
 deinterleave_second.cpp
 dist.cpp

--- a/test/function/simd/deinterleave.cpp
+++ b/test/function/simd/deinterleave.cpp
@@ -1,0 +1,45 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#include <boost/simd/function/deinterleave.hpp>
+#include <boost/simd/pack.hpp>
+#include <simd_test.hpp>
+
+namespace bs = boost::simd;
+
+template <typename T, int N, typename Env>
+void test(Env&, std::false_type const&)
+{}
+
+template <typename T, int N, typename Env>
+void test(Env& $, std::true_type const& = {})
+{
+  using p_t = bs::pack<T, N>;
+
+  T a1[N], a2[N];
+  for(int i = 0; i < N; ++i)
+  {
+    a1[i] = (i%2) ? T(i) : T(2*i);
+    a2[i] = (i%2) ? T(i+N) : T(2*(i+N));
+  }
+
+  p_t aa1(&a1[0], &a1[0]+N);
+  p_t aa2(&a2[0], &a2[0]+N);
+
+  std::array<p_t,2> out = bs::deinterleave(aa1, aa2);
+  STF_EQUAL( out[0], bs::deinterleave_first(aa1,aa2)  );
+  STF_EQUAL( out[1], bs::deinterleave_second(aa1,aa2) );
+}
+
+STF_CASE_TPL("Check deinterleave on pack", STF_NUMERIC_TYPES)
+{
+  static const std::size_t N = bs::pack<T>::static_size;
+  test<T, N  >($, brigand::bool_<(N>1)>());
+  test<T, N/2>($, brigand::bool_<(N>2)>());
+  test<T, N*2>($);
+}


### PR DESCRIPTION
deinterleave(x,y) is a new function that returns an array containing both deinterleave_first and _second call over x and y. Implementation is made to be optimized in number of operations as far as possible.
