### PR TITLE
Make usage of is_aligned ore flexible

### DIFF
--- a/include/boost/simd/algorithm/transform.hpp
+++ b/include/boost/simd/algorithm/transform.hpp
@@ -13,7 +13,7 @@
 #include <boost/simd/function/aligned_store.hpp>
 #include <boost/simd/function/store.hpp>
 #include <boost/simd/pack.hpp>
-#include <boost/align/is_aligned.hpp>
+#include <boost/simd/detail/is_aligned.hpp>
 
 namespace boost { namespace simd
 {
@@ -72,7 +72,7 @@ namespace boost { namespace simd
     for( auto const & e : std::get<0>(pr) ) *out++ = f(e);
 
     // main SIMD part - checks if we can store efficiently or not
-    if(boost::alignment::is_aligned(out, vU::alignment))
+    if(boost::simd::detail::is_aligned(out, vU::alignment))
     {
       for( auto const& e : std::get<1>(pr) )
       {
@@ -119,8 +119,8 @@ namespace boost { namespace simd
     for( auto const & e : std::get<0>(pr) ) *out++ = f(e, *first2++);
 
     // main SIMD part - Everybody is aligned
-    if(   boost::alignment::is_aligned(out    , vU::alignment )
-      &&  boost::alignment::is_aligned(first2 , vT2::alignment)
+    if(   boost::simd::detail::is_aligned(out    , vU::alignment )
+      &&  boost::simd::detail::is_aligned(first2 , vT2::alignment)
       )
     {
       for( auto const& e : std::get<1>(pr) )
@@ -131,7 +131,7 @@ namespace boost { namespace simd
       }
     }
     // main SIMD part - input1 and output is aligned
-    else if( boost::alignment::is_aligned(out, vU::alignment ) )
+    else if( boost::simd::detail::is_aligned(out, vU::alignment ) )
     {
       for( auto const& e : std::get<1>(pr) )
       {
@@ -141,7 +141,7 @@ namespace boost { namespace simd
       }
     }
     // main SIMD part - Both inputs is aligned
-    else if( boost::alignment::is_aligned(first2, vT2::alignment ) )
+    else if( boost::simd::detail::is_aligned(first2, vT2::alignment ) )
     {
       for( auto const& e : std::get<1>(pr) )
       {

--- a/include/boost/simd/arch/common/simd/function/aligned_load/mask.hpp
+++ b/include/boost/simd/arch/common/simd/function/aligned_load/mask.hpp
@@ -12,7 +12,7 @@
 #include <boost/simd/detail/overload.hpp>
 #include <boost/simd/function/load.hpp>
 #include <boost/simd/mask.hpp>
-#include <boost/align/is_aligned.hpp>
+#include <boost/simd/detail/is_aligned.hpp>
 #include <boost/assert.hpp>
 
 namespace boost { namespace simd { namespace ext
@@ -34,7 +34,7 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE
     target_t operator()(Pointer const& p, Target const&) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p.get(),target_t::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(p.get(),target_t::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer"
                       );
 

--- a/include/boost/simd/arch/common/simd/function/aligned_load/misaligned.hpp
+++ b/include/boost/simd/arch/common/simd/function/aligned_load/misaligned.hpp
@@ -14,7 +14,7 @@
 #include <boost/simd/function/load.hpp>
 #include <boost/simd/detail/dispatch/adapted/common/pointer.hpp>
 #include <boost/simd/detail/dispatch/adapted/std/integral_constant.hpp>
-#include <boost/align/is_aligned.hpp>
+#include <boost/simd/detail/is_aligned.hpp>
 #include <boost/assert.hpp>
 
 #ifdef BOOST_MSVC
@@ -44,7 +44,7 @@ namespace boost { namespace simd { namespace ext
       static const std::size_t                        card = target_t::static_size;
       static const typename Misalignment::value_type  unalignment = Misalignment::value % card;
 
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p-Misalignment::value,target_t::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(p-Misalignment::value,target_t::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer"
                       );
 

--- a/include/boost/simd/arch/common/simd/function/aligned_load/regular.hpp
+++ b/include/boost/simd/arch/common/simd/function/aligned_load/regular.hpp
@@ -13,7 +13,7 @@
 #include <boost/simd/function/combine.hpp>
 #include <boost/simd/function/load.hpp>
 #include <boost/simd/detail/dispatch/adapted/common/pointer.hpp>
-#include <boost/align/is_aligned.hpp>
+#include <boost/simd/detail/is_aligned.hpp>
 #include <boost/assert.hpp>
 
 namespace boost { namespace simd { namespace ext
@@ -35,7 +35,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target_t operator()(Pointer p, Target const&) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p,target_t::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(p,target_t::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer"
                       );
 

--- a/include/boost/simd/arch/common/simd/function/aligned_store.hpp
+++ b/include/boost/simd/arch/common/simd/function/aligned_store.hpp
@@ -12,7 +12,7 @@
 #include <boost/simd/detail/overload.hpp>
 #include <boost/simd/detail/dispatch/adapted/common/pointer.hpp>
 #include <boost/simd/function/store.hpp>
-#include <boost/align/is_aligned.hpp>
+#include <boost/simd/detail/is_aligned.hpp>
 #include <boost/config.hpp>
 
 namespace boost { namespace simd { namespace ext
@@ -31,7 +31,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE void operator()(const A0& a0, A1  a1) const BOOST_NOEXCEPT
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(a1,A0::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(a1,A0::alignment)
                       , "boost::simd::aligned_store was performed on an unaligned pointer of integer"
                       );
       bs::store(a0, a1);

--- a/include/boost/simd/arch/ppc/vmx/simd/function/aligned_load.hpp
+++ b/include/boost/simd/arch/ppc/vmx/simd/function/aligned_load.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
     using target = typename Target::type;
     BOOST_FORCEINLINE target operator()(Pointer p, Target const&) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p,target::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(p,target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of double"
                       );
 

--- a/include/boost/simd/arch/ppc/vmx/simd/function/aligned_store.hpp
+++ b/include/boost/simd/arch/ppc/vmx/simd/function/aligned_store.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE void operator()(const Src& s, Pointer p) const BOOST_NOEXCEPT
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, Src::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(p, Src::alignment)
                       , "boost::simd::aligned_store was performed on an unaligned pointer"
                       );
 

--- a/include/boost/simd/arch/x86/avx/simd/function/aligned_load.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/aligned_load.hpp
@@ -12,7 +12,7 @@
 #include <boost/simd/detail/overload.hpp>
 #include <boost/simd/function/if_else.hpp>
 #include <boost/simd/detail/dispatch/adapted/common/pointer.hpp>
-#include <boost/align/is_aligned.hpp>
+#include <boost/simd/detail/is_aligned.hpp>
 #include <boost/assert.hpp>
 
 #ifdef BOOST_MSVC
@@ -37,7 +37,7 @@ namespace boost { namespace simd { namespace ext
     using target = typename Target::type;
     BOOST_FORCEINLINE target operator()(Pointer p, Target const&) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of integer"
                       );
 
@@ -57,7 +57,7 @@ namespace boost { namespace simd { namespace ext
     using target = typename Target::type;
     BOOST_FORCEINLINE target operator()(Pointer p, Target const&) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of double"
                       );
 
@@ -78,7 +78,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator() ( Pointer p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of float"
                       );
 
@@ -130,7 +130,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Pointer const& p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned masked pointer of float"
                       );
       __m256i msk = _mm256_castps_si256(bs::as_logical_t<target>(p.mask()).storage());
@@ -149,7 +149,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Pointer const& p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned masked pointer of float"
                       );
       auto const& msk = p.mask();
@@ -173,7 +173,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Pointer const& p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned masked pointer of double"
                       );
       __m256i msk = _mm256_castpd_si256(bs::as_logical_t<target>(p.mask()).storage());
@@ -192,7 +192,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Pointer const& p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned masked pointer of float"
                       );
       auto const& msk = p.mask();

--- a/include/boost/simd/arch/x86/avx/simd/function/aligned_store.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/aligned_store.hpp
@@ -11,7 +11,7 @@
 
 #include <boost/simd/detail/overload.hpp>
 #include <boost/simd/detail/dispatch/adapted/common/pointer.hpp>
-#include <boost/align/is_aligned.hpp>
+#include <boost/simd/detail/is_aligned.hpp>
 #include <boost/assert.hpp>
 
 namespace boost { namespace simd { namespace ext
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE void operator() (const Vec& a0, Pointer a1) const BOOST_NOEXCEPT
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(a1, Vec::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(a1, Vec::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of double"
                       );
       _mm256_store_pd(a1,a0);
@@ -44,7 +44,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE void operator() (const Vec& a0, Pointer a1) const BOOST_NOEXCEPT
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(a1, Vec::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(a1, Vec::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of float"
                       );
       _mm256_store_ps(a1,a0);
@@ -60,7 +60,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE void operator() (const Vec& a0, Pointer a1) const BOOST_NOEXCEPT
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(a1, Vec::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(a1, Vec::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of integer"
                       );
        _mm256_store_si256(reinterpret_cast<__m256i*>(a1), a0);

--- a/include/boost/simd/arch/x86/avx2/simd/function/aligned_load.hpp
+++ b/include/boost/simd/arch/x86/avx2/simd/function/aligned_load.hpp
@@ -12,7 +12,7 @@
 #include <boost/simd/meta/hierarchy/simd.hpp>
 #include <boost/simd/detail/dispatch/function/overload.hpp>
 #include <boost/simd/detail/dispatch/adapted/common/pointer.hpp>
-#include <boost/align/is_aligned.hpp>
+#include <boost/simd/detail/is_aligned.hpp>
 #include <boost/assert.hpp>
 #include <boost/config.hpp>
 
@@ -34,7 +34,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Pointer const& p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an "
                         "unaligned masked pointer of 32 bits integers"
                       );
@@ -56,7 +56,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Pointer const& p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an "
                         "unaligned masked pointer of 32 bits integers"
                       );
@@ -82,7 +82,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Pointer const& p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an "
                         "unaligned masked pointer of 64 bits integers"
                       );
@@ -104,7 +104,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Pointer const& p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an "
                         "unaligned masked pointer of 64 bits integers"
                       );

--- a/include/boost/simd/arch/x86/sse1/simd/function/aligned_load.hpp
+++ b/include/boost/simd/arch/x86/sse1/simd/function/aligned_load.hpp
@@ -14,7 +14,7 @@
 #include <boost/simd/detail/overload.hpp>
 #include <boost/simd/function/slide.hpp>
 #include <boost/simd/detail/dispatch/adapted/common/pointer.hpp>
-#include <boost/align/is_aligned.hpp>
+#include <boost/simd/detail/is_aligned.hpp>
 #include <boost/assert.hpp>
 
 #ifdef BOOST_MSVC
@@ -40,7 +40,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator()(Pointer p, Target const&) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of float"
                       );
 

--- a/include/boost/simd/arch/x86/sse1/simd/function/aligned_store.hpp
+++ b/include/boost/simd/arch/x86/sse1/simd/function/aligned_store.hpp
@@ -13,7 +13,7 @@
 
 #include <boost/simd/detail/overload.hpp>
 #include <boost/simd/detail/dispatch/adapted/common/pointer.hpp>
-#include <boost/align/is_aligned.hpp>
+#include <boost/simd/detail/is_aligned.hpp>
 
 namespace boost { namespace simd { namespace ext
 {
@@ -29,7 +29,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE void operator() (const Vec& a0, Pointer a1) const BOOST_NOEXCEPT
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(a1, Vec::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(a1, Vec::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of integer"
                       );
       _mm_store_ps(a1,a0);

--- a/include/boost/simd/arch/x86/sse2/simd/function/aligned_load.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/aligned_load.hpp
@@ -14,7 +14,7 @@
 #include <boost/simd/detail/overload.hpp>
 #include <boost/simd/detail/dispatch/adapted/common/pointer.hpp>
 #include <boost/simd/meta/is_pointing_to.hpp>
-#include <boost/align/is_aligned.hpp>
+#include <boost/simd/detail/is_aligned.hpp>
 #include <boost/assert.hpp>
 
 namespace boost { namespace simd { namespace ext
@@ -34,7 +34,7 @@ namespace boost { namespace simd { namespace ext
     using target = typename Target::type;
     BOOST_FORCEINLINE target operator()(Pointer p, Target const&) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of double"
                       );
 
@@ -56,7 +56,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE target operator() ( Pointer p, Target const& ) const
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(p, target::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(p, target::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of integer"
                       );
 

--- a/include/boost/simd/arch/x86/sse2/simd/function/aligned_store.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/aligned_store.hpp
@@ -12,7 +12,7 @@
 #include <boost/simd/detail/overload.hpp>
 #include <boost/simd/detail/dispatch/adapted/common/pointer.hpp>
 #include <boost/simd/meta/is_pointing_to.hpp>
-#include <boost/align/is_aligned.hpp>
+#include <boost/simd/detail/is_aligned.hpp>
 
 namespace boost { namespace simd { namespace ext
 {
@@ -29,7 +29,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE void operator() (const Vec& a0, Pointer a1) const BOOST_NOEXCEPT
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(a1, Vec::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(a1, Vec::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of integer"
                       );
       _mm_store_pd(reinterpret_cast<double*>(a1),a0);
@@ -46,7 +46,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE void operator() (const Vec& a0, Pointer a1) const BOOST_NOEXCEPT
     {
-      BOOST_ASSERT_MSG( boost::alignment::is_aligned(a1, Vec::alignment)
+      BOOST_ASSERT_MSG( boost::simd::detail::is_aligned(a1, Vec::alignment)
                       , "boost::simd::aligned_load was performed on an unaligned pointer of integer"
                       );
        _mm_store_si128(reinterpret_cast<__m128i*>(a1), a0);

--- a/include/boost/simd/detail/is_aligned.hpp
+++ b/include/boost/simd/detail/is_aligned.hpp
@@ -1,0 +1,31 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_DETAIL_IS_ALIGNED_HPP_INCLUDED
+#define BOOST_SIMD_DETAIL_IS_ALIGNED_HPP_INCLUDED
+
+#include <boost/align/is_aligned.hpp>
+
+namespace boost { namespace simd { namespace detail
+{
+  inline bool is_aligned(const void* ptr,std::size_t alignment) BOOST_NOEXCEPT
+  {
+#if (BOOST_VERSION > 106000)
+    return boost::alignment::is_aligned(ptr,alignment);
+#else
+    return boost::alignment::is_aligned(alignment,ptr);
+#endif
+  }
+
+  inline bool is_aligned(std::size_t value,std::size_t alignment) BOOST_NOEXCEPT
+  {
+    return (value & (alignment - 1)) == 0;
+  }
+} } }
+
+#endif

--- a/include/boost/simd/pack.hpp
+++ b/include/boost/simd/pack.hpp
@@ -27,7 +27,7 @@
 #include <boost/simd/function/inc.hpp>
 #include <boost/simd/function/dec.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <boost/align/is_aligned.hpp>
+#include <boost/simd/detail/is_aligned.hpp>
 #include <boost/config.hpp>
 #include <array>
 #include <iterator>

--- a/include/boost/simd/range/aligned_input_range.hpp
+++ b/include/boost/simd/range/aligned_input_range.hpp
@@ -14,7 +14,7 @@
 
 #include <boost/simd/range/detail/aligned_input_iterator.hpp>
 #include <boost/range/iterator_range.hpp>
-#include <boost/align/is_aligned.hpp>
+#include <boost/simd/detail/is_aligned.hpp>
 #include <boost/assert.hpp>
 #include <iterator>
 
@@ -43,7 +43,7 @@ namespace boost { namespace simd
   aligned_input_range( Iterator begin, Iterator end )
   {
     BOOST_ASSERT_MSG
-    ( boost::alignment::is_aligned(std::distance(begin,end), C)
+    ( boost::simd::detail::is_aligned(std::distance(begin,end), C)
     , "Range being adapted holds a non integral number of SIMD pack."
     );
 
@@ -58,7 +58,7 @@ namespace boost { namespace simd
   aligned_input_range( Iterator begin, Iterator end )
   {
     BOOST_ASSERT_MSG
-    ( boost::alignment::is_aligned( std::distance(begin,end)
+    ( boost::simd::detail::is_aligned( std::distance(begin,end)
                                   , detail::aligned_input_iterator<Iterator>::cardinal
                                   )
     , "Range being adapted holds a non integral number of SIMD pack."

--- a/include/boost/simd/range/aligned_output_range.hpp
+++ b/include/boost/simd/range/aligned_output_range.hpp
@@ -14,7 +14,7 @@
 
 #include <boost/simd/range/detail/aligned_output_iterator.hpp>
 #include <boost/range/iterator_range.hpp>
-#include <boost/align/is_aligned.hpp>
+#include <boost/simd/detail/is_aligned.hpp>
 #include <boost/assert.hpp>
 #include <iterator>
 
@@ -43,7 +43,7 @@ namespace boost { namespace simd
   aligned_output_range( Iterator begin, Iterator end )
   {
     BOOST_ASSERT_MSG
-    ( boost::alignment::is_aligned(std::distance(begin,end), C)
+    ( boost::simd::detail::is_aligned(std::distance(begin,end), C)
     , "Range being adapted holds a non integral number of SIMD pack."
     );
 
@@ -58,7 +58,7 @@ namespace boost { namespace simd
   aligned_output_range( Iterator begin, Iterator end )
   {
     BOOST_ASSERT_MSG
-    ( boost::alignment::is_aligned( std::distance(begin,end)
+    ( boost::simd::detail::is_aligned( std::distance(begin,end)
                 , detail::aligned_output_iterator<Iterator>::cardinal
                 )
     , "Range being adapted holds a non integral number of SIMD pack."

--- a/include/boost/simd/range/detail/aligned_input_iterator.hpp
+++ b/include/boost/simd/range/detail/aligned_input_iterator.hpp
@@ -15,7 +15,7 @@
 #include <boost/simd/range/detail/uncheck_iterator.hpp>
 #include <boost/simd/range/detail/input_iterator_base.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
-#include <boost/align/is_aligned.hpp>
+#include <boost/simd/detail/is_aligned.hpp>
 #include <boost/core/ignore_unused.hpp>
 #include <boost/config.hpp>
 #include <iterator>
@@ -56,7 +56,7 @@ namespace boost { namespace simd { namespace detail
 
       using target_pack = pack<typename std::iterator_traits<Iterator>::value_type, C>;
       BOOST_ASSERT_MSG
-      ( boost::alignment::is_aligned(&(*lp) , target_pack::alignment )
+      ( boost::simd::detail::is_aligned(&(*lp) , target_pack::alignment )
       , "The constructor of aligned_input_iterator has been called on a pointer "
         "which alignment is not compatible with the current SIMD extension."
       );

--- a/include/boost/simd/range/detail/aligned_output_iterator.hpp
+++ b/include/boost/simd/range/detail/aligned_output_iterator.hpp
@@ -16,7 +16,7 @@
 #include <boost/simd/range/detail/output_iterator_base.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/core/ignore_unused.hpp>
-#include <boost/align/is_aligned.hpp>
+#include <boost/simd/detail/is_aligned.hpp>
 #include <boost/assert.hpp>
 
 namespace boost { namespace simd { namespace detail
@@ -55,7 +55,7 @@ namespace boost { namespace simd { namespace detail
 
       using target_pack = pack<typename std::iterator_traits<Iterator>::value_type, C>;
       BOOST_ASSERT_MSG
-      ( boost::alignment::is_aligned(&(*lp) , target_pack::alignment )
+      ( boost::simd::detail::is_aligned(&(*lp) , target_pack::alignment )
       , "The constructor of iterator<T,C> has been called on a pointer "
         "which alignment is not compatible with the current SIMD extension."
       );

--- a/include/boost/simd/range/input_range.hpp
+++ b/include/boost/simd/range/input_range.hpp
@@ -14,7 +14,7 @@
 
 #include <boost/simd/range/detail/input_iterator.hpp>
 #include <boost/range/iterator_range.hpp>
-#include <boost/align/is_aligned.hpp>
+#include <boost/simd/detail/is_aligned.hpp>
 #include <boost/assert.hpp>
 #include <iterator>
 
@@ -42,7 +42,7 @@ namespace boost { namespace simd
   input_range( Iterator begin, Iterator end )
   {
     BOOST_ASSERT_MSG
-    ( boost::alignment::is_aligned(std::distance(begin,end), N)
+    ( boost::simd::detail::is_aligned(std::distance(begin,end), N)
     , "Range being adapted holds a non integral number of SIMD pack."
     );
 
@@ -55,7 +55,7 @@ namespace boost { namespace simd
   input_range( Iterator begin, Iterator end )
   {
     BOOST_ASSERT_MSG
-    ( boost::alignment::is_aligned(std::distance(begin,end) , detail::input_iterator<Iterator>::cardinal)
+    ( boost::simd::detail::is_aligned(std::distance(begin,end) , detail::input_iterator<Iterator>::cardinal)
     , "Range being adapted holds a non integral number of SIMD pack."
     );
 

--- a/include/boost/simd/range/output_range.hpp
+++ b/include/boost/simd/range/output_range.hpp
@@ -14,7 +14,7 @@
 
 #include <boost/simd/range/detail/output_iterator.hpp>
 #include <boost/range/iterator_range.hpp>
-#include <boost/align/is_aligned.hpp>
+#include <boost/simd/detail/is_aligned.hpp>
 #include <boost/assert.hpp>
 #include <iterator>
 
@@ -42,7 +42,7 @@ namespace boost { namespace simd
   output_range( Iterator begin, Iterator end )
   {
     BOOST_ASSERT_MSG
-    ( boost::alignment::is_aligned(std::distance(begin,end), C)
+    ( boost::simd::detail::is_aligned(std::distance(begin,end), C)
     , "Range being adapted holds a non integral number of SIMD pack."
     );
 
@@ -57,7 +57,7 @@ namespace boost { namespace simd
   output_range( Iterator begin, Iterator end )
   {
     BOOST_ASSERT_MSG
-    ( boost::alignment::is_aligned(std::distance(begin,end) , detail::output_iterator<Iterator>::cardinal)
+    ( boost::simd::detail::is_aligned(std::distance(begin,end) , detail::output_iterator<Iterator>::cardinal)
     , "Range being adapted holds a non integral number of SIMD pack."
     );
 


### PR DESCRIPTION
is_aligned in boost::alignment changed its prototype recently and it made the requirements ont he boost version a bit too high. This wrap the difference so bosot requirements can go down.
