### PR TITLE
Equal in unit tests

### DIFF
--- a/test/function/scalar/abs.cpp
+++ b/test/function/scalar/abs.cpp
@@ -27,13 +27,13 @@ STF_CASE_TPL( "Check abs behavior with floating", STF_IEEE_TYPES )
   STF_TYPE_IS(r_t, T);
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(abs(bs::Inf<T>()),  bs::Inf<r_t>());
-  STF_EQUAL(abs(bs::Minf<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(abs(bs::Nan<T>()),  bs::Nan<r_t>());
+  STF_ULP_EQUAL(abs(bs::Inf<T>()),  bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(abs(bs::Minf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(abs(bs::Nan<T>()),  bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(abs(bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(abs(bs::One<T>()),  bs::One<r_t>());
-  STF_EQUAL(abs(bs::Mone<T>()), bs::One<r_t>());
+  STF_ULP_EQUAL(abs(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(abs(bs::One<T>()),  bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(abs(bs::Mone<T>()), bs::One<r_t>(), 0.5);
 }
 
 STF_CASE_TPL( "Check abs behavior with signed integral", STF_SIGNED_INTEGRAL_TYPES )
@@ -61,13 +61,13 @@ STF_CASE_TPL( "Check std abs behavior with floating", STF_IEEE_TYPES )
   STF_TYPE_IS(r_t, T);
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bs::std_(abs)(bs::Inf<T>()),  bs::Inf<r_t>());
-  STF_EQUAL(bs::std_(abs)(bs::Minf<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(bs::std_(abs)(bs::Nan<T>()),  bs::Nan<r_t>());
+  STF_ULP_EQUAL(bs::std_(abs)(bs::Inf<T>()),  bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(abs)(bs::Minf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(abs)(bs::Nan<T>()),  bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(bs::std_(abs)(bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(bs::std_(abs)(bs::One<T>()),  bs::One<r_t>());
-  STF_EQUAL(bs::std_(abs)(bs::Mone<T>()), bs::One<r_t>());
+  STF_ULP_EQUAL(bs::std_(abs)(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(abs)(bs::One<T>()),  bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(abs)(bs::Mone<T>()), bs::One<r_t>(), 0.5);
 }
 
 STF_CASE_TPL( "Check std abs behavior with signed integral", STF_SIGNED_INTEGRAL_TYPES )

--- a/test/function/scalar/abs.saturated.cpp
+++ b/test/function/scalar/abs.saturated.cpp
@@ -27,15 +27,15 @@ STF_CASE_TPL( "Check bs::saturated_(abs) behavior with floating", STF_IEEE_TYPES
   STF_TYPE_IS(r_t, T);
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bs::saturated_(abs)(bs::Inf<T>()),  bs::Inf<r_t>());
-  STF_EQUAL(bs::saturated_(abs)(bs::Minf<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(bs::saturated_(abs)(bs::Nan<T>()),  bs::Nan<r_t>());
+  STF_ULP_EQUAL(bs::saturated_(abs)(bs::Inf<T>()),  bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(abs)(bs::Minf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(abs)(bs::Nan<T>()),  bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(bs::saturated_(abs)(bs::Mone<T>()), bs::One<T>());
-  STF_EQUAL(bs::saturated_(abs)(bs::One<T>()), bs::One<T>());
-  STF_EQUAL(bs::saturated_(abs)(bs::Valmax<T>()), bs::Valmax<T>());
-  STF_EQUAL(bs::saturated_(abs)(bs::Valmin<T>()), bs::Valmax<T>());
-  STF_EQUAL(bs::saturated_(abs)(bs::Zero<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(bs::saturated_(abs)(bs::Mone<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(abs)(bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(abs)(bs::Valmax<T>()), bs::Valmax<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(abs)(bs::Valmin<T>()), bs::Valmax<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(abs)(bs::Zero<T>()), bs::Zero<T>(), 0.5);
 }
 
 

--- a/test/function/scalar/arg.cpp
+++ b/test/function/scalar/arg.cpp
@@ -28,13 +28,13 @@ STF_CASE_TPL (" arg real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(arg(bs::Inf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(arg(bs::Minf<T>()), bs::Pi<r_t>());
-  STF_IEEE_EQUAL(arg(bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(arg(bs::Inf<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(arg(bs::Minf<T>()), bs::Pi<r_t>(), 0.5);
+  STF_ULP_EQUAL(arg(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(arg(bs::Mone<T>()), bs::Pi<r_t>());
-  STF_EQUAL(arg(bs::One<T>()), bs::Zero<r_t>());
-  STF_EQUAL(arg(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(arg(bs::Mone<T>()), bs::Pi<r_t>(), 0.5);
+  STF_ULP_EQUAL(arg(bs::One<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(arg(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 } // end of test for floating_
 
 

--- a/test/function/scalar/average.cpp
+++ b/test/function/scalar/average.cpp
@@ -29,13 +29,13 @@ STF_CASE_TPL (" average real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(average(bs::Inf<T>(),  bs::Inf<T>()),  bs::Inf<T>());
-  STF_EQUAL(average(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<T>());
-  STF_IEEE_EQUAL(average(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(average(bs::Inf<T>(),  bs::Inf<T>()),  bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(average(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<T>(), 0.5);
+  STF_ULP_EQUAL(average(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(average(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<T>());
-  STF_EQUAL(average(bs::One<T>(),  bs::One<T>()),  bs::One<T>());
-  STF_EQUAL(average(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(average(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(average(bs::One<T>(),  bs::One<T>()),  bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(average(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" average signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/bitinteger.cpp
+++ b/test/function/scalar/bitinteger.cpp
@@ -31,11 +31,11 @@ STF_CASE_TPL (" bit integerreal",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bitinteger(bs::Nan<T>()), -bs::Valmax<r_t>());
+  STF_ULP_EQUAL(bitinteger(bs::Nan<T>()), -bs::Valmax<r_t>(), 0.5);
 #endif
 #if !defined(BOOST_SIMD_NO_DENORMALS)
-  STF_EQUAL(bitinteger(bs::Bitincrement<T>()), bs::One<r_t>());
-  STF_EQUAL(bitinteger(-bs::Bitincrement<T>()), bs::Mone<r_t>());
+  STF_ULP_EQUAL(bitinteger(bs::Bitincrement<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitinteger(-bs::Bitincrement<T>()), bs::Mone<r_t>(), 0.5);
 #endif
-  STF_EQUAL(bitinteger(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(bitinteger(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 }

--- a/test/function/scalar/bitofsign.cpp
+++ b/test/function/scalar/bitofsign.cpp
@@ -29,13 +29,13 @@ STF_CASE_TPL (" bitofsign real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bitofsign(bs::Inf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(bitofsign(bs::Minf<T>()), bs::Mzero<r_t>());
-  STF_IEEE_EQUAL(bitofsign(bs::Nan<T>()), bs::Mzero<r_t>());
+  STF_ULP_EQUAL(bitofsign(bs::Inf<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitofsign(bs::Minf<T>()), bs::Mzero<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitofsign(bs::Nan<T>()), bs::Mzero<r_t>(), 0.5);
 #endif
-  STF_EQUAL(bitofsign(bs::Mzero<T>()), bs::Mzero<r_t>());
-  STF_EQUAL(bitofsign(bs::One<T>()), bs::Zero<r_t>());
-  STF_EQUAL(bitofsign(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(bitofsign(bs::Mzero<T>()), bs::Mzero<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitofsign(bs::One<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitofsign(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 }
 
 STF_CASE_TPL (" bitofsign unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/bits.cpp
+++ b/test/function/scalar/bits.cpp
@@ -30,9 +30,9 @@ STF_CASE_TPL (" bits real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(bits(bs::Nan<T>()), bs::Mone<r_t>());
+  STF_ULP_EQUAL(bits(bs::Nan<T>()), bs::Mone<r_t>(), 0.5);
 #endif
-  STF_EQUAL(bits(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(bits(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" bits signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/bitwise_and.cpp
+++ b/test/function/scalar/bitwise_and.cpp
@@ -29,11 +29,11 @@ STF_CASE_TPL( "Check bitwise_and behavior with floating", STF_IEEE_TYPES )
   STF_TYPE_IS(r_t, T);
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bitwise_and(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(bitwise_and(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(bitwise_and(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(bitwise_and(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitwise_and(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitwise_and(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(bitwise_and(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(bitwise_and(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 }
 
 STF_CASE_TPL("bitwise_and_ui", STF_UNSIGNED_INTEGRAL_TYPES)
@@ -77,9 +77,9 @@ STF_CASE_TPL("bitwise_and_mix", STF_IEEE_TYPES)
   STF_EXPR_IS(bitwise_and(siT(), T()), siT);
 
   // specific values tests
-  STF_EQUAL(bitwise_and(bs::Zero<T>(),bs::Zero<uiT>()), bs::Zero<T>());
-  STF_EQUAL(bitwise_and(bs::Zero<T>(), bs::Zero<siT>()), bs::Zero<T>());
-  STF_EQUAL(bitwise_and(bs::Valmin<siT>(),bs::Nan<T>()), bs::Valmin<siT>());
-  STF_EQUAL(bitwise_and(bs::Zero<uiT>(), bs::Nan<T>()), bs::Zero<uiT>());
+  STF_ULP_EQUAL(bitwise_and(bs::Zero<T>(),bs::Zero<uiT>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bitwise_and(bs::Zero<T>(), bs::Zero<siT>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bitwise_and(bs::Valmin<siT>(),bs::Nan<T>()), bs::Valmin<siT>(), 0.5);
+  STF_ULP_EQUAL(bitwise_and(bs::Zero<uiT>(), bs::Nan<T>()), bs::Zero<uiT>(), 0.5);
 }
 

--- a/test/function/scalar/bitwise_andnot.cpp
+++ b/test/function/scalar/bitwise_andnot.cpp
@@ -31,12 +31,12 @@ STF_CASE_TPL (" bitwise_andnot real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bitwise_andnot(bs::Inf<T>(), bs::Inf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(bitwise_andnot(bs::Minf<T>(), bs::Minf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(bitwise_andnot(bs::Nan<T>(), bs::Nan<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(bitwise_andnot(bs::Inf<T>(), bs::Inf<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitwise_andnot(bs::Minf<T>(), bs::Minf<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitwise_andnot(bs::Nan<T>(), bs::Nan<T>()), bs::Zero<r_t>(), 0.5);
 #endif
-  STF_EQUAL(bitwise_andnot(bs::One<T>(),bs::Zero<T>()), bs::One<r_t>());
-  STF_EQUAL(bitwise_andnot(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(bitwise_andnot(bs::One<T>(),bs::Zero<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitwise_andnot(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" bitwise_andnot integer",  STF_INTEGRAL_TYPES)
@@ -70,10 +70,10 @@ STF_CASE_TPL("bitwise_andnot mix", STF_IEEE_TYPES)
   STF_EXPR_IS(bitwise_andnot(siT(), T()), siT);
 
   // specific values tests
-  STF_IEEE_EQUAL(bitwise_andnot(bs::Nan<T>(),bs::Zero<uiT>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bitwise_andnot(bs::Nan<T>(), bs::Zero<siT>()), bs::Nan<T>());
-  STF_EQUAL(bitwise_andnot(bs::Mone<siT>(),bs::Zero<T>()), bs::Mone<siT>());
-  STF_EQUAL(bitwise_andnot(bs::Valmax<uiT>(), bs::Zero<T>()), bs::Valmax<uiT>());
+  STF_ULP_EQUAL(bitwise_andnot(bs::Nan<T>(),bs::Zero<uiT>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bitwise_andnot(bs::Nan<T>(), bs::Zero<siT>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bitwise_andnot(bs::Mone<siT>(),bs::Zero<T>()), bs::Mone<siT>(), 0.5);
+  STF_ULP_EQUAL(bitwise_andnot(bs::Valmax<uiT>(), bs::Zero<T>()), bs::Valmax<uiT>(), 0.5);
 }
 
 

--- a/test/function/scalar/bitwise_not.cpp
+++ b/test/function/scalar/bitwise_not.cpp
@@ -32,9 +32,9 @@ STF_CASE_TPL ("check bitwise_not for floating",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bitwise_not(bs::Nan<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(bitwise_not(bs::Nan<T>()), bs::Zero<r_t>(), 0.5);
 #endif
-  STF_IEEE_EQUAL(bitwise_not(bs::Zero<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(bitwise_not(bs::Zero<T>()), bs::Nan<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL ("check bitwise_not for integral",  STF_INTEGRAL_TYPES)

--- a/test/function/scalar/bitwise_notand.cpp
+++ b/test/function/scalar/bitwise_notand.cpp
@@ -29,12 +29,12 @@ STF_CASE_TPL (" bitwise_notand real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bitwise_notand(bs::Inf<T>(), bs::Inf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(bitwise_notand(bs::Minf<T>(), bs::Minf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(bitwise_notand(bs::Nan<T>(), bs::Nan<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(bitwise_notand(bs::Inf<T>(), bs::Inf<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitwise_notand(bs::Minf<T>(), bs::Minf<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitwise_notand(bs::Nan<T>(), bs::Nan<T>()), bs::Zero<r_t>(), 0.5);
 #endif
-  STF_EQUAL(bitwise_notand(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(bitwise_notand(bs::Zero<T>(),bs::One<T>()), bs::One<r_t>());
+  STF_ULP_EQUAL(bitwise_notand(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitwise_notand(bs::Zero<T>(),bs::One<T>()), bs::One<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL("bitwise_notand mix", STF_IEEE_TYPES)
@@ -52,8 +52,8 @@ STF_CASE_TPL("bitwise_notand mix", STF_IEEE_TYPES)
   STF_EXPR_IS(bitwise_notand(siT(), T()), siT);
 
   // specific values tests
-  STF_IEEE_EQUAL(bitwise_notand(bs::Zero<T>(),bs::Valmax<uiT>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bitwise_notand(bs::Zero<T>(), bs::Mone<siT>()), bs::Nan<T>());
-  STF_EQUAL(bitwise_notand(bs::Zero<siT>(),bs::Nan<T>()), bs::Mone<siT>());
-  STF_EQUAL(bitwise_notand(bs::Zero<uiT>(), bs::Nan<T>()), bs::Valmax<uiT>());
+  STF_ULP_EQUAL(bitwise_notand(bs::Zero<T>(),bs::Valmax<uiT>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bitwise_notand(bs::Zero<T>(), bs::Mone<siT>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bitwise_notand(bs::Zero<siT>(),bs::Nan<T>()), bs::Mone<siT>(), 0.5);
+  STF_ULP_EQUAL(bitwise_notand(bs::Zero<uiT>(), bs::Nan<T>()), bs::Valmax<uiT>(), 0.5);
 }

--- a/test/function/scalar/bitwise_notor.cpp
+++ b/test/function/scalar/bitwise_notor.cpp
@@ -32,11 +32,11 @@ STF_CASE_TPL (" bitwise_notor real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(bitwise_notor(bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(bitwise_notor(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(bitwise_notor(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(bitwise_notor(bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitwise_notor(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitwise_notor(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_IEEE_EQUAL(bitwise_notor(bs::Zero<T>(), bs::Zero<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(bitwise_notor(bs::Zero<T>(), bs::Zero<T>()), bs::Nan<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" bitwise_notor signed_int",  STF_SIGNED_INTEGRAL_TYPES)
@@ -89,8 +89,8 @@ STF_CASE_TPL("bitwise_notor mix", STF_IEEE_TYPES)
   STF_EXPR_IS(bitwise_notor(siT(), T()), siT);
 
    // specific values tests
-  STF_EQUAL(bitwise_notor(bs::Nan<T>(),bs::One<uiT>()), bs::Bitincrement<T>());
-  STF_EQUAL(bitwise_notor(bs::Nan<T>(), bs::One<siT>()), bs::Bitincrement<T>());
-  STF_EQUAL(bitwise_notor(bs::Valmin<siT>(),bs::Zero<T>()), bs::Valmax<siT>());
-  STF_EQUAL(bitwise_notor(bs::Zero<uiT>(), bs::Zero<T>()), bs::Valmax<uiT>());
+  STF_ULP_EQUAL(bitwise_notor(bs::Nan<T>(),bs::One<uiT>()), bs::Bitincrement<T>(), 0.5);
+  STF_ULP_EQUAL(bitwise_notor(bs::Nan<T>(), bs::One<siT>()), bs::Bitincrement<T>(), 0.5);
+  STF_ULP_EQUAL(bitwise_notor(bs::Valmin<siT>(),bs::Zero<T>()), bs::Valmax<siT>(), 0.5);
+  STF_ULP_EQUAL(bitwise_notor(bs::Zero<uiT>(), bs::Zero<T>()), bs::Valmax<uiT>(), 0.5);
 }

--- a/test/function/scalar/bitwise_or.cpp
+++ b/test/function/scalar/bitwise_or.cpp
@@ -29,11 +29,11 @@ STF_CASE_TPL( "Check bitwise_or behavior with floating", STF_IEEE_TYPES )
   STF_TYPE_IS(r_t, T);
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bitwise_or(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(bitwise_or(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(bitwise_or(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(bitwise_or(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitwise_or(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitwise_or(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(bitwise_or(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(bitwise_or(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 }
 
 STF_CASE_TPL("bitwise_or_ui", STF_UNSIGNED_INTEGRAL_TYPES)
@@ -77,10 +77,10 @@ STF_CASE_TPL("bitwise_or_mix", STF_IEEE_TYPES)
   STF_EXPR_IS(bitwise_or(siT(), T()), siT);
 
   // specific values tests
-  STF_EQUAL(bitwise_or(bs::Zero<T>(),bs::Zero<uiT>()), bs::Zero<T>());
-  STF_EQUAL(bitwise_or(bs::Zero<T>(), bs::Zero<siT>()), bs::Zero<T>());
-  STF_EQUAL(bitwise_or(bs::Valmin<siT>(),bs::Nan<T>()), bs::Mone<siT>());
-  STF_EQUAL(bitwise_or(bs::Zero<uiT>(), bs::Nan<T>()), bs::Valmax<uiT>());
+  STF_ULP_EQUAL(bitwise_or(bs::Zero<T>(),bs::Zero<uiT>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bitwise_or(bs::Zero<T>(), bs::Zero<siT>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bitwise_or(bs::Valmin<siT>(),bs::Nan<T>()), bs::Mone<siT>(), 0.5);
+  STF_ULP_EQUAL(bitwise_or(bs::Zero<uiT>(), bs::Nan<T>()), bs::Valmax<uiT>(), 0.5);
 }
 
 

--- a/test/function/scalar/bitwise_ornot.cpp
+++ b/test/function/scalar/bitwise_ornot.cpp
@@ -32,11 +32,11 @@ STF_CASE_TPL (" bitwise_ornot real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(bitwise_ornot(bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(bitwise_ornot(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(bitwise_ornot(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(bitwise_ornot(bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitwise_ornot(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitwise_ornot(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_IEEE_EQUAL(bitwise_ornot(bs::Zero<T>(), bs::Zero<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(bitwise_ornot(bs::Zero<T>(), bs::Zero<T>()), bs::Nan<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" bitwise_ornot integer",  STF_INTEGRAL_TYPES)
@@ -73,9 +73,9 @@ STF_CASE_TPL("bitwise_ornot mix", STF_IEEE_TYPES)
   STF_EXPR_IS(bitwise_ornot(siT(), T()), siT);
 
   // specific values tests
-  STF_IEEE_EQUAL(bitwise_ornot(bs::Zero<T>(),bs::Zero<uiT>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bitwise_ornot(bs::Zero<T>(), bs::Zero<siT>()), bs::Nan<T>());
-  STF_EQUAL(bitwise_ornot(bs::Valmin<siT>(),bs::Nan<T>()), bs::Valmin<siT>());
-  STF_EQUAL(bitwise_ornot(bs::Zero<uiT>(), bs::Nan<T>()), bs::Zero<uiT>());
+  STF_ULP_EQUAL(bitwise_ornot(bs::Zero<T>(),bs::Zero<uiT>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bitwise_ornot(bs::Zero<T>(), bs::Zero<siT>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bitwise_ornot(bs::Valmin<siT>(),bs::Nan<T>()), bs::Valmin<siT>(), 0.5);
+  STF_ULP_EQUAL(bitwise_ornot(bs::Zero<uiT>(), bs::Nan<T>()), bs::Zero<uiT>(), 0.5);
 }
 

--- a/test/function/scalar/bitwise_xor.cpp
+++ b/test/function/scalar/bitwise_xor.cpp
@@ -28,12 +28,12 @@ STF_CASE_TPL (" bitwise xor_real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bitwise_xor(bs::Inf<T>(), bs::Inf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(bitwise_xor(bs::Minf<T>(), bs::Minf<T>()), bs::Zero<r_t>());
-  STF_IEEE_EQUAL(bitwise_xor(bs::Nan<T>(), bs::Nan<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(bitwise_xor(bs::Inf<T>(), bs::Inf<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitwise_xor(bs::Minf<T>(), bs::Minf<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitwise_xor(bs::Nan<T>(), bs::Nan<T>()), bs::Zero<r_t>(), 0.5);
 #endif
-  STF_EQUAL(bitwise_xor(bs::One<T>(),bs::Zero<T>()), bs::One<r_t>());
-  STF_EQUAL(bitwise_xor(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(bitwise_xor(bs::One<T>(),bs::Zero<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(bitwise_xor(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" bitwise xor_integer",  STF_INTEGRAL_TYPES)
@@ -68,10 +68,10 @@ STF_CASE_TPL("bitwise xor_mix", STF_IEEE_TYPES)
   STF_EXPR_IS(bitwise_xor(siT(), T()), siT);
 
   // specific values tests
-  STF_EQUAL(bitwise_xor(bs::Nan<T>(),bs::Valmax<uiT>()), bs::Zero<T>());
-  STF_EQUAL(bitwise_xor(bs::Nan<T>(), bs::Mone<siT>()), bs::Zero<T>());
-  STF_EQUAL(bitwise_xor(bs::Mone<siT>(),bs::Zero<T>()), bs::Mone<siT>());
-  STF_EQUAL(bitwise_xor(bs::Valmax<uiT>(), bs::Zero<T>()), bs::Valmax<uiT>());
+  STF_ULP_EQUAL(bitwise_xor(bs::Nan<T>(),bs::Valmax<uiT>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bitwise_xor(bs::Nan<T>(), bs::Mone<siT>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bitwise_xor(bs::Mone<siT>(),bs::Zero<T>()), bs::Mone<siT>(), 0.5);
+  STF_ULP_EQUAL(bitwise_xor(bs::Valmax<uiT>(), bs::Zero<T>()), bs::Valmax<uiT>(), 0.5);
 }
 
 

--- a/test/function/scalar/ceil.cpp
+++ b/test/function/scalar/ceil.cpp
@@ -29,16 +29,16 @@ STF_CASE_TPL (" ceil real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(ceil(bs::Inf<T>()), bs::Inf<T>());
-  STF_EQUAL(ceil(bs::Minf<T>()), bs::Minf<T>());
-  STF_IEEE_EQUAL(ceil(bs::Nan<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(ceil(bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(ceil(bs::Minf<T>()), bs::Minf<T>(), 0.5);
+  STF_ULP_EQUAL(ceil(bs::Nan<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(ceil(bs::Mone<T>()), bs::Mone<T>());
-  STF_EQUAL(ceil(bs::One<T>()), bs::One<T>());
-  STF_EQUAL(ceil(bs::Zero<T>()), bs::Zero<T>());
-  STF_EQUAL(ceil(bs::Pi<T>()), bs::Four<T>());
-  STF_EQUAL(ceil(T(-1.1)), r_t(-1));
-  STF_EQUAL(ceil(T(1.1)), r_t(2));
+  STF_ULP_EQUAL(ceil(bs::Mone<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(ceil(bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(ceil(bs::Zero<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(ceil(bs::Pi<T>()), bs::Four<T>(), 0.5);
+  STF_ULP_EQUAL(ceil(T(-1.1)), r_t(-1), 0.5);
+  STF_ULP_EQUAL(ceil(T(1.1)), r_t(2), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" ceil signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/clz.cpp
+++ b/test/function/scalar/clz.cpp
@@ -33,10 +33,10 @@ STF_CASE_TPL (" clz real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(clz(bs::Nan<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(clz(bs::Nan<T>()), bs::Zero<r_t>(), 0.5);
 #endif
-  STF_EQUAL(clz(bs::Mone<T>()), bs::Zero<r_t>());
-  STF_EQUAL(clz(bs::Signmask<T>()),bs::Zero<r_t>());
+  STF_ULP_EQUAL(clz(bs::Mone<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(clz(bs::Signmask<T>()),bs::Zero<r_t>(), 0.5);
 } // end of test for real_
 
 STF_CASE_TPL (" clz signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/complement.cpp
+++ b/test/function/scalar/complement.cpp
@@ -32,9 +32,9 @@ STF_CASE_TPL ("check complement for floating",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(complement(bs::Nan<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(complement(bs::Nan<T>()), bs::Zero<r_t>(), 0.5);
 #endif
-  STF_IEEE_EQUAL(complement(bs::Zero<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(complement(bs::Zero<T>()), bs::Nan<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL ("check complement for integral",  STF_INTEGRAL_TYPES)

--- a/test/function/scalar/conj.cpp
+++ b/test/function/scalar/conj.cpp
@@ -28,13 +28,13 @@ STF_CASE_TPL (" conj real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(conj(bs::Inf<T>()), bs::Inf<T>());
-  STF_EQUAL(conj(bs::Minf<T>()), bs::Minf<T>());
-  STF_IEEE_EQUAL(conj(bs::Nan<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(conj(bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(conj(bs::Minf<T>()), bs::Minf<T>(), 0.5);
+  STF_ULP_EQUAL(conj(bs::Nan<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(conj(bs::Mone<T>()), bs::Mone<T>());
-  STF_EQUAL(conj(bs::One<T>()), bs::One<T>());
-  STF_EQUAL(conj(bs::Zero<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(conj(bs::Mone<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(conj(bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(conj(bs::Zero<T>()), bs::Zero<T>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" conj unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/copysign.cpp
+++ b/test/function/scalar/copysign.cpp
@@ -29,19 +29,19 @@ STF_CASE_TPL (" copysign real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(copysign(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(copysign(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(copysign(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
-  STF_EQUAL(copysign(bs::Inf<T>(), bs::Minf<T>()), bs::Minf<r_t>());
-  STF_EQUAL(copysign(bs::Minf<T>(), bs::Inf<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(copysign(bs::Nan<T>(), bs::Inf<T>()), bs::Nan<r_t>());
-  STF_EQUAL(copysign(bs::One<T>(), bs::Nan<T>()), bs::Mone<r_t>());
+  STF_ULP_EQUAL(copysign(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(copysign(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(copysign(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(copysign(bs::Inf<T>(), bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(copysign(bs::Minf<T>(), bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(copysign(bs::Nan<T>(), bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(copysign(bs::One<T>(), bs::Nan<T>()), bs::Mone<r_t>(), 0.5);
 #endif
-  STF_EQUAL(copysign(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(copysign(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(copysign(bs::One<T>(), bs::Mzero<T>()), bs::Mone<r_t>());
-  STF_EQUAL(copysign(bs::One<T>(), bs::Zero<T>()), bs::One<r_t>());
-  STF_EQUAL(copysign(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(copysign(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(copysign(bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(copysign(bs::One<T>(), bs::Mzero<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(copysign(bs::One<T>(), bs::Zero<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(copysign(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 }
 
 STF_CASE_TPL (" copysign signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/ctz.cpp
+++ b/test/function/scalar/ctz.cpp
@@ -30,11 +30,11 @@ STF_CASE_TPL (" ctz real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(ctz(bs::Inf<T>()), r_t(bs::Nbmantissabits<T>()));
-  STF_EQUAL(ctz(bs::Minf<T>()), r_t(bs::Nbmantissabits<T>()));
+  STF_ULP_EQUAL(ctz(bs::Inf<T>()), r_t(bs::Nbmantissabits<T>()), 0.5);
+  STF_ULP_EQUAL(ctz(bs::Minf<T>()), r_t(bs::Nbmantissabits<T>()), 0.5);
 #endif
-  STF_EQUAL(ctz(bs::Zero<T>()), r_t(sizeof(T)*8));
-  STF_EQUAL(ctz(bs::Signmask<T>()), r_t(sizeof(T)*8-1));
+  STF_ULP_EQUAL(ctz(bs::Zero<T>()), r_t(sizeof(T)*8), 0.5);
+  STF_ULP_EQUAL(ctz(bs::Signmask<T>()), r_t(sizeof(T)*8-1), 0.5);
 } // end of test for real_
 
 STF_CASE_TPL (" ctz signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/cummax.cpp
+++ b/test/function/scalar/cummax.cpp
@@ -28,13 +28,13 @@ STF_CASE_TPL (" cummax real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(cummax(bs::Inf<T>()), bs::Inf<T>());
-  STF_EQUAL(cummax(bs::Minf<T>()), bs::Minf<T>());
-  STF_IEEE_EQUAL(cummax(bs::Nan<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(cummax(bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(cummax(bs::Minf<T>()), bs::Minf<T>(), 0.5);
+  STF_ULP_EQUAL(cummax(bs::Nan<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(cummax(bs::Mone<T>()), bs::Mone<T>());
-  STF_EQUAL(cummax(bs::One<T>()), bs::One<T>());
-  STF_EQUAL(cummax(bs::Zero<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(cummax(bs::Mone<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(cummax(bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(cummax(bs::Zero<T>()), bs::Zero<T>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" cummax unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/cummin.cpp
+++ b/test/function/scalar/cummin.cpp
@@ -28,13 +28,13 @@ STF_CASE_TPL (" cummin real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(cummin(bs::Inf<T>()), bs::Inf<T>());
-  STF_EQUAL(cummin(bs::Minf<T>()), bs::Minf<T>());
-  STF_IEEE_EQUAL(cummin(bs::Nan<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(cummin(bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(cummin(bs::Minf<T>()), bs::Minf<T>(), 0.5);
+  STF_ULP_EQUAL(cummin(bs::Nan<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(cummin(bs::Mone<T>()), bs::Mone<T>());
-  STF_EQUAL(cummin(bs::One<T>()), bs::One<T>());
-  STF_EQUAL(cummin(bs::Zero<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(cummin(bs::Mone<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(cummin(bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(cummin(bs::Zero<T>()), bs::Zero<T>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" cummin unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/cumprod.cpp
+++ b/test/function/scalar/cumprod.cpp
@@ -28,13 +28,13 @@ STF_CASE_TPL (" cumprod real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(cumprod(bs::Inf<T>()), bs::Inf<T>());
-  STF_EQUAL(cumprod(bs::Minf<T>()), bs::Minf<T>());
-  STF_IEEE_EQUAL(cumprod(bs::Nan<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(cumprod(bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(cumprod(bs::Minf<T>()), bs::Minf<T>(), 0.5);
+  STF_ULP_EQUAL(cumprod(bs::Nan<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(cumprod(bs::Mone<T>()), bs::Mone<T>());
-  STF_EQUAL(cumprod(bs::One<T>()), bs::One<T>());
-  STF_EQUAL(cumprod(bs::Zero<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(cumprod(bs::Mone<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(cumprod(bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(cumprod(bs::Zero<T>()), bs::Zero<T>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" cumprod unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/cumsum.cpp
+++ b/test/function/scalar/cumsum.cpp
@@ -28,13 +28,13 @@ STF_CASE_TPL (" cumsum real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(cumsum(bs::Inf<T>()), bs::Inf<T>());
-  STF_EQUAL(cumsum(bs::Minf<T>()), bs::Minf<T>());
-  STF_IEEE_EQUAL(cumsum(bs::Nan<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(cumsum(bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(cumsum(bs::Minf<T>()), bs::Minf<T>(), 0.5);
+  STF_ULP_EQUAL(cumsum(bs::Nan<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(cumsum(bs::Mone<T>()), bs::Mone<T>());
-  STF_EQUAL(cumsum(bs::One<T>()), bs::One<T>());
-  STF_EQUAL(cumsum(bs::Zero<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(cumsum(bs::Mone<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(cumsum(bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(cumsum(bs::Zero<T>()), bs::Zero<T>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" cumsum unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/dec.cpp
+++ b/test/function/scalar/dec.cpp
@@ -57,11 +57,11 @@ STF_CASE_TPL(" dec floating", STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(dec(bs::Inf<T>()), bs::Inf<T>());
-  STF_IEEE_EQUAL(dec(bs::Nan<T>()), bs::Nan<T>());
-  STF_EQUAL(dec(bs::Minf<T>()), bs::Minf<T>());
+  STF_ULP_EQUAL(dec(bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(dec(bs::Nan<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(dec(bs::Minf<T>()), bs::Minf<T>(), 0.5);
 #endif
-  STF_EQUAL(dec(bs::One<T>()), bs::Zero<T>());
-  STF_EQUAL(dec(bs::Two<T>()), bs::One<T>());
-  STF_EQUAL(dec(bs::Zero<T>()), bs::Mone<T>());
+  STF_ULP_EQUAL(dec(bs::One<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(dec(bs::Two<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(dec(bs::Zero<T>()), bs::Mone<T>(), 0.5);
 }

--- a/test/function/scalar/dec.saturated.cpp
+++ b/test/function/scalar/dec.saturated.cpp
@@ -67,11 +67,11 @@ STF_CASE_TPL(" bs::saturated_(dec) floating", STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bs::saturated_(dec)(bs::Inf<T>()), bs::Inf<T>());
-  STF_IEEE_EQUAL(bs::saturated_(dec)(bs::Nan<T>()), bs::Nan<T>());
-  STF_EQUAL(bs::saturated_(dec)(bs::Minf<T>()), bs::Minf<T>());
+  STF_ULP_EQUAL(bs::saturated_(dec)(bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(dec)(bs::Nan<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(dec)(bs::Minf<T>()), bs::Minf<T>(), 0.5);
 #endif
-  STF_EQUAL(bs::saturated_(dec)(bs::One<T>()), bs::Zero<T>());
-  STF_EQUAL(bs::saturated_(dec)(bs::Two<T>()), bs::One<T>());
-  STF_EQUAL(bs::saturated_(dec)(bs::Zero<T>()), bs::Mone<T>());
+  STF_ULP_EQUAL(bs::saturated_(dec)(bs::One<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(dec)(bs::Two<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(dec)(bs::Zero<T>()), bs::Mone<T>(), 0.5);
 }

--- a/test/function/scalar/dist.cpp
+++ b/test/function/scalar/dist.cpp
@@ -31,14 +31,14 @@ STF_CASE_TPL (" dist real",  STF_IEEE_TYPES)
   STF_EXPR_IS( dist(T(), T()), T );
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(dist(bs::Inf<T>() , bs::Inf<T>()) , bs::Nan<T>());
-  STF_IEEE_EQUAL(dist(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(dist(bs::Nan<T>() , bs::Nan<T>()) , bs::Nan<T>());
+  STF_ULP_EQUAL(dist(bs::Inf<T>() , bs::Inf<T>()) , bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(dist(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(dist(bs::Nan<T>() , bs::Nan<T>()) , bs::Nan<T>(), 0.5);
 #endif
 
-  STF_EQUAL(dist(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>());
-  STF_EQUAL(dist(bs::Mone<T>(), bs::One<T>()), bs::Two<T>());
-  STF_EQUAL(dist(bs::One<T>(), bs::Three<T>()), bs::Two<T>());
+  STF_ULP_EQUAL(dist(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(dist(bs::Mone<T>(), bs::One<T>()), bs::Two<T>(), 0.5);
+  STF_ULP_EQUAL(dist(bs::One<T>(), bs::Three<T>()), bs::Two<T>(), 0.5);
 }
 
 STF_CASE_TPL (" dist integer_ui",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/dist.saturated.cpp
+++ b/test/function/scalar/dist.saturated.cpp
@@ -30,14 +30,14 @@ STF_CASE_TPL (" bs::saturated_(bs::dist)_s real",  STF_IEEE_TYPES)
   STF_EXPR_IS( bs::saturated_(bs::dist)(T(), T()), T );
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(bs::saturated_(bs::dist)(bs::Inf<T>() , bs::Inf<T>()) , bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::saturated_(bs::dist)(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::saturated_(bs::dist)(bs::Nan<T>() , bs::Nan<T>()) , bs::Nan<T>());
+  STF_ULP_EQUAL(bs::saturated_(bs::dist)(bs::Inf<T>() , bs::Inf<T>()) , bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::dist)(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::dist)(bs::Nan<T>() , bs::Nan<T>()) , bs::Nan<T>(), 0.5);
 #endif
 
-  STF_EQUAL(bs::saturated_(bs::dist)(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>());
-  STF_EQUAL(bs::saturated_(bs::dist)(bs::Mone<T>(), bs::One<T>()), bs::Two<T>());
-  STF_EQUAL(bs::saturated_(bs::dist)(bs::One<T>(), bs::Three<T>()), bs::Two<T>());
+  STF_ULP_EQUAL(bs::saturated_(bs::dist)(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::dist)(bs::Mone<T>(), bs::One<T>()), bs::Two<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::dist)(bs::One<T>(), bs::Three<T>()), bs::Two<T>(), 0.5);
 }
 
 STF_CASE_TPL (" bs::saturated_(bs::dist) integer_ui",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/div/div.ceil.cpp
+++ b/test/function/scalar/div/div.ceil.cpp
@@ -28,17 +28,17 @@ STF_CASE_TPL (" div real",  STF_IEEE_TYPES)
   using r_t = decltype(div(bs::ceil, T(), T()));
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(div(bs::ceil, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::ceil, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::ceil, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(div(bs::ceil, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ceil, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ceil, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(div(bs::ceil, T(4),T(0)), bs::Inf<r_t>());
-  STF_EQUAL(div(bs::ceil, T(4),T(3)), 2);
-  STF_EQUAL(div(bs::ceil, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::ceil, bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>());
-  STF_EQUAL(div(bs::ceil, bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::ceil, bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(div(bs::ceil, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(div(bs::ceil, T(4),T(0)), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ceil, T(4),T(3)), 2, 0.5);
+  STF_ULP_EQUAL(div(bs::ceil, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ceil, bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ceil, bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ceil, bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ceil, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" div unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/div/div.cpp
+++ b/test/function/scalar/div/div.cpp
@@ -28,13 +28,13 @@ STF_CASE_TPL( "Check div behavior with floating", STF_IEEE_TYPES )
   STF_TYPE_IS(r_t, T);
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(div(bs::Inf<T>(),  bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::Nan<T>(),  bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(div(bs::Inf<T>(),  bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::Nan<T>(),  bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(div(bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(div(bs::Zero<T>(), bs::Zero<T>()), bs::Nan<r_t>());
-  STF_EQUAL(div(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
+  STF_ULP_EQUAL(div(bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::Zero<T>(), bs::Zero<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
 }
 
 

--- a/test/function/scalar/div/div.fix.cpp
+++ b/test/function/scalar/div/div.fix.cpp
@@ -28,18 +28,18 @@ STF_CASE_TPL (" divfix real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(div(bs::fix, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::fix, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::fix, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(div(bs::fix, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::fix, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::fix, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(div(bs::fix, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::fix, bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::fix, bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>());
-  STF_EQUAL(div(bs::fix, bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::fix, bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(div(bs::fix, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>());
-  STF_EQUAL(div(bs::fix, T(4),T(3)), T(1));
-  STF_EQUAL(div(bs::fix, T(-4),T(3)), T(-1));
+  STF_ULP_EQUAL(div(bs::fix, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::fix, bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::fix, bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::fix, bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::fix, bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::fix, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::fix, T(4),T(3)), T(1), 0.5);
+  STF_ULP_EQUAL(div(bs::fix, T(-4),T(3)), T(-1), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" divfix unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/div/div.floor.cpp
+++ b/test/function/scalar/div/div.floor.cpp
@@ -32,18 +32,18 @@ STF_CASE_TPL (" div real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(div(bs::floor, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::floor, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::floor, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(div(bs::floor, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::floor, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::floor, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(div(bs::floor, T(4),T(0)), bs::Inf<r_t>());
-  STF_EQUAL(div(bs::floor, T(4),T(3)), bs::One<r_t>());
-  STF_EQUAL(div(bs::floor, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::floor, bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::floor, bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>());
-  STF_EQUAL(div(bs::floor, bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::floor, bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(div(bs::floor, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(div(bs::floor, T(4),T(0)), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::floor, T(4),T(3)), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::floor, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::floor, bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::floor, bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::floor, bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::floor, bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::floor, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" divunsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/div/div.iceil.cpp
+++ b/test/function/scalar/div/div.iceil.cpp
@@ -28,17 +28,17 @@ STF_CASE_TPL (" div real",  STF_IEEE_TYPES)
   using r_t = decltype(div(bs::iceil, T(), T()));
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(div(bs::iceil, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::iceil, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::iceil, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(div(bs::iceil, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::iceil, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::iceil, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(div(bs::iceil, T(4),T(0)), bs::Inf<r_t>());
-  STF_EQUAL(div(bs::iceil, T(4),T(3)), 2);
-  STF_EQUAL(div(bs::iceil, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::iceil, bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>());
-  STF_EQUAL(div(bs::iceil, bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::iceil, bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(div(bs::iceil, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(div(bs::iceil, T(4),T(0)), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::iceil, T(4),T(3)), 2, 0.5);
+  STF_ULP_EQUAL(div(bs::iceil, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::iceil, bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::iceil, bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::iceil, bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::iceil, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" div unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/div/div.ifix.cpp
+++ b/test/function/scalar/div/div.ifix.cpp
@@ -30,18 +30,18 @@ STF_CASE_TPL (" divifix real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(div(bs::ifix, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::ifix, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::ifix, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(div(bs::ifix, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ifix, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ifix, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(div(bs::ifix, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::ifix, bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::ifix, bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>());
-  STF_EQUAL(div(bs::ifix, bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::ifix, bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(div(bs::ifix, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>());
-  STF_EQUAL(div(bs::ifix, T(4),T(3)), T(1));
-  STF_EQUAL(div(bs::ifix, T(-4),T(3)), T(-1));
+  STF_ULP_EQUAL(div(bs::ifix, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ifix, bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ifix, bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ifix, bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ifix, bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ifix, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ifix, T(4),T(3)), T(1), 0.5);
+  STF_ULP_EQUAL(div(bs::ifix, T(-4),T(3)), T(-1), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" divifix unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/div/div.ifloor.cpp
+++ b/test/function/scalar/div/div.ifloor.cpp
@@ -34,18 +34,18 @@ STF_CASE_TPL (" div real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(div(bs::ifloor, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::ifloor, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::ifloor, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(div(bs::ifloor, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ifloor, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ifloor, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(div(bs::ifloor, T(4),T(0)), bs::Inf<r_t>());
-  STF_EQUAL(div(bs::ifloor, T(4),T(3)), bs::One<r_t>());
-  STF_EQUAL(div(bs::ifloor, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::ifloor, bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::ifloor, bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>());
-  STF_EQUAL(div(bs::ifloor, bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::ifloor, bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(div(bs::ifloor, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(div(bs::ifloor, T(4),T(0)), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ifloor, T(4),T(3)), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ifloor, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ifloor, bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ifloor, bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ifloor, bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ifloor, bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::ifloor, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" divunsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/div/div.inearbyint.cpp
+++ b/test/function/scalar/div/div.inearbyint.cpp
@@ -23,11 +23,11 @@ STF_CASE_TPL (" div real",  STF_IEEE_TYPES)
   using bs::div;
   using r_t = decltype(div(bs::inearbyint, T(), T()));
 
-  STF_IEEE_EQUAL(div(bs::inearbyint, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::inearbyint, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_EQUAL(div(bs::inearbyint, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_IEEE_EQUAL(div(bs::inearbyint, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
-  STF_EQUAL(div(bs::inearbyint, bs::One<T>(), bs::One<T>()), bs::One<r_t>());
+  STF_ULP_EQUAL(div(bs::inearbyint, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::inearbyint, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::inearbyint, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::inearbyint, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::inearbyint, bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" div unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/div/div.iround.cpp
+++ b/test/function/scalar/div/div.iround.cpp
@@ -25,18 +25,18 @@ STF_CASE_TPL (" divreal",  STF_IEEE_TYPES)
   using r_t = decltype(div(bs::iround, T(), T()));
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(div(bs::iround, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::iround, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::iround, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(div(bs::iround, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::iround, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::iround, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(div(bs::iround, T(4),T(0)), bs::Inf<r_t>());
-  STF_EQUAL(div(bs::iround, T(4),T(3)), bs::One<r_t>());
-  STF_EQUAL(div(bs::iround, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::iround, bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::iround, bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>());
-  STF_EQUAL(div(bs::iround, bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::iround, bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(div(bs::iround, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(div(bs::iround, T(4),T(0)), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::iround, T(4),T(3)), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::iround, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::iround, bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::iround, bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::iround, bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::iround, bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::iround, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" divunsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/div/div.itrunc.cpp
+++ b/test/function/scalar/div/div.itrunc.cpp
@@ -26,18 +26,18 @@ STF_CASE_TPL (" divitrunc real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(div(bs::itrunc, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::itrunc, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::itrunc, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(div(bs::itrunc, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::itrunc, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::itrunc, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(div(bs::itrunc, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::itrunc, bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::itrunc, bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>());
-  STF_EQUAL(div(bs::itrunc, bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::itrunc, bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(div(bs::itrunc, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>());
-  STF_EQUAL(div(bs::itrunc, T(4),T(3)), T(1));
-  STF_EQUAL(div(bs::itrunc, T(-4),T(3)), T(-1));
+  STF_ULP_EQUAL(div(bs::itrunc, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::itrunc, bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::itrunc, bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::itrunc, bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::itrunc, bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::itrunc, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::itrunc, T(4),T(3)), T(1), 0.5);
+  STF_ULP_EQUAL(div(bs::itrunc, T(-4),T(3)), T(-1), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" divitrunc unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/div/div.nearbyint.cpp
+++ b/test/function/scalar/div/div.nearbyint.cpp
@@ -23,11 +23,11 @@ STF_CASE_TPL (" div real",  STF_IEEE_TYPES)
   using bs::div;
   using r_t = decltype(div(bs::nearbyint, T(), T()));
 
-  STF_IEEE_EQUAL(div(bs::nearbyint, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::nearbyint, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_EQUAL(div(bs::nearbyint, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_IEEE_EQUAL(div(bs::nearbyint, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
-  STF_EQUAL(div(bs::nearbyint, bs::One<T>(), bs::One<T>()), bs::One<r_t>());
+  STF_ULP_EQUAL(div(bs::nearbyint, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::nearbyint, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::nearbyint, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::nearbyint, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::nearbyint, bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" div unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/div/div.round.cpp
+++ b/test/function/scalar/div/div.round.cpp
@@ -25,18 +25,18 @@ STF_CASE_TPL (" divreal",  STF_IEEE_TYPES)
   using r_t = decltype(div(T(), T()));
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(div(bs::round, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::round, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::round, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(div(bs::round, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::round, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::round, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(div(bs::round, T(4),T(0)), bs::Inf<r_t>());
-  STF_EQUAL(div(bs::round, T(4),T(3)), bs::One<r_t>());
-  STF_EQUAL(div(bs::round, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::round, bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::round, bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>());
-  STF_EQUAL(div(bs::round, bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::round, bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(div(bs::round, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(div(bs::round, T(4),T(0)), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::round, T(4),T(3)), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::round, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::round, bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::round, bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::round, bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::round, bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::round, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" divunsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/div/div.trunc.cpp
+++ b/test/function/scalar/div/div.trunc.cpp
@@ -28,18 +28,18 @@ STF_CASE_TPL (" divtrunc real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(div(bs::trunc, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::trunc, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(div(bs::trunc, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(div(bs::trunc, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::trunc, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::trunc, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(div(bs::trunc, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::trunc, bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::trunc, bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>());
-  STF_EQUAL(div(bs::trunc, bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(div(bs::trunc, bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(div(bs::trunc, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>());
-  STF_EQUAL(div(bs::trunc, T(4),T(3)), T(1));
-  STF_EQUAL(div(bs::trunc, T(-4),T(3)), T(-1));
+  STF_ULP_EQUAL(div(bs::trunc, bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::trunc, bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::trunc, bs::Mone<T>(),bs::Zero<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::trunc, bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::trunc, bs::One<T>(),bs::Zero<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::trunc, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(div(bs::trunc, T(4),T(3)), T(1), 0.5);
+  STF_ULP_EQUAL(div(bs::trunc, T(-4),T(3)), T(-1), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" divtrunc unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/divides.cpp
+++ b/test/function/scalar/divides.cpp
@@ -29,13 +29,13 @@ STF_CASE_TPL( "Check divides behavior with floating", STF_IEEE_TYPES )
   STF_TYPE_IS(r_t, T);
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(divides(bs::Inf<T>(),  bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(divides(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(divides(bs::Nan<T>(),  bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(divides(bs::Inf<T>(),  bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(divides(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(divides(bs::Nan<T>(),  bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(divides(T(1), T(0)), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(divides(T(0), T(0)), bs::Nan<r_t>());
-  STF_EQUAL(divides(T(1), T(1)), bs::One<r_t>());
+  STF_ULP_EQUAL(divides(T(1), T(0)), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(divides(T(0), T(0)), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(divides(T(1), T(1)), bs::One<r_t>(), 0.5);
 }
 
 

--- a/test/function/scalar/dot.cpp
+++ b/test/function/scalar/dot.cpp
@@ -23,12 +23,12 @@ STF_CASE_TPL (" dot",  STF_IEEE_TYPES)
   using bs::dot;
 
   // specific values tests
-  STF_EQUAL(dot(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<T>());
-  STF_EQUAL(dot(bs::Minf<T>(), bs::Minf<T>()), bs::Inf<T>());
-  STF_EQUAL(dot(bs::Mone<T>(), bs::Mone<T>()), bs::One<T>());
-  STF_IEEE_EQUAL(dot(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>());
-  STF_EQUAL(dot(bs::One<T>(), bs::One<T>()), bs::One<T>());
-  STF_EQUAL(dot(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(dot(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(dot(bs::Minf<T>(), bs::Minf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(dot(bs::Mone<T>(), bs::Mone<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(dot(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(dot(bs::One<T>(), bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(dot(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>(), 0.5);
 } // end of test for floating_
 
 

--- a/test/function/scalar/eps.cpp
+++ b/test/function/scalar/eps.cpp
@@ -28,16 +28,16 @@ STF_CASE_TPL ("eps for IEEE types",  STF_IEEE_TYPES)
 
   // specific values tests
  #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(eps(bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(eps(bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(eps(bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(eps(bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(eps(bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(eps(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
  #endif
 
-  STF_EQUAL(eps(T{-1}), bs::Eps<r_t>());
-  STF_EQUAL(eps(T{1}) , bs::Eps<r_t>());
+  STF_ULP_EQUAL(eps(T{-1}), bs::Eps<r_t>(), 0.5);
+  STF_ULP_EQUAL(eps(T{1}) , bs::Eps<r_t>(), 0.5);
 
  #if !defined(BOOST_SIMD_NO_DENORMALS)
-  STF_EQUAL(eps(T{0}), bs::Mindenormal<r_t>());
+  STF_ULP_EQUAL(eps(T{0}), bs::Mindenormal<r_t>(), 0.5);
  #endif
 }
 

--- a/test/function/scalar/exponent.cpp
+++ b/test/function/scalar/exponent.cpp
@@ -30,15 +30,15 @@ STF_CASE_TPL (" exponent real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(exponent(bs::Minf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(exponent(bs::Inf <T>()), bs::Zero<r_t>());
-  STF_EQUAL(exponent(bs::Nan <T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(exponent(bs::Minf<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(exponent(bs::Inf <T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(exponent(bs::Nan <T>()), bs::Zero<r_t>(), 0.5);
 #endif
-  STF_EQUAL(exponent(bs::Mone<T>()), bs::Zero<r_t>());
-  STF_EQUAL(exponent(bs::One<T>()),  bs::Zero<r_t>());
-  STF_EQUAL(exponent(bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(exponent(bs::Two<T>()),  bs::One<r_t>() );
-  STF_EQUAL(exponent(T(1.5)),        bs::Zero<r_t>() );
+  STF_ULP_EQUAL(exponent(bs::Mone<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(exponent(bs::One<T>()),  bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(exponent(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(exponent(bs::Two<T>()),  bs::One<r_t>() , 0.5);
+  STF_ULP_EQUAL(exponent(T(1.5)),        bs::Zero<r_t>() , 0.5);
 }
 STF_CASE_TPL (" exponent i",  STF_INTEGRAL_TYPES)
 {

--- a/test/function/scalar/ffs.cpp
+++ b/test/function/scalar/ffs.cpp
@@ -32,12 +32,12 @@ STF_CASE_TPL (" ffs real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(ffs(bs::Inf<T>()), r_t(bs::Nbmantissabits<T>()+1));
-  STF_EQUAL(ffs(bs::Minf<T>()), r_t(bs::Nbmantissabits<T>()+1));
-  STF_EQUAL(ffs(bs::Nan<T>()), r_t(bs::One<r_t>()));
+  STF_ULP_EQUAL(ffs(bs::Inf<T>()), r_t(bs::Nbmantissabits<T>()+1), 0.5);
+  STF_ULP_EQUAL(ffs(bs::Minf<T>()), r_t(bs::Nbmantissabits<T>()+1), 0.5);
+  STF_ULP_EQUAL(ffs(bs::Nan<T>()), r_t(bs::One<r_t>()), 0.5);
 #endif
-  STF_EQUAL(ffs(bs::Signmask<T>()), r_t(sizeof(T)*8));
-  STF_EQUAL(ffs(bs::Zero<T>()), r_t(bs::Zero<r_t>()));
+  STF_ULP_EQUAL(ffs(bs::Signmask<T>()), r_t(sizeof(T)*8), 0.5);
+  STF_ULP_EQUAL(ffs(bs::Zero<T>()), r_t(bs::Zero<r_t>()), 0.5);
 } // end of test for real_
 
 STF_CASE_TPL (" ffs signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/firstbitset.cpp
+++ b/test/function/scalar/firstbitset.cpp
@@ -33,12 +33,12 @@ STF_CASE_TPL (" firstbitset real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(firstbitset(bs::Inf<T>()), r_t(1ull<<bs::Nbmantissabits<T>()));
-  STF_EQUAL(firstbitset(bs::Minf<T>()), r_t(1ull<<bs::Nbmantissabits<T>()));
-  STF_EQUAL(firstbitset(bs::Nan<T>()), bs::One<r_t>());
+  STF_ULP_EQUAL(firstbitset(bs::Inf<T>()), r_t(1ull<<bs::Nbmantissabits<T>()), 0.5);
+  STF_ULP_EQUAL(firstbitset(bs::Minf<T>()), r_t(1ull<<bs::Nbmantissabits<T>()), 0.5);
+  STF_ULP_EQUAL(firstbitset(bs::Nan<T>()), bs::One<r_t>(), 0.5);
 #endif
-  STF_EQUAL(firstbitset(bs::Signmask<T>()), bs::One<r_t>()+bs::Valmax<r_t>()/2);
-  STF_EQUAL(firstbitset(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(firstbitset(bs::Signmask<T>()), bs::One<r_t>()+bs::Valmax<r_t>()/2, 0.5);
+  STF_ULP_EQUAL(firstbitset(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 } // end of test for real_
 
 STF_CASE_TPL (" firstbitset signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/firstbitunset.cpp
+++ b/test/function/scalar/firstbitunset.cpp
@@ -31,12 +31,12 @@ STF_CASE_TPL (" firstbitunsetreal",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(firstbitunset(bs::Inf<T>()), bs::One<r_t>());
-  STF_EQUAL(firstbitunset(bs::Minf<T>()), bs::One<r_t>());
-  STF_EQUAL(firstbitunset(bs::Nan<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(firstbitunset(bs::Inf<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(firstbitunset(bs::Minf<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(firstbitunset(bs::Nan<T>()), bs::Zero<r_t>(), 0.5);
 #endif
-  STF_EQUAL(firstbitunset(bs::Signmask<T>()), bs::One<r_t>());
-  STF_EQUAL(firstbitunset(bs::Zero<T>()), bs::One<r_t>());
+  STF_ULP_EQUAL(firstbitunset(bs::Signmask<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(firstbitunset(bs::Zero<T>()), bs::One<r_t>(), 0.5);
 } // end of test for floating_
 
 

--- a/test/function/scalar/floor.cpp
+++ b/test/function/scalar/floor.cpp
@@ -31,16 +31,16 @@ STF_CASE_TPL (" floor real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(floor(bs::Inf<T>()), bs::Inf<T>());
-  STF_EQUAL(floor(bs::Minf<T>()), bs::Minf<T>());
-  STF_IEEE_EQUAL(floor(bs::Nan<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(floor(bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(floor(bs::Minf<T>()), bs::Minf<T>(), 0.5);
+  STF_ULP_EQUAL(floor(bs::Nan<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(floor(bs::One<T>()), bs::One<T>());
-  STF_EQUAL(floor(bs::Mone<T>()), bs::Mone<T>());
-  STF_EQUAL(floor(bs::Zero<T>()), bs::Zero<T>());
-  STF_EQUAL(floor(bs::Pi<T>()), bs::Three<T>());
-  STF_EQUAL(floor(T(-1.1)), r_t(-2));
-  STF_EQUAL(floor(T(1.1)), r_t(1));
+  STF_ULP_EQUAL(floor(bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(floor(bs::Mone<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(floor(bs::Zero<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(floor(bs::Pi<T>()), bs::Three<T>(), 0.5);
+  STF_ULP_EQUAL(floor(T(-1.1)), r_t(-2), 0.5);
+  STF_ULP_EQUAL(floor(T(1.1)), r_t(1), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" floor unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/fma.conformant.cpp
+++ b/test/function/scalar/fma.conformant.cpp
@@ -34,16 +34,16 @@ STF_CASE_TPL (" bs::conformant_(fma) real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bs::conformant_(fma)(bs::Inf<T>(), bs::Inf<T>(), bs::Inf<T>()), bs::Inf<T>());
-  STF_IEEE_EQUAL(bs::conformant_(fma)(bs::Minf<T>(), bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::conformant_(fma)(bs::Nan<T>(), bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(bs::conformant_(fma)(bs::Inf<T>(), bs::Inf<T>(), bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(bs::conformant_(fma)(bs::Minf<T>(), bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::conformant_(fma)(bs::Nan<T>(), bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(bs::conformant_(fma)(bs::Mone<T>(), bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>());
-  STF_EQUAL(bs::conformant_(fma)(bs::One<T>(), bs::One<T>(), bs::One<T>()), bs::Two<T>());
-  STF_EQUAL(bs::conformant_(fma)(bs::One<T>()+bs::Eps<T>(), bs::One<T>()-bs::Eps<T>(),bs::Mone<T>()), -bs::Eps<T>()*bs::Eps<T>());
-  STF_EQUAL(bs::conformant_(fma)(bs::Zero<T>(), bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(bs::conformant_(fma)(bs::Mone<T>(), bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bs::conformant_(fma)(bs::One<T>(), bs::One<T>(), bs::One<T>()), bs::Two<T>(), 0.5);
+  STF_ULP_EQUAL(bs::conformant_(fma)(bs::One<T>()+bs::Eps<T>(), bs::One<T>()-bs::Eps<T>(),bs::Mone<T>()), -bs::Eps<T>()*bs::Eps<T>(), 0.5);
+  STF_ULP_EQUAL(bs::conformant_(fma)(bs::Zero<T>(), bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>(), 0.5);
 #ifndef  STF_DONT_CARE__FMA_OVERFLOW
-  STF_EQUAL(bs::conformant_(fma)(bs::Valmax<T>(), bs::Two<T>(), -bs::Valmax<T>()), bs::Valmax<T>());
+  STF_ULP_EQUAL(bs::conformant_(fma)(bs::Valmax<T>(), bs::Two<T>(), -bs::Valmax<T>()), bs::Valmax<T>(), 0.5);
 #endif
 } // end of test for floating_
 
@@ -89,13 +89,13 @@ STF_CASE_TPL (" bs::conformant_(fma) std real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL( bs::std_(fma)(bs::Inf<T>(), bs::Inf<T>(), bs::Inf<T>()), bs::Inf<T>());
-  STF_IEEE_EQUAL( bs::std_(fma)(bs::Minf<T>(), bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL( bs::std_(fma)(bs::Nan<T>(), bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL( bs::std_(fma)(bs::Inf<T>(), bs::Inf<T>(), bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL( bs::std_(fma)(bs::Minf<T>(), bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL( bs::std_(fma)(bs::Nan<T>(), bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL( bs::std_(fma)(bs::Mone<T>(), bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>());
-  STF_EQUAL( bs::std_(fma)(bs::One<T>(), bs::One<T>(), bs::One<T>()), bs::Two<T>());
-  STF_EQUAL( bs::std_(fma)(bs::One<T>()+bs::Eps<T>(), bs::One<T>()-bs::Eps<T>(),bs::Mone<T>()), -bs::Eps<T>()*bs::Eps<T>());
-  STF_EQUAL( bs::std_(fma)(bs::Zero<T>(), bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>());
-  STF_EQUAL( bs::std_(fma)(bs::Valmax<T>(), bs::Two<T>(), -bs::Valmax<T>()), bs::Valmax<T>());
+  STF_ULP_EQUAL( bs::std_(fma)(bs::Mone<T>(), bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL( bs::std_(fma)(bs::One<T>(), bs::One<T>(), bs::One<T>()), bs::Two<T>(), 0.5);
+  STF_ULP_EQUAL( bs::std_(fma)(bs::One<T>()+bs::Eps<T>(), bs::One<T>()-bs::Eps<T>(),bs::Mone<T>()), -bs::Eps<T>()*bs::Eps<T>(), 0.5);
+  STF_ULP_EQUAL( bs::std_(fma)(bs::Zero<T>(), bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL( bs::std_(fma)(bs::Valmax<T>(), bs::Two<T>(), -bs::Valmax<T>()), bs::Valmax<T>(), 0.5);
 } // end of test for floating_

--- a/test/function/scalar/fma.cpp
+++ b/test/function/scalar/fma.cpp
@@ -29,13 +29,13 @@ STF_CASE_TPL (" fma real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(fma(bs::Inf<T>(), bs::Inf<T>(), bs::Inf<T>()), bs::Inf<T>());
-  STF_IEEE_EQUAL(fma(bs::Minf<T>(), bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(fma(bs::Nan<T>(), bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(fma(bs::Inf<T>(), bs::Inf<T>(), bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(fma(bs::Minf<T>(), bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(fma(bs::Nan<T>(), bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(fma(bs::Mone<T>(), bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>());
-  STF_EQUAL(fma(bs::One<T>(), bs::One<T>(), bs::One<T>()), bs::Two<T>());
-  STF_EQUAL(fma(bs::Zero<T>(), bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(fma(bs::Mone<T>(), bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(fma(bs::One<T>(), bs::One<T>(), bs::One<T>()), bs::Two<T>(), 0.5);
+  STF_ULP_EQUAL(fma(bs::Zero<T>(), bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" fma unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/fms.cpp
+++ b/test/function/scalar/fms.cpp
@@ -18,10 +18,10 @@ STF_CASE_TPL(" fms",  STF_IEEE_TYPES)
 
   STF_EXPR_IS(fms(T(),T(),T()), T);
 
-  STF_EQUAL(fms(T(2),T(2),T(4)) , T(0));
-  STF_EQUAL(fms(T(2),T(2),T(-4)), T(8));
-  STF_EQUAL(fms(T(2),T(-2),T(4)), T(-8));
-  STF_EQUAL(fms(T(-2),T(2),T(4)), T(-8));
+  STF_ULP_EQUAL(fms(T(2),T(2),T(4)) , T(0), 0.5);
+  STF_ULP_EQUAL(fms(T(2),T(2),T(-4)), T(8), 0.5);
+  STF_ULP_EQUAL(fms(T(2),T(-2),T(4)), T(-8), 0.5);
+  STF_ULP_EQUAL(fms(T(-2),T(2),T(4)), T(-8), 0.5);
 }
 
 

--- a/test/function/scalar/fnma.cpp
+++ b/test/function/scalar/fnma.cpp
@@ -19,10 +19,10 @@ STF_CASE_TPL(" fnma",  STF_IEEE_TYPES)
 
   STF_EXPR_IS(fnma(T(),T(),T()), T);
 
-  STF_EQUAL(fnma(T(4),T(2),T(2)) , T(-10));
-  STF_EQUAL(fnma(T(4),T(-2),T(2)), T(6));
-  STF_EQUAL(fnma(T(4),T(2),T(-2)), T(-6));
-  STF_EQUAL(fnma(T(4),T(-2),T(-2)), T(10));
+  STF_ULP_EQUAL(fnma(T(4),T(2),T(2)) , T(-10), 0.5);
+  STF_ULP_EQUAL(fnma(T(4),T(-2),T(2)), T(6), 0.5);
+  STF_ULP_EQUAL(fnma(T(4),T(2),T(-2)), T(-6), 0.5);
+  STF_ULP_EQUAL(fnma(T(4),T(-2),T(-2)), T(10), 0.5);
 }
 
 

--- a/test/function/scalar/fnms.cpp
+++ b/test/function/scalar/fnms.cpp
@@ -19,8 +19,8 @@ STF_CASE_TPL(" fnms",  STF_IEEE_TYPES)
   STF_EXPR_IS(fnms(T(),T(),T()), T);
 
 
-  STF_EQUAL(fnms(T(2),T(2),T(4)) , T(0));
-  STF_EQUAL(fnms(T(-2),T(2),T(4)), T(8));
-  STF_EQUAL(fnms(T(2),T(-2),T(4)), T(8));
-  STF_EQUAL(fnms(T(-2),T(-2),T(4)), T(0));
+  STF_ULP_EQUAL(fnms(T(2),T(2),T(4)) , T(0), 0.5);
+  STF_ULP_EQUAL(fnms(T(-2),T(2),T(4)), T(8), 0.5);
+  STF_ULP_EQUAL(fnms(T(2),T(-2),T(4)), T(8), 0.5);
+  STF_ULP_EQUAL(fnms(T(-2),T(-2),T(4)), T(0), 0.5);
 }

--- a/test/function/scalar/fpclassify.cpp
+++ b/test/function/scalar/fpclassify.cpp
@@ -35,16 +35,16 @@ STF_CASE_TPL (" fpclassify",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(fpclassify(bs::Inf<T>()), FP_INFINITE);
-  STF_EQUAL(fpclassify(bs::Minf<T>()), FP_INFINITE);
-  STF_EQUAL(fpclassify(bs::Nan<T>()), FP_NAN);
+  STF_ULP_EQUAL(fpclassify(bs::Inf<T>()), FP_INFINITE, 0.5);
+  STF_ULP_EQUAL(fpclassify(bs::Minf<T>()), FP_INFINITE, 0.5);
+  STF_ULP_EQUAL(fpclassify(bs::Nan<T>()), FP_NAN, 0.5);
 #endif
-  STF_EQUAL(fpclassify(bs::Half<T>()), FP_NORMAL);
-  STF_EQUAL(fpclassify(bs::Mhalf<T>()), FP_NORMAL);
-  STF_EQUAL(fpclassify(bs::Mone<T>()), FP_NORMAL);
-  STF_EQUAL(fpclassify(bs::Mindenormal<T>()), FP_SUBNORMAL);
-  STF_EQUAL(fpclassify(bs::Zero<T>()), FP_ZERO);
-  STF_EQUAL(fpclassify(bs::Mzero<T>()), FP_ZERO);
+  STF_ULP_EQUAL(fpclassify(bs::Half<T>()), FP_NORMAL, 0.5);
+  STF_ULP_EQUAL(fpclassify(bs::Mhalf<T>()), FP_NORMAL, 0.5);
+  STF_ULP_EQUAL(fpclassify(bs::Mone<T>()), FP_NORMAL, 0.5);
+  STF_ULP_EQUAL(fpclassify(bs::Mindenormal<T>()), FP_SUBNORMAL, 0.5);
+  STF_ULP_EQUAL(fpclassify(bs::Zero<T>()), FP_ZERO, 0.5);
+  STF_ULP_EQUAL(fpclassify(bs::Mzero<T>()), FP_ZERO, 0.5);
 }
 
 STF_CASE_TPL (" fpclassify std",  STF_IEEE_TYPES)
@@ -60,14 +60,14 @@ STF_CASE_TPL (" fpclassify std",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bs::std_(fpclassify)(bs::Inf<T>()), FP_INFINITE);
-  STF_EQUAL(bs::std_(fpclassify)(bs::Minf<T>()), FP_INFINITE);
-  STF_EQUAL(bs::std_(fpclassify)(bs::Nan<T>()), FP_NAN);
+  STF_ULP_EQUAL(bs::std_(fpclassify)(bs::Inf<T>()), FP_INFINITE, 0.5);
+  STF_ULP_EQUAL(bs::std_(fpclassify)(bs::Minf<T>()), FP_INFINITE, 0.5);
+  STF_ULP_EQUAL(bs::std_(fpclassify)(bs::Nan<T>()), FP_NAN, 0.5);
 #endif
-  STF_EQUAL(bs::std_(fpclassify)(bs::Half<T>()), FP_NORMAL);
-  STF_EQUAL(bs::std_(fpclassify)(bs::Mhalf<T>()), FP_NORMAL);
-  STF_EQUAL(bs::std_(fpclassify)(bs::Mone<T>()), FP_NORMAL);
-  STF_EQUAL(bs::std_(fpclassify)(bs::Mindenormal<T>()), FP_SUBNORMAL);
-  STF_EQUAL(bs::std_(fpclassify)(bs::Zero<T>()), FP_ZERO);
-  STF_EQUAL(bs::std_(fpclassify)(bs::Mzero<T>()), FP_ZERO);
+  STF_ULP_EQUAL(bs::std_(fpclassify)(bs::Half<T>()), FP_NORMAL, 0.5);
+  STF_ULP_EQUAL(bs::std_(fpclassify)(bs::Mhalf<T>()), FP_NORMAL, 0.5);
+  STF_ULP_EQUAL(bs::std_(fpclassify)(bs::Mone<T>()), FP_NORMAL, 0.5);
+  STF_ULP_EQUAL(bs::std_(fpclassify)(bs::Mindenormal<T>()), FP_SUBNORMAL, 0.5);
+  STF_ULP_EQUAL(bs::std_(fpclassify)(bs::Zero<T>()), FP_ZERO, 0.5);
+  STF_ULP_EQUAL(bs::std_(fpclassify)(bs::Mzero<T>()), FP_ZERO, 0.5);
 }

--- a/test/function/scalar/frac.cpp
+++ b/test/function/scalar/frac.cpp
@@ -30,15 +30,15 @@ STF_CASE_TPL (" frac real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(frac(bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(frac(bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(frac(bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(frac(bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(frac(bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(frac(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(frac(bs::Mone<T>()), bs::Zero<r_t>());
-  STF_EQUAL(frac(bs::One<T>()), bs::Zero<r_t>());
-  STF_EQUAL(frac(bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(frac(T(1.5)),  bs::Half<r_t>());
-  STF_EQUAL(frac(T(-1.5)),  bs::Mhalf<r_t>());
+  STF_ULP_EQUAL(frac(bs::Mone<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(frac(bs::One<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(frac(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(frac(T(1.5)),  bs::Half<r_t>(), 0.5);
+  STF_ULP_EQUAL(frac(T(-1.5)),  bs::Mhalf<r_t>(), 0.5);
 }
 
 STF_CASE_TPL (" frac unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/frexp.cpp
+++ b/test/function/scalar/frexp.cpp
@@ -41,8 +41,8 @@ STF_CASE_TPL(" frexp0", STF_IEEE_TYPES)
     T  a = bs::Valmax<T>();
     std::tie(m, e) = frexp(a);
     STF_ULP_EQUAL(m, bs::One<T>()-bs::Halfeps<T>(), 1);
-    STF_EQUAL(e, bs::Limitexponent<T>());
-    STF_EQUAL(ldexp(m,e),a);
+    STF_ULP_EQUAL(e, bs::Limitexponent<T>(), 0.5);
+    STF_ULP_EQUAL(ldexp(m,e),a, 0.5);
   }
 
 #ifndef BOOST_SIMD_NO_DENORMALS
@@ -53,8 +53,8 @@ STF_CASE_TPL(" frexp0", STF_IEEE_TYPES)
     T a = bs::Mindenormal<T>();
     std::tie(m, e) = frexp(a);
     STF_ULP_EQUAL(m, bs::Half<T>(), 1);
-    STF_EQUAL(e, bs::Minexponent<T>()-bs::Nbmantissabits<T>()+bs::One<T>());
-    STF_EQUAL(ldexp(m,e),a);
+    STF_ULP_EQUAL(e, bs::Minexponent<T>()-bs::Nbmantissabits<T>()+bs::One<T>(), 0.5);
+    STF_ULP_EQUAL(ldexp(m,e),a, 0.5);
   }
 
   {
@@ -64,8 +64,8 @@ STF_CASE_TPL(" frexp0", STF_IEEE_TYPES)
     T a = bs::Smallestposval<T>()/2;
     std::tie(m, e) = frexp(a);
     STF_ULP_EQUAL(m, bs::Half<T>(), 1);
-    STF_EQUAL(e, bs::Minexponent<T>());
-    STF_EQUAL(ldexp(m,e),a);
+    STF_ULP_EQUAL(e, bs::Minexponent<T>(), 0.5);
+    STF_ULP_EQUAL(ldexp(m,e),a, 0.5);
   }
 
   {
@@ -75,8 +75,8 @@ STF_CASE_TPL(" frexp0", STF_IEEE_TYPES)
     T a = bs::Smallestposval<T>()/4;
     std::tie(m, e) = frexp(a);
     STF_ULP_EQUAL(m, bs::Half<T>(), 1);
-    STF_EQUAL(e, bs::Minexponent<T>()-bs::One<T>());
-    STF_EQUAL(ldexp(m,e),a);
+    STF_ULP_EQUAL(e, bs::Minexponent<T>()-bs::One<T>(), 0.5);
+    STF_ULP_EQUAL(ldexp(m,e),a, 0.5);
   }
 #endif
 
@@ -99,8 +99,8 @@ STF_CASE_TPL(" frexp", STF_IEEE_TYPES)
     T  m;
 
     std::tie(m, e) = frexp(bs::One<T>());
-    STF_EQUAL(m, bs::Half<T>());
-    STF_EQUAL(e, bs::One<iT>());
+    STF_ULP_EQUAL(m, bs::Half<T>(), 0.5);
+    STF_ULP_EQUAL(e, bs::One<iT>(), 0.5);
   }
 
   {
@@ -108,8 +108,8 @@ STF_CASE_TPL(" frexp", STF_IEEE_TYPES)
     std::pair<T,iT> p;
 
     p = frexp(bs::One<T>());
-    STF_EQUAL(p.first  , bs::Half<T>());
-    STF_EQUAL(p.second , bs::One<iT>());
+    STF_ULP_EQUAL(p.first  , bs::Half<T>(), 0.5);
+    STF_ULP_EQUAL(p.second , bs::One<iT>(), 0.5);
   }
 }
 
@@ -127,8 +127,8 @@ STF_CASE_TPL(" frexp0", STF_IEEE_TYPES)
     T  a = bs::Valmax<T>();
     std::tie(m, e) = frexp(a);
     STF_ULP_EQUAL(m, bs::One<T>()-bs::Halfeps<T>(), 1);
-    STF_EQUAL(e, bs::Limitexponent<T>());
-    STF_EQUAL(ldexp(m,e),a);
+    STF_ULP_EQUAL(e, bs::Limitexponent<T>(), 0.5);
+    STF_ULP_EQUAL(ldexp(m,e),a, 0.5);
   }
 
 #ifndef BOOST_SIMD_NO_DENORMALS
@@ -139,8 +139,8 @@ STF_CASE_TPL(" frexp0", STF_IEEE_TYPES)
     T a = bs::Mindenormal<T>();
     std::tie(m, e) = frexp(a);
     STF_ULP_EQUAL(m, bs::Half<T>(), 1);
-    STF_EQUAL(e, bs::Minexponent<T>()-bs::Nbmantissabits<T>()+bs::One<T>());
-    STF_EQUAL(ldexp(m,e),a);
+    STF_ULP_EQUAL(e, bs::Minexponent<T>()-bs::Nbmantissabits<T>()+bs::One<T>(), 0.5);
+    STF_ULP_EQUAL(ldexp(m,e),a, 0.5);
   }
 
   {
@@ -150,8 +150,8 @@ STF_CASE_TPL(" frexp0", STF_IEEE_TYPES)
     T a = bs::Smallestposval<T>()/2;
     std::tie(m, e) = frexp(a);
     STF_ULP_EQUAL(m, bs::Half<T>(), 1);
-    STF_EQUAL(e, bs::Minexponent<T>());
-    STF_EQUAL(ldexp(m,e),a);
+    STF_ULP_EQUAL(e, bs::Minexponent<T>(), 0.5);
+    STF_ULP_EQUAL(ldexp(m,e),a, 0.5);
   }
 
   {
@@ -161,8 +161,8 @@ STF_CASE_TPL(" frexp0", STF_IEEE_TYPES)
     T a = bs::Smallestposval<T>()/4;
     std::tie(m, e) = frexp(a);
     STF_ULP_EQUAL(m, bs::Half<T>(), 1);
-    STF_EQUAL(e, bs::Minexponent<T>()-bs::One<T>());
-    STF_EQUAL(ldexp(m,e),a);
+    STF_ULP_EQUAL(e, bs::Minexponent<T>()-bs::One<T>(), 0.5);
+    STF_ULP_EQUAL(ldexp(m,e),a, 0.5);
   }
 #endif
 
@@ -186,8 +186,8 @@ STF_CASE_TPL(" frexp fast", STF_IEEE_TYPES)
     T  m;
 
     std::tie(m, e) = bs::fast_(frexp)(bs::One<T>());
-    STF_EQUAL(m, bs::Half<T>());
-    STF_EQUAL(e, bs::One<iT>());
+    STF_ULP_EQUAL(m, bs::Half<T>(), 0.5);
+    STF_ULP_EQUAL(e, bs::One<iT>(), 0.5);
   }
 
   {
@@ -195,7 +195,7 @@ STF_CASE_TPL(" frexp fast", STF_IEEE_TYPES)
     std::pair<T,iT> p;
 
     p = bs::fast_(frexp)(bs::One<T>());
-    STF_EQUAL(p.first  , bs::Half<T>());
-    STF_EQUAL(p.second , bs::One<iT>());
+    STF_ULP_EQUAL(p.first  , bs::Half<T>(), 0.5);
+    STF_ULP_EQUAL(p.second , bs::One<iT>(), 0.5);
   }
 }

--- a/test/function/scalar/genmask.cpp
+++ b/test/function/scalar/genmask.cpp
@@ -75,8 +75,8 @@ STF_CASE_TPL ("Check genmask behavior on IEEE754 special values",  STF_IEEE_TYPE
   namespace bs = boost::simd;
   using bs::genmask;
 
-  STF_IEEE_EQUAL(genmask(bs::Inf<T>())  , bs::Allbits<T>());
-  STF_IEEE_EQUAL(genmask(bs::Minf<T>()) , bs::Allbits<T>());
-  STF_IEEE_EQUAL(genmask(bs::Nan<T>())  , bs::Allbits<T>());
+  STF_ULP_EQUAL(genmask(bs::Inf<T>())  , bs::Allbits<T>(), 0.5);
+  STF_ULP_EQUAL(genmask(bs::Minf<T>()) , bs::Allbits<T>(), 0.5);
+  STF_ULP_EQUAL(genmask(bs::Nan<T>())  , bs::Allbits<T>(), 0.5);
 }
 #endif

--- a/test/function/scalar/genmaskc.cpp
+++ b/test/function/scalar/genmaskc.cpp
@@ -31,11 +31,11 @@ STF_CASE_TPL (" genmaskc real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(genmaskc(bs::Inf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(genmaskc(bs::Minf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(genmaskc(bs::Nan<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(genmaskc(bs::Inf<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(genmaskc(bs::Minf<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(genmaskc(bs::Nan<T>()), bs::Zero<r_t>(), 0.5);
 #endif
-  STF_IEEE_EQUAL(genmaskc(bs::Zero<T>()), bs::Allbits<r_t>());
+  STF_ULP_EQUAL(genmaskc(bs::Zero<T>()), bs::Allbits<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" genmaskc integer",  (int16_t)(int32_t)(int64_t)(uint32_t)(uint64_t))//STF_INTEGRAL_TYPES)

--- a/test/function/scalar/hmsb.cpp
+++ b/test/function/scalar/hmsb.cpp
@@ -26,14 +26,14 @@ STF_CASE_TPL (" hmsb real",  STF_IEEE_TYPES)
   using bs::hmsb;
 
   // specific values tests
-  STF_EQUAL(hmsb(bs::Allbits<T>()), 1u);
-  STF_EQUAL(hmsb(bs::Inf<T>()), 0u);
-  STF_EQUAL(hmsb(bs::Minf<T>()), 1u);
-  STF_EQUAL(hmsb(bs::Mone<T>()), 1u);
-  STF_EQUAL(hmsb(bs::Nan<T>()), 1u);
-  STF_EQUAL(hmsb(bs::One<T>()), 0u);
-  STF_EQUAL(hmsb(bs::Signmask<T>()), 1u);
-  STF_EQUAL(hmsb(bs::Zero<T>()), 0u);
+  STF_ULP_EQUAL(hmsb(bs::Allbits<T>()), 1u, 0.5);
+  STF_ULP_EQUAL(hmsb(bs::Inf<T>()), 0u, 0.5);
+  STF_ULP_EQUAL(hmsb(bs::Minf<T>()), 1u, 0.5);
+  STF_ULP_EQUAL(hmsb(bs::Mone<T>()), 1u, 0.5);
+  STF_ULP_EQUAL(hmsb(bs::Nan<T>()), 1u, 0.5);
+  STF_ULP_EQUAL(hmsb(bs::One<T>()), 0u, 0.5);
+  STF_ULP_EQUAL(hmsb(bs::Signmask<T>()), 1u, 0.5);
+  STF_ULP_EQUAL(hmsb(bs::Zero<T>()), 0u, 0.5);
 } // end of test for real_
 
 

--- a/test/function/scalar/horn.cpp
+++ b/test/function/scalar/horn.cpp
@@ -41,9 +41,9 @@ float g(const double & x)
 
 STF_CASE_TPL( "Check horner behavior with floating", STF_IEEE_TYPES )
 {
-  STF_EQUAL(g(bs::Mone<T>()), bs::Mtwo<T>());
-  STF_EQUAL(g(bs::One<T>()),  bs::Ten<T>());
-  STF_EQUAL(g(bs::Mone<T>()), bs::Mtwo<T>());
+  STF_ULP_EQUAL(g(bs::Mone<T>()), bs::Mtwo<T>(), 0.5);
+  STF_ULP_EQUAL(g(bs::One<T>()),  bs::Ten<T>(), 0.5);
+  STF_ULP_EQUAL(g(bs::Mone<T>()), bs::Mtwo<T>(), 0.5);
 }
 
 

--- a/test/function/scalar/horn1.cpp
+++ b/test/function/scalar/horn1.cpp
@@ -41,9 +41,9 @@ STF_CASE_TPL( "Check horn1 behavior with floating", STF_IEEE_TYPES )
 {
   namespace bs = boost::simd;
 
-  STF_EQUAL(g(bs::Zero<T>()), T(1.0));
-  STF_EQUAL(g(bs::One<T>()),  T(11.0));
-  STF_EQUAL(g(bs::Mone<T>()), T(-1.0));
+  STF_ULP_EQUAL(g(bs::Zero<T>()), T(1.0), 0.5);
+  STF_ULP_EQUAL(g(bs::One<T>()),  T(11.0), 0.5);
+  STF_ULP_EQUAL(g(bs::Mone<T>()), T(-1.0), 0.5);
 }
 
 

--- a/test/function/scalar/horner.cpp
+++ b/test/function/scalar/horner.cpp
@@ -68,12 +68,12 @@ STF_CASE_TPL( "Check horner behavior with floating", STF_IEEE_TYPES )
   using r_t = decltype(f(T()));
   STF_TYPE_IS(r_t, T);
 
-  STF_EQUAL(f(bs::Zero<T>()), bs::One<r_t>());
-  STF_EQUAL(f(bs::One<T>()),  bs::Ten<r_t>());
-  STF_EQUAL(f(bs::Mone<T>()), bs::Mtwo<r_t>());
-  STF_EQUAL(g(bs::Mone<T>()), bs::Mtwo<r_t>());
-  STF_EQUAL(g(bs::One<T>()),  bs::Ten<r_t>());
-  STF_EQUAL(g(bs::Mone<T>()), bs::Mtwo<r_t>());
+  STF_ULP_EQUAL(f(bs::Zero<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(f(bs::One<T>()),  bs::Ten<r_t>(), 0.5);
+  STF_ULP_EQUAL(f(bs::Mone<T>()), bs::Mtwo<r_t>(), 0.5);
+  STF_ULP_EQUAL(g(bs::Mone<T>()), bs::Mtwo<r_t>(), 0.5);
+  STF_ULP_EQUAL(g(bs::One<T>()),  bs::Ten<r_t>(), 0.5);
+  STF_ULP_EQUAL(g(bs::Mone<T>()), bs::Mtwo<r_t>(), 0.5);
 }
 
 

--- a/test/function/scalar/iceil.cpp
+++ b/test/function/scalar/iceil.cpp
@@ -31,13 +31,13 @@ STF_CASE_TPL (" iceil real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(iceil(bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(iceil(bs::Minf<T>()), bs::Minf<r_t>());
-  STF_EQUAL(iceil(bs::Nan<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(iceil(bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(iceil(bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(iceil(bs::Nan<T>()), bs::Zero<r_t>(), 0.5);
 #endif
-  STF_EQUAL(iceil(bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(iceil(bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(iceil(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(iceil(bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(iceil(bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(iceil(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" iceil unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/if_allbits_else.cpp
+++ b/test/function/scalar/if_allbits_else.cpp
@@ -30,12 +30,12 @@ STF_CASE_TPL (" if_allbits_else real",  STF_IEEE_TYPES)
   STF_EXPR_IS( if_allbits_else(T(), T()), T );
 
   // specific values tests
-  STF_EQUAL(if_allbits_else(T(0), T(1)), T(1));
-  STF_IEEE_EQUAL(if_allbits_else(T(1), T(1)), Nan<T>());
-  STF_IEEE_EQUAL(if_allbits_else(bs::Inf<T>(), T(1)) , Nan<T>());
-  STF_IEEE_EQUAL(if_allbits_else(bs::Minf<T>(), T(1)), Nan<T>());
-  STF_IEEE_EQUAL(if_allbits_else(bs::Nan<T>(), T(1)) , Nan<T>());
-  STF_EQUAL(if_allbits_else(bs::Zero<T>(), T(1)), T(1));
+  STF_ULP_EQUAL(if_allbits_else(T(0), T(1)), T(1), 0.5);
+  STF_ULP_EQUAL(if_allbits_else(T(1), T(1)), Nan<T>(), 0.5);
+  STF_ULP_EQUAL(if_allbits_else(bs::Inf<T>(), T(1)) , Nan<T>(), 0.5);
+  STF_ULP_EQUAL(if_allbits_else(bs::Minf<T>(), T(1)), Nan<T>(), 0.5);
+  STF_ULP_EQUAL(if_allbits_else(bs::Nan<T>(), T(1)) , Nan<T>(), 0.5);
+  STF_ULP_EQUAL(if_allbits_else(bs::Zero<T>(), T(1)), T(1), 0.5);
 
 
 } // end of test for floating_

--- a/test/function/scalar/if_allbits_else_zero.cpp
+++ b/test/function/scalar/if_allbits_else_zero.cpp
@@ -30,11 +30,11 @@ STF_CASE_TPL (" if_allbits_else_zero real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(if_allbits_else_zero(bs::Inf<T>()), bs::Allbits<r_t>());
-  STF_IEEE_EQUAL(if_allbits_else_zero(bs::Minf<T>()), bs::Allbits<r_t>());
-  STF_IEEE_EQUAL(if_allbits_else_zero(bs::Nan<T>()), bs::Allbits<r_t>());
+  STF_ULP_EQUAL(if_allbits_else_zero(bs::Inf<T>()), bs::Allbits<r_t>(), 0.5);
+  STF_ULP_EQUAL(if_allbits_else_zero(bs::Minf<T>()), bs::Allbits<r_t>(), 0.5);
+  STF_ULP_EQUAL(if_allbits_else_zero(bs::Nan<T>()), bs::Allbits<r_t>(), 0.5);
 #endif
-  STF_EQUAL(if_allbits_else_zero(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(if_allbits_else_zero(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" if_allbits_else_zero integer",  STF_INTEGRAL_TYPES)

--- a/test/function/scalar/if_dec.cpp
+++ b/test/function/scalar/if_dec.cpp
@@ -59,9 +59,9 @@ STF_CASE_TPL(" if_dec floating", STF_IEEE_TYPES)
   STF_EXPR_IS( if_dec(T(), T()), T );
 
   // specific values tests
-  STF_EQUAL(if_dec(bs::One<T>(), bs::One<T>()), bs::Zero<T>());
-  STF_EQUAL(if_dec(bs::One<T>(), bs::Two<T>()), bs::One<T>());
-  STF_EQUAL(if_dec(bs::One<T>(), bs::Zero<T>()), bs::Mone<T>());
+  STF_ULP_EQUAL(if_dec(bs::One<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(if_dec(bs::One<T>(), bs::Two<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(if_dec(bs::One<T>(), bs::Zero<T>()), bs::Mone<T>(), 0.5);
 }
 
 

--- a/test/function/scalar/if_else.cpp
+++ b/test/function/scalar/if_else.cpp
@@ -50,10 +50,10 @@ STF_CASE_TPL (" if_else real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(if_else( bs::One<T>(), bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(if_else( bs::One<T>(), bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(if_else( bs::One<T>(),bs::Zero<T>(),bs::Two<T>()), bs::Zero<r_t>());
-  STF_EQUAL(if_else( bs::Zero<T>(), bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(if_else( bs::One<T>(),bs::Zero<T>(),bs::Two<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(if_else( bs::Zero<T>(), bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 } // end of test for floating_
 
 

--- a/test/function/scalar/if_else_allbits.cpp
+++ b/test/function/scalar/if_else_allbits.cpp
@@ -29,12 +29,12 @@ STF_CASE_TPL (" if_else allbitsreal",  STF_IEEE_TYPES)
   STF_EXPR_IS( if_else_allbits(T(), T()), T );
 
   // specific values tests
-  STF_IEEE_EQUAL(if_else_allbits(T(0), T(1)), Allbits<T>());
-  STF_EQUAL(if_else_allbits(T(1), T(1)), T(1));
-  STF_EQUAL(if_else_allbits(bs::Inf<T>(),  T(1)), T(1));
-  STF_EQUAL(if_else_allbits(bs::Minf<T>(), T(1)), T(1));
-  STF_EQUAL(if_else_allbits(bs::Nan<T>(),  T(1)), T(1));
-  STF_IEEE_EQUAL(if_else_allbits(bs::Zero<T>(), T(1)), Allbits<T>());
+  STF_ULP_EQUAL(if_else_allbits(T(0), T(1)), Allbits<T>(), 0.5);
+  STF_ULP_EQUAL(if_else_allbits(T(1), T(1)), T(1), 0.5);
+  STF_ULP_EQUAL(if_else_allbits(bs::Inf<T>(),  T(1)), T(1), 0.5);
+  STF_ULP_EQUAL(if_else_allbits(bs::Minf<T>(), T(1)), T(1), 0.5);
+  STF_ULP_EQUAL(if_else_allbits(bs::Nan<T>(),  T(1)), T(1), 0.5);
+  STF_ULP_EQUAL(if_else_allbits(bs::Zero<T>(), T(1)), Allbits<T>(), 0.5);
 
 
 } // end of test for floating_

--- a/test/function/scalar/if_else_nan.cpp
+++ b/test/function/scalar/if_else_nan.cpp
@@ -29,12 +29,12 @@ STF_CASE_TPL (" if_else allbitsreal",  STF_IEEE_TYPES)
   STF_EXPR_IS( if_else_nan(T(), T()), T );
 
   // specific values tests
-  STF_IEEE_EQUAL(if_else_nan(T(0), T(1)), Allbits<T>());
-  STF_EQUAL(if_else_nan(T(1), T(1)), T(1));
-  STF_EQUAL(if_else_nan(bs::Inf<T>(),  T(1)), T(1));
-  STF_EQUAL(if_else_nan(bs::Minf<T>(), T(1)), T(1));
-  STF_EQUAL(if_else_nan(bs::Nan<T>(),  T(1)), T(1));
-  STF_IEEE_EQUAL(if_else_nan(bs::Zero<T>(), T(1)), Allbits<T>());
+  STF_ULP_EQUAL(if_else_nan(T(0), T(1)), Allbits<T>(), 0.5);
+  STF_ULP_EQUAL(if_else_nan(T(1), T(1)), T(1), 0.5);
+  STF_ULP_EQUAL(if_else_nan(bs::Inf<T>(),  T(1)), T(1), 0.5);
+  STF_ULP_EQUAL(if_else_nan(bs::Minf<T>(), T(1)), T(1), 0.5);
+  STF_ULP_EQUAL(if_else_nan(bs::Nan<T>(),  T(1)), T(1), 0.5);
+  STF_ULP_EQUAL(if_else_nan(bs::Zero<T>(), T(1)), Allbits<T>(), 0.5);
 
 
 } // end of test for floating_

--- a/test/function/scalar/if_else_zero.cpp
+++ b/test/function/scalar/if_else_zero.cpp
@@ -28,12 +28,12 @@ STF_CASE_TPL (" if_else zero real",  STF_IEEE_TYPES)
   STF_EXPR_IS( if_else_zero(T(), T()), T);
 
   // specific values tests
-  STF_EQUAL(if_else_zero(T(0), T(1)), T(0));
-  STF_EQUAL(if_else_zero(T(1), T(1)), T(1));
-  STF_EQUAL(if_else_zero(bs::Inf<T>(), T(1)) , T(1));
-  STF_EQUAL(if_else_zero(bs::Minf<T>(), T(1)), T(1));
-  STF_EQUAL(if_else_zero(bs::Nan<T>(), T(1)) , T(1));
-  STF_EQUAL(if_else_zero(bs::Zero<T>(), T(1)), T(0));
+  STF_ULP_EQUAL(if_else_zero(T(0), T(1)), T(0), 0.5);
+  STF_ULP_EQUAL(if_else_zero(T(1), T(1)), T(1), 0.5);
+  STF_ULP_EQUAL(if_else_zero(bs::Inf<T>(), T(1)) , T(1), 0.5);
+  STF_ULP_EQUAL(if_else_zero(bs::Minf<T>(), T(1)), T(1), 0.5);
+  STF_ULP_EQUAL(if_else_zero(bs::Nan<T>(), T(1)) , T(1), 0.5);
+  STF_ULP_EQUAL(if_else_zero(bs::Zero<T>(), T(1)), T(0), 0.5);
 
 
 } // end of test for floating_

--- a/test/function/scalar/if_inc.cpp
+++ b/test/function/scalar/if_inc.cpp
@@ -60,8 +60,8 @@ STF_CASE_TPL(" if_inc floating", STF_IEEE_TYPES)
   STF_EXPR_IS( if_inc(T(), T()), T );
 
   // specific values tests
-  STF_EQUAL(if_inc(bs::One<T>(), bs::Mone<T>()), bs::Zero<T>());
-  STF_EQUAL(if_inc(bs::One<T>(), bs::One<T>()), bs::Two<T>());
-  STF_EQUAL(if_inc(bs::One<T>(), bs::Valmax<T>()), bs::Valmax<T>());
-  STF_EQUAL(if_inc(bs::One<T>(), bs::Zero<T>()), bs::One<T>());
+  STF_ULP_EQUAL(if_inc(bs::One<T>(), bs::Mone<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(if_inc(bs::One<T>(), bs::One<T>()), bs::Two<T>(), 0.5);
+  STF_ULP_EQUAL(if_inc(bs::One<T>(), bs::Valmax<T>()), bs::Valmax<T>(), 0.5);
+  STF_ULP_EQUAL(if_inc(bs::One<T>(), bs::Zero<T>()), bs::One<T>(), 0.5);
 }

--- a/test/function/scalar/if_minus.cpp
+++ b/test/function/scalar/if_minus.cpp
@@ -30,12 +30,12 @@ STF_CASE_TPL (" if_minus real",  STF_IEEE_TYPES)
   STF_TYPE_IS( r_t, T );
 
   // specific values tests
-  STF_EQUAL(if_minus(logical<T>(T(0)),T(1),T(2)), T(1));
-  STF_EQUAL(if_minus(logical<T>(bs::Nan<T>()),T(1),T(2)), T(-1));
-  STF_IEEE_EQUAL(if_minus(logical<T>(bs::Nan<T>()),bs::Inf<T>(),bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(if_minus(logical<T>(bs::Nan<T>()),bs::Minf<T>(),bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(if_minus(logical<T>(bs::Nan<T>()),bs::Nan<T>(),bs::Nan<T>()), bs::Nan<r_t>());
-  STF_EQUAL(if_minus(logical<T>(bs::Nan<T>()),bs::Zero<T>(),bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(if_minus(logical<T>(T(0)),T(1),T(2)), T(1), 0.5);
+  STF_ULP_EQUAL(if_minus(logical<T>(bs::Nan<T>()),T(1),T(2)), T(-1), 0.5);
+  STF_ULP_EQUAL(if_minus(logical<T>(bs::Nan<T>()),bs::Inf<T>(),bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(if_minus(logical<T>(bs::Nan<T>()),bs::Minf<T>(),bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(if_minus(logical<T>(bs::Nan<T>()),bs::Nan<T>(),bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(if_minus(logical<T>(bs::Nan<T>()),bs::Zero<T>(),bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" if_minus signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/if_nan_else.cpp
+++ b/test/function/scalar/if_nan_else.cpp
@@ -30,12 +30,12 @@ STF_CASE_TPL (" if_nan_else real",  STF_IEEE_TYPES)
   STF_EXPR_IS( if_nan_else(T(), T()), T );
 
   // specific values tests
-  STF_EQUAL(if_nan_else(T(0), T(1)), T(1));
-  STF_IEEE_EQUAL(if_nan_else(T(1), T(1)), Nan<T>());
-  STF_IEEE_EQUAL(if_nan_else(bs::Inf<T>(), T(1)) , Nan<T>());
-  STF_IEEE_EQUAL(if_nan_else(bs::Minf<T>(), T(1)), Nan<T>());
-  STF_IEEE_EQUAL(if_nan_else(bs::Nan<T>(), T(1)) , Nan<T>());
-  STF_EQUAL(if_nan_else(bs::Zero<T>(), T(1)), T(1));
+  STF_ULP_EQUAL(if_nan_else(T(0), T(1)), T(1), 0.5);
+  STF_ULP_EQUAL(if_nan_else(T(1), T(1)), Nan<T>(), 0.5);
+  STF_ULP_EQUAL(if_nan_else(bs::Inf<T>(), T(1)) , Nan<T>(), 0.5);
+  STF_ULP_EQUAL(if_nan_else(bs::Minf<T>(), T(1)), Nan<T>(), 0.5);
+  STF_ULP_EQUAL(if_nan_else(bs::Nan<T>(), T(1)) , Nan<T>(), 0.5);
+  STF_ULP_EQUAL(if_nan_else(bs::Zero<T>(), T(1)), T(1), 0.5);
 
 
 } // end of test for floating_

--- a/test/function/scalar/if_one_else_zero.cpp
+++ b/test/function/scalar/if_one_else_zero.cpp
@@ -32,12 +32,12 @@ STF_CASE_TPL (" if_one_else_zero real",  STF_IEEE_TYPES)
   STF_EXPR_IS( if_one_else_zero(T()),  T);
 
   // specific values tests
-  STF_EQUAL(if_one_else_zero(T(0)), 0);
-  STF_EQUAL(if_one_else_zero(T(1)), 1);
-  STF_EQUAL(if_one_else_zero(bs::Inf<T>()) , 1);
-  STF_EQUAL(if_one_else_zero(bs::Minf<T>()),1);
-  STF_EQUAL(if_one_else_zero(bs::Nan<T>()) , 1);
-  STF_EQUAL(if_one_else_zero(bs::Zero<T>()),0);
+  STF_ULP_EQUAL(if_one_else_zero(T(0)), 0, 0.5);
+  STF_ULP_EQUAL(if_one_else_zero(T(1)), 1, 0.5);
+  STF_ULP_EQUAL(if_one_else_zero(bs::Inf<T>()) , 1, 0.5);
+  STF_ULP_EQUAL(if_one_else_zero(bs::Minf<T>()),1, 0.5);
+  STF_ULP_EQUAL(if_one_else_zero(bs::Nan<T>()) , 1, 0.5);
+  STF_ULP_EQUAL(if_one_else_zero(bs::Zero<T>()),0, 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" if_one_else_zero signed_int",  STF_SIGNED_INTEGRAL_TYPES)
@@ -67,16 +67,16 @@ STF_CASE_TPL (" if_one_else_zero real",  STF_IEEE_TYPES)
 
 
   // specific values tests
-  STF_EQUAL(if_one_else_zero(-bs::Zero<T>()), r_t(false));
-  STF_EQUAL(if_one_else_zero(bs::Half<T>()), r_t(true));
-  STF_EQUAL(if_one_else_zero(bs::Inf<T>()), r_t(true));
-  STF_EQUAL(if_one_else_zero(bs::Minf<T>()), r_t(true));
-  STF_EQUAL(if_one_else_zero(bs::Mone<T>()), r_t(true));
-  STF_EQUAL(if_one_else_zero(bs::Nan<T>()), r_t(true));
-  STF_EQUAL(if_one_else_zero(bs::One<T>()), r_t(true));
-  STF_EQUAL(if_one_else_zero(bs::Quarter<T>()), r_t(true));
-  STF_EQUAL(if_one_else_zero(bs::Two<T>()), r_t(true));
-  STF_EQUAL(if_one_else_zero(bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(if_one_else_zero(-bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(if_one_else_zero(bs::Half<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(if_one_else_zero(bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(if_one_else_zero(bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(if_one_else_zero(bs::Mone<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(if_one_else_zero(bs::Nan<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(if_one_else_zero(bs::One<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(if_one_else_zero(bs::Quarter<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(if_one_else_zero(bs::Two<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(if_one_else_zero(bs::Zero<T>()), r_t(false), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" if_one_else_zerosigned_int__1_0",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/if_plus.cpp
+++ b/test/function/scalar/if_plus.cpp
@@ -30,12 +30,12 @@ STF_CASE_TPL (" if_plus real",  STF_IEEE_TYPES)
   STF_TYPE_IS( r_t, T );
 
   // specific values tests
-  STF_EQUAL(if_plus(logical<T>(T(0)),T(1),T(2)), T(1));
-  STF_EQUAL(if_plus(logical<T>(bs::Nan<T>()),T(1),T(2)), T(3));
-  STF_EQUAL(if_plus(logical<T>(bs::Nan<T>()),bs::Inf<T>(),bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(if_plus(logical<T>(bs::Nan<T>()),bs::Minf<T>(),bs::Minf<T>()), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(if_plus(logical<T>(bs::Nan<T>()),bs::Nan<T>(),bs::Nan<T>()), bs::Nan<r_t>());
-  STF_EQUAL(if_plus(logical<T>(bs::Nan<T>()),bs::Zero<T>(),bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(if_plus(logical<T>(T(0)),T(1),T(2)), T(1), 0.5);
+  STF_ULP_EQUAL(if_plus(logical<T>(bs::Nan<T>()),T(1),T(2)), T(3), 0.5);
+  STF_ULP_EQUAL(if_plus(logical<T>(bs::Nan<T>()),bs::Inf<T>(),bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(if_plus(logical<T>(bs::Nan<T>()),bs::Minf<T>(),bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(if_plus(logical<T>(bs::Nan<T>()),bs::Nan<T>(),bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(if_plus(logical<T>(bs::Nan<T>()),bs::Zero<T>(),bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" if_plus integer",  STF_INTEGRAL_TYPES)

--- a/test/function/scalar/if_zero_else.cpp
+++ b/test/function/scalar/if_zero_else.cpp
@@ -29,13 +29,13 @@ STF_CASE_TPL (" if_zero_else real",  STF_IEEE_TYPES)
   STF_EXPR_IS( if_zero_else(T(), T()), T);
 
   // specific values tests
-  STF_EQUAL(if_zero_else(T(0), T(1)), T(1));
-  STF_EQUAL(if_zero_else(T(1), T(1)), T(0));
-  STF_EQUAL(if_zero_else(bs::Inf<T>(), T(1)) , T(0));
-  STF_EQUAL(if_zero_else(bs::Minf<T>(), T(1)), T(0));
-  STF_EQUAL(if_zero_else(bs::Nan<T>(), T(1)) , T(0));
-  STF_EQUAL(if_zero_else(bs::Zero<T>(), T(1)), T(1));
- //  STF_EQUAL(if_zero_else(bs::True< bs::logical<T> >(), T(1)), T(0));
+  STF_ULP_EQUAL(if_zero_else(T(0), T(1)), T(1), 0.5);
+  STF_ULP_EQUAL(if_zero_else(T(1), T(1)), T(0), 0.5);
+  STF_ULP_EQUAL(if_zero_else(bs::Inf<T>(), T(1)) , T(0), 0.5);
+  STF_ULP_EQUAL(if_zero_else(bs::Minf<T>(), T(1)), T(0), 0.5);
+  STF_ULP_EQUAL(if_zero_else(bs::Nan<T>(), T(1)) , T(0), 0.5);
+  STF_ULP_EQUAL(if_zero_else(bs::Zero<T>(), T(1)), T(1), 0.5);
+ //  STF_ULP_EQUAL(if_zero_else(bs::True< bs::logical<T> >(), T(1)), T(0), 0.5);
 
 
 } // end of test for floating_

--- a/test/function/scalar/if_zero_else_allbits.cpp
+++ b/test/function/scalar/if_zero_else_allbits.cpp
@@ -31,11 +31,11 @@ STF_CASE_TPL (" if_zero_else_allbits real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(if_zero_else_allbits(bs::Inf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(if_zero_else_allbits(bs::Minf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(if_zero_else_allbits(bs::Nan<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(if_zero_else_allbits(bs::Inf<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(if_zero_else_allbits(bs::Minf<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(if_zero_else_allbits(bs::Nan<T>()), bs::Zero<r_t>(), 0.5);
 #endif
-  STF_IEEE_EQUAL(if_zero_else_allbits(bs::Zero<T>()), bs::Allbits<r_t>());
+  STF_ULP_EQUAL(if_zero_else_allbits(bs::Zero<T>()), bs::Allbits<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" if_zero_else_allbits integer",  (int16_t)(int32_t)(int64_t)(uint32_t)(uint64_t))//STF_INTEGRAL_TYPES)

--- a/test/function/scalar/if_zero_else_one.cpp
+++ b/test/function/scalar/if_zero_else_one.cpp
@@ -28,12 +28,12 @@ STF_CASE_TPL (" if_zero_else_one real",  STF_IEEE_TYPES)
   STF_EXPR_IS( if_zero_else_one(T()), T);
 
   // specific values tests
-  STF_EQUAL(if_zero_else_one(T(0)), 1);
-  STF_EQUAL(if_zero_else_one(T(1)), 0);
-  STF_EQUAL(if_zero_else_one(bs::Inf<T>()) , 0);
-  STF_EQUAL(if_zero_else_one(bs::Minf<T>()), 0);
-  STF_EQUAL(if_zero_else_one(bs::Nan<T>()) , 0);
-  STF_EQUAL(if_zero_else_one(bs::Zero<T>()), 1);
+  STF_ULP_EQUAL(if_zero_else_one(T(0)), 1, 0.5);
+  STF_ULP_EQUAL(if_zero_else_one(T(1)), 0, 0.5);
+  STF_ULP_EQUAL(if_zero_else_one(bs::Inf<T>()) , 0, 0.5);
+  STF_ULP_EQUAL(if_zero_else_one(bs::Minf<T>()), 0, 0.5);
+  STF_ULP_EQUAL(if_zero_else_one(bs::Nan<T>()) , 0, 0.5);
+  STF_ULP_EQUAL(if_zero_else_one(bs::Zero<T>()), 1, 0.5);
 
 
 } // end of test for floating_

--- a/test/function/scalar/ifix.cpp
+++ b/test/function/scalar/ifix.cpp
@@ -29,18 +29,18 @@ STF_CASE_TPL (" ifix real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, (bd::as_integer_t<T>));
 
   // specific values tests
-  STF_EQUAL(ifix(T(2)*bs::Valmax<r_t>()),  bs::Valmax<r_t>());
-  STF_EQUAL(ifix(T(2)*bs::Valmin<r_t>()),  bs::Valmin<r_t>());
-  STF_EQUAL(ifix(T(1.5)*bs::Valmax<r_t>()),  bs::Valmax<r_t>());
-  STF_EQUAL(ifix(T(1.5)*bs::Valmin<r_t>()),  bs::Valmin<r_t>());
+  STF_ULP_EQUAL(ifix(T(2)*bs::Valmax<r_t>()),  bs::Valmax<r_t>(), 0.5);
+  STF_ULP_EQUAL(ifix(T(2)*bs::Valmin<r_t>()),  bs::Valmin<r_t>(), 0.5);
+  STF_ULP_EQUAL(ifix(T(1.5)*bs::Valmax<r_t>()),  bs::Valmax<r_t>(), 0.5);
+  STF_ULP_EQUAL(ifix(T(1.5)*bs::Valmin<r_t>()),  bs::Valmin<r_t>(), 0.5);
 
 
-  STF_EQUAL(ifix(bs::Inf<T>()),  bs::Inf<r_t>());
-  STF_EQUAL(ifix(bs::Minf<T>()), bs::Minf<r_t>());
-  STF_EQUAL(ifix(bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(ifix(bs::Nan<T>()),  bs::Zero<r_t>());
-  STF_EQUAL(ifix(bs::One<T>()),  bs::One<r_t>());
-  STF_EQUAL(ifix(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(ifix(bs::Inf<T>()),  bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(ifix(bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(ifix(bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(ifix(bs::Nan<T>()),  bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(ifix(bs::One<T>()),  bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(ifix(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 
   T v = T(1);
   r_t iv = 1;
@@ -49,13 +49,13 @@ STF_CASE_TPL (" ifix real",  STF_IEEE_TYPES)
   {
   namespace bs = boost::simd;
   namespace bd = boost::dispatch;
-    STF_EQUAL(ifix(v), iv);
-    STF_EQUAL(ifix(-v), -iv);
+    STF_ULP_EQUAL(ifix(v), iv, 0.5);
+    STF_ULP_EQUAL(ifix(-v), -iv, 0.5);
   }
-  STF_EQUAL(ifix(bs::ldexp(bs::One<T>(), N)), bs::Valmax<r_t>());
-  STF_EQUAL(ifix(bs::ldexp(bs::One<T>(), N+1)), bs::Valmax<r_t>());
-  STF_EQUAL(ifix(-bs::ldexp(bs::One<T>(), N+1)), bs::Valmin<r_t>());
-  STF_EQUAL(ifix(-bs::ldexp(bs::One<T>(), N+1)), bs::Valmin<r_t>());
+  STF_ULP_EQUAL(ifix(bs::ldexp(bs::One<T>(), N)), bs::Valmax<r_t>(), 0.5);
+  STF_ULP_EQUAL(ifix(bs::ldexp(bs::One<T>(), N+1)), bs::Valmax<r_t>(), 0.5);
+  STF_ULP_EQUAL(ifix(-bs::ldexp(bs::One<T>(), N+1)), bs::Valmin<r_t>(), 0.5);
+  STF_ULP_EQUAL(ifix(-bs::ldexp(bs::One<T>(), N+1)), bs::Valmin<r_t>(), 0.5);
 
 } // end of test for floating_
 

--- a/test/function/scalar/ifloor.cpp
+++ b/test/function/scalar/ifloor.cpp
@@ -30,13 +30,13 @@ STF_CASE_TPL (" ifloor real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(ifloor(bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(ifloor(bs::Minf<T>()), bs::Minf<r_t>());
-  STF_EQUAL(ifloor(bs::Nan<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(ifloor(bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(ifloor(bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(ifloor(bs::Nan<T>()), bs::Zero<r_t>(), 0.5);
 #endif
-  STF_EQUAL(ifloor(bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(ifloor(bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(ifloor(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(ifloor(bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(ifloor(bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(ifloor(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" ifloor unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/ifnot_dec.cpp
+++ b/test/function/scalar/ifnot_dec.cpp
@@ -63,9 +63,9 @@ STF_CASE_TPL(" ifnot_dec floating", STF_IEEE_TYPES)
   STF_EXPR_IS( ifnot_dec(T(), T()), T);
 
   // specific values tests
-  STF_EQUAL(ifnot_dec(bs::Zero<T>(), bs::One<T>()), bs::Zero<T>());
-  STF_EQUAL(ifnot_dec(bs::Zero<T>(), bs::Two<T>()), bs::One<T>());
-  STF_EQUAL(ifnot_dec(bs::Zero<T>(), bs::Zero<T>()), bs::Mone<T>());
-  STF_EQUAL(ifnot_dec(bs::One<T>(), bs::One<T>()), bs::One<T>());
-  STF_EQUAL(ifnot_dec(bs::One<T>(), bs::Zero<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(ifnot_dec(bs::Zero<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(ifnot_dec(bs::Zero<T>(), bs::Two<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(ifnot_dec(bs::Zero<T>(), bs::Zero<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(ifnot_dec(bs::One<T>(), bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(ifnot_dec(bs::One<T>(), bs::Zero<T>()), bs::Zero<T>(), 0.5);
 }

--- a/test/function/scalar/ifnot_inc.cpp
+++ b/test/function/scalar/ifnot_inc.cpp
@@ -64,11 +64,11 @@ STF_CASE_TPL(" ifnot_inc _floating", STF_IEEE_TYPES)
   STF_EXPR_IS( ifnot_inc(T(), T()), T);
 
   // specific values tests
-  STF_EQUAL(ifnot_inc(bs::Zero<T>(), bs::Mone<T>()), bs::Zero<T>());
-  STF_EQUAL(ifnot_inc(bs::Zero<T>(), bs::One<T>()), bs::Two<T>());
-  STF_EQUAL(ifnot_inc(bs::Zero<T>(), bs::Valmax<T>()), bs::Valmax<T>());
-  STF_EQUAL(ifnot_inc(bs::Zero<T>(), bs::Zero<T>()), bs::One<T>());
-  STF_EQUAL(ifnot_inc(bs::One<T>(), bs::Mone<T>()), bs::Mone<T>());
-  STF_EQUAL(ifnot_inc(bs::One<T>(), bs::One<T>()), bs::One<T>());
-  STF_EQUAL(ifnot_inc(bs::One<T>(), bs::Zero<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(ifnot_inc(bs::Zero<T>(), bs::Mone<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(ifnot_inc(bs::Zero<T>(), bs::One<T>()), bs::Two<T>(), 0.5);
+  STF_ULP_EQUAL(ifnot_inc(bs::Zero<T>(), bs::Valmax<T>()), bs::Valmax<T>(), 0.5);
+  STF_ULP_EQUAL(ifnot_inc(bs::Zero<T>(), bs::Zero<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(ifnot_inc(bs::One<T>(), bs::Mone<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(ifnot_inc(bs::One<T>(), bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(ifnot_inc(bs::One<T>(), bs::Zero<T>()), bs::Zero<T>(), 0.5);
 }

--- a/test/function/scalar/ifnot_minus.cpp
+++ b/test/function/scalar/ifnot_minus.cpp
@@ -29,12 +29,12 @@ STF_CASE_TPL (" ifnot_minus real",  STF_IEEE_TYPES)
   STF_TYPE_IS( r_t, T );
 
   // specific values tests
-  STF_EQUAL(ifnot_minus(T(0),T(1),T(2)), T(-1));
-  STF_EQUAL(ifnot_minus(T(1),T(1),T(2)), T(1));
-  STF_EQUAL(ifnot_minus(T(1),bs::Inf<T>(),bs::Inf<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(ifnot_minus(T(0),bs::Minf<T>(),bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(ifnot_minus(T(0),bs::Nan<T>(),bs::Nan<T>()), bs::Nan<r_t>());
-  STF_EQUAL(ifnot_minus(T(0),bs::Zero<T>(),bs::One<T>()), bs::Mone<r_t>());
+  STF_ULP_EQUAL(ifnot_minus(T(0),T(1),T(2)), T(-1), 0.5);
+  STF_ULP_EQUAL(ifnot_minus(T(1),T(1),T(2)), T(1), 0.5);
+  STF_ULP_EQUAL(ifnot_minus(T(1),bs::Inf<T>(),bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(ifnot_minus(T(0),bs::Minf<T>(),bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(ifnot_minus(T(0),bs::Nan<T>(),bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(ifnot_minus(T(0),bs::Zero<T>(),bs::One<T>()), bs::Mone<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" ifnot_minus integer",  STF_INTEGRAL_TYPES)

--- a/test/function/scalar/ifnot_plus.cpp
+++ b/test/function/scalar/ifnot_plus.cpp
@@ -32,8 +32,8 @@ STF_CASE_TPL (" ifnot_plus real",  STF_IEEE_TYPES)
   STF_TYPE_IS( r_t, T );
 
   // specific values tests
-  STF_EQUAL(ifnot_plus(T(0),T(1),T(2)), T(3));
-  STF_EQUAL(ifnot_plus(T(1),T(1),T(2)), T(1));
+  STF_ULP_EQUAL(ifnot_plus(T(0),T(1),T(2)), T(3), 0.5);
+  STF_ULP_EQUAL(ifnot_plus(T(1),T(1),T(2)), T(1), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" ifnot_plus integer",  STF_INTEGRAL_TYPES)

--- a/test/function/scalar/ilog2.cpp
+++ b/test/function/scalar/ilog2.cpp
@@ -27,11 +27,11 @@ STF_CASE_TPL (" ilog2real",  STF_IEEE_TYPES)
   STF_EXPR_IS(ilog2(T()),  bd::as_integer_t<T>);
 
   // specific values tests
-  STF_EQUAL(ilog2(bs::Two<T>()), 1);
-  STF_EQUAL(ilog2(bs::Three<T>()), 1);
-  STF_EQUAL(ilog2(bs::Four<T> ()), 2);
-  STF_EQUAL(ilog2(bs::Pi<T> ()), 1);
-  STF_EQUAL(ilog2(bs::One<T>()), 0);
+  STF_ULP_EQUAL(ilog2(bs::Two<T>()), 1, 0.5);
+  STF_ULP_EQUAL(ilog2(bs::Three<T>()), 1, 0.5);
+  STF_ULP_EQUAL(ilog2(bs::Four<T> ()), 2, 0.5);
+  STF_ULP_EQUAL(ilog2(bs::Pi<T> ()), 1, 0.5);
+  STF_ULP_EQUAL(ilog2(bs::One<T>()), 0, 0.5);
 } // end of test for real_
 
 STF_CASE_TPL (" ilog2signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/ilogb.cpp
+++ b/test/function/scalar/ilogb.cpp
@@ -31,14 +31,14 @@ STF_CASE_TPL (" ilogb real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(ilogb(bs::Minf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(ilogb(bs::Nan<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(ilogb(bs::Minf<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(ilogb(bs::Nan<T>()), bs::Zero<r_t>(), 0.5);
 #endif
-  STF_EQUAL(ilogb(bs::Mone<T>()), bs::Zero<r_t>());
-  STF_EQUAL(ilogb(bs::One<T>()), bs::Zero<r_t>());
-  STF_EQUAL(ilogb(bs::Two<T>()), bs::One<r_t>());
-  STF_EQUAL(ilogb(bs::Four<T>()), bs::Two<r_t>());
-  STF_EQUAL(ilogb(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(ilogb(bs::Mone<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(ilogb(bs::One<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(ilogb(bs::Two<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(ilogb(bs::Four<T>()), bs::Two<r_t>(), 0.5);
+  STF_ULP_EQUAL(ilogb(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 }
 
 STF_CASE_TPL (" ilogb unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/inc.cpp
+++ b/test/function/scalar/inc.cpp
@@ -61,12 +61,12 @@ STF_CASE_TPL(" inc floating", STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(inc(bs::Inf<T>()), bs::Inf<T>());
-  STF_IEEE_EQUAL(inc(bs::Nan<T>()), bs::Nan<T>());
-  STF_EQUAL(inc(bs::Minf<T>()), bs::Minf<T>());
+  STF_ULP_EQUAL(inc(bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(inc(bs::Nan<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(inc(bs::Minf<T>()), bs::Minf<T>(), 0.5);
 #endif
-  STF_EQUAL(inc(bs::One<T>()), bs::Two<T>());
-  STF_EQUAL(inc(bs::Two<T>()), bs::Three<T>());
-  STF_EQUAL(inc(bs::Zero<T>()), bs::One<T>());
-  STF_EQUAL(inc(bs::Valmax<T>()), bs::Valmax<T>());
+  STF_ULP_EQUAL(inc(bs::One<T>()), bs::Two<T>(), 0.5);
+  STF_ULP_EQUAL(inc(bs::Two<T>()), bs::Three<T>(), 0.5);
+  STF_ULP_EQUAL(inc(bs::Zero<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(inc(bs::Valmax<T>()), bs::Valmax<T>(), 0.5);
 }

--- a/test/function/scalar/inc.saturated.cpp
+++ b/test/function/scalar/inc.saturated.cpp
@@ -62,11 +62,11 @@ STF_CASE_TPL(" bs::saturated_(bs::inc) floating", STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bs::saturated_(bs::inc)(bs::Inf<T>()), bs::Inf<T>());
-  STF_IEEE_EQUAL(bs::saturated_(bs::inc)(bs::Nan<T>()), bs::Nan<T>());
-  STF_EQUAL(bs::saturated_(bs::inc)(bs::Minf<T>()), bs::Minf<T>());
+  STF_ULP_EQUAL(bs::saturated_(bs::inc)(bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::inc)(bs::Nan<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::inc)(bs::Minf<T>()), bs::Minf<T>(), 0.5);
 #endif
-  STF_EQUAL(bs::saturated_(bs::inc)(bs::One<T>()), bs::Two<T>());
-  STF_EQUAL(bs::saturated_(bs::inc)(bs::Two<T>()), bs::Three<T>());
-  STF_EQUAL(bs::saturated_(bs::inc)(bs::Zero<T>()), bs::One<T>());
+  STF_ULP_EQUAL(bs::saturated_(bs::inc)(bs::One<T>()), bs::Two<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::inc)(bs::Two<T>()), bs::Three<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::inc)(bs::Zero<T>()), bs::One<T>(), 0.5);
 }

--- a/test/function/scalar/inearbyint.cpp
+++ b/test/function/scalar/inearbyint.cpp
@@ -30,21 +30,21 @@ STF_CASE_TPL (" inearbyint real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(inearbyint(bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(inearbyint(bs::Minf<T>()), bs::Minf<r_t>());
-  STF_EQUAL(inearbyint(bs::Nan<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(inearbyint(bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(inearbyint(bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(inearbyint(bs::Nan<T>()), bs::Zero<r_t>(), 0.5);
 #endif
-  STF_EQUAL(inearbyint(bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(inearbyint(bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(inearbyint(bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(inearbyint(T(1.4)), T(1));
-  STF_EQUAL(inearbyint(T(1.5)), T(2));
-  STF_EQUAL(inearbyint(T(1.6)), T(2));
-  STF_EQUAL(inearbyint(T(2.5)), T(2));
-  STF_EQUAL(inearbyint(T(-1.4)), T(-1));
-  STF_EQUAL(inearbyint(T(-1.5)), T(-2));
-  STF_EQUAL(inearbyint(T(-1.6)), T(-2));
-  STF_EQUAL(inearbyint(T(-2.5)), T(-2));
+  STF_ULP_EQUAL(inearbyint(bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(inearbyint(bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(inearbyint(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(inearbyint(T(1.4)), T(1), 0.5);
+  STF_ULP_EQUAL(inearbyint(T(1.5)), T(2), 0.5);
+  STF_ULP_EQUAL(inearbyint(T(1.6)), T(2), 0.5);
+  STF_ULP_EQUAL(inearbyint(T(2.5)), T(2), 0.5);
+  STF_ULP_EQUAL(inearbyint(T(-1.4)), T(-1), 0.5);
+  STF_ULP_EQUAL(inearbyint(T(-1.5)), T(-2), 0.5);
+  STF_ULP_EQUAL(inearbyint(T(-1.6)), T(-2), 0.5);
+  STF_ULP_EQUAL(inearbyint(T(-2.5)), T(-2), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" inearbyint unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
@@ -91,16 +91,16 @@ STF_CASE_TPL (" inearbyint real fast",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bs::fast_(inearbyint)(bs::Minf<T>()), bs::Minf<r_t>());
+  STF_ULP_EQUAL(bs::fast_(inearbyint)(bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
 #endif
-  STF_EQUAL(bs::fast_(inearbyint)(bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(bs::fast_(inearbyint)(bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(bs::fast_(inearbyint)(bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(bs::fast_(inearbyint)(T(1.4)), T(1));
-  STF_EQUAL(bs::fast_(inearbyint)(T(1.5)), T(2));
-  STF_EQUAL(bs::fast_(inearbyint)(T(1.6)), T(2));
-  STF_EQUAL(bs::fast_(inearbyint)(T(2.5)), T(2));
-  STF_EQUAL(bs::fast_(inearbyint)(T(-1.4)), T(-1));
-  STF_EQUAL(bs::fast_(inearbyint)(T(-1.5)), T(-2));
-  STF_EQUAL(bs::fast_(inearbyint)(T(-1.6)), T(-2));
-  STF_EQUAL(bs::fast_(inearbyint)(T(-2.5)), T(-2));} // end of test for floating_
+  STF_ULP_EQUAL(bs::fast_(inearbyint)(bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(inearbyint)(bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(inearbyint)(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(inearbyint)(T(1.4)), T(1), 0.5);
+  STF_ULP_EQUAL(bs::fast_(inearbyint)(T(1.5)), T(2), 0.5);
+  STF_ULP_EQUAL(bs::fast_(inearbyint)(T(1.6)), T(2), 0.5);
+  STF_ULP_EQUAL(bs::fast_(inearbyint)(T(2.5)), T(2), 0.5);
+  STF_ULP_EQUAL(bs::fast_(inearbyint)(T(-1.4)), T(-1), 0.5);
+  STF_ULP_EQUAL(bs::fast_(inearbyint)(T(-1.5)), T(-2), 0.5);
+  STF_ULP_EQUAL(bs::fast_(inearbyint)(T(-1.6)), T(-2), 0.5);
+  STF_ULP_EQUAL(bs::fast_(inearbyint)(T(-2.5)), T(-2), 0.5);} // end of test for floating_

--- a/test/function/scalar/iround.cpp
+++ b/test/function/scalar/iround.cpp
@@ -33,32 +33,32 @@ STF_CASE_TPL (" iround real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(iround(bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(iround(bs::Minf<T>()), bs::Minf<r_t>());
-  STF_EQUAL(iround(bs::Nan<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(iround(bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(iround(bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(iround(bs::Nan<T>()), bs::Zero<r_t>(), 0.5);
 
-  STF_EQUAL(iround(bs::Mhalf<T>()), bs::Mone<r_t>());
-  STF_EQUAL(iround(bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(iround(bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(iround(bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(iround(T(1.4)), r_t(1));
-  STF_EQUAL(iround(T(1.5)), r_t(2));
-  STF_EQUAL(iround(T(1.6)), r_t(2));
-  STF_EQUAL(iround(T(2.5)), r_t(3));
-  STF_EQUAL(iround(T(-1.4)), r_t(-1));
-  STF_EQUAL(iround(T(-1.5)), r_t(-2));
-  STF_EQUAL(iround(T(-1.6)), r_t(-2));
-  STF_EQUAL(iround(T(-2.5)), r_t(-3));
-  STF_EQUAL(iround(bs::Half<T>()), bs::One<r_t>());
-  STF_EQUAL(iround(prev(prev(bs::Half<T>()))),  bs::Zero<r_t>());
-  STF_EQUAL(iround(prev(bs::Half<T>())),  bs::Zero<r_t>());
-  STF_EQUAL(iround(     bs::Half<T>()) ,  bs::One <r_t>());
-  STF_EQUAL(iround(next(bs::Half<T>())),  bs::One <r_t>());
+  STF_ULP_EQUAL(iround(bs::Mhalf<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(iround(bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(iround(bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(iround(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(iround(T(1.4)), r_t(1), 0.5);
+  STF_ULP_EQUAL(iround(T(1.5)), r_t(2), 0.5);
+  STF_ULP_EQUAL(iround(T(1.6)), r_t(2), 0.5);
+  STF_ULP_EQUAL(iround(T(2.5)), r_t(3), 0.5);
+  STF_ULP_EQUAL(iround(T(-1.4)), r_t(-1), 0.5);
+  STF_ULP_EQUAL(iround(T(-1.5)), r_t(-2), 0.5);
+  STF_ULP_EQUAL(iround(T(-1.6)), r_t(-2), 0.5);
+  STF_ULP_EQUAL(iround(T(-2.5)), r_t(-3), 0.5);
+  STF_ULP_EQUAL(iround(bs::Half<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(iround(prev(prev(bs::Half<T>()))),  bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(iround(prev(bs::Half<T>())),  bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(iround(     bs::Half<T>()) ,  bs::One <r_t>(), 0.5);
+  STF_ULP_EQUAL(iround(next(bs::Half<T>())),  bs::One <r_t>(), 0.5);
 
 #endif
-  STF_EQUAL(iround(bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(iround(bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(iround(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(iround(bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(iround(bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(iround(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" iround unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_denormal.cpp
+++ b/test/function/scalar/is_denormal.cpp
@@ -36,21 +36,21 @@ STF_CASE_TPL (" is_denormal",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_denormal(bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_denormal(bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_denormal(bs::Nan<T>()), r_t(false));
+  STF_ULP_EQUAL(is_denormal(bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_denormal(bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_denormal(bs::Nan<T>()), r_t(false), 0.5);
 #endif
-  STF_EQUAL(is_denormal(-bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_denormal(bs::Half<T>()), r_t(false));
-  STF_EQUAL(is_denormal(bs::Mone<T>()), r_t(false));
-  STF_EQUAL(is_denormal(bs::One<T>()), r_t(false));
-  STF_EQUAL(is_denormal(bs::Quarter<T>()), r_t(false));
-  STF_EQUAL(is_denormal(bs::Two<T>()), r_t(false));
-  STF_EQUAL(is_denormal(bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_denormal(bs::Smallestposval<T>()),  r_t(false));
+  STF_ULP_EQUAL(is_denormal(-bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_denormal(bs::Half<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_denormal(bs::Mone<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_denormal(bs::One<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_denormal(bs::Quarter<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_denormal(bs::Two<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_denormal(bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_denormal(bs::Smallestposval<T>()),  r_t(false), 0.5);
 #ifndef STF_NO_DENORMAL
-  STF_EQUAL(is_denormal(bs::Mindenormal<T>()), r_t(true));
-  STF_EQUAL(is_denormal(bs::Smallestposval<T>()/bs::Two<T>()), r_t(true));
+  STF_ULP_EQUAL(is_denormal(bs::Mindenormal<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_denormal(bs::Smallestposval<T>()/bs::Two<T>()), r_t(true), 0.5);
 #endif
 }
 

--- a/test/function/scalar/is_equal.cpp
+++ b/test/function/scalar/is_equal.cpp
@@ -45,11 +45,11 @@ STF_CASE_TPL (" is_equal real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t,bs::logical<T>);
 
   // specific values tests
-  STF_EQUAL(is_equal(bs::Inf<T>(), bs::Inf<T>()), r_t(true));
-  STF_EQUAL(is_equal(bs::Minf<T>(), bs::Minf<T>()), r_t(true));
-  STF_EQUAL(is_equal(bs::Nan<T>(), bs::Nan<T>()), r_t(false));
-  STF_EQUAL(is_equal(bs::One<T>(),bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_equal(bs::Zero<T>(), bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_equal(bs::Inf<T>(), bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_equal(bs::Minf<T>(), bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_equal(bs::Nan<T>(), bs::Nan<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_equal(bs::One<T>(),bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_equal(bs::Zero<T>(), bs::Zero<T>()), r_t(true), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" is_equal logical",  STF_IEEE_TYPES)
@@ -62,10 +62,10 @@ STF_CASE_TPL (" is_equal logical",  STF_IEEE_TYPES)
   // return type conformity test
   STF_TYPE_IS(r_t, bs::logical<T>);
 
-  STF_EQUAL(is_equal(bs::True< bs::logical<T> >(), bs::True< bs::logical<T> >()), r_t(true));
-  STF_EQUAL(is_equal(bs::False< bs::logical<T> >(), bs::False< bs::logical<T> >()), r_t(true));
-  STF_EQUAL(is_equal(bs::True< bs::logical<T> >(), bs::False< bs::logical<T> >()), r_t(false));
-  STF_EQUAL(is_equal(bs::False< bs::logical<T> >(), bs::True< bs::logical<T> >()), r_t(false));
+  STF_ULP_EQUAL(is_equal(bs::True< bs::logical<T> >(), bs::True< bs::logical<T> >()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_equal(bs::False< bs::logical<T> >(), bs::False< bs::logical<T> >()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_equal(bs::True< bs::logical<T> >(), bs::False< bs::logical<T> >()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_equal(bs::False< bs::logical<T> >(), bs::True< bs::logical<T> >()), r_t(false), 0.5);
 }
 
 STF_CASE ( "is_equal bool")
@@ -77,10 +77,10 @@ STF_CASE ( "is_equal bool")
   STF_EXPR_IS(is_equal(bool(), bool()), bool);
 
   // specific values tests
-  STF_EQUAL(is_equal(true, false), false);
-  STF_EQUAL(is_equal(false, true), false);
-  STF_EQUAL(is_equal(true, true), true);
-  STF_EQUAL(is_equal(false, false), true);
+  STF_ULP_EQUAL(is_equal(true, false), false, 0.5);
+  STF_ULP_EQUAL(is_equal(false, true), false, 0.5);
+  STF_ULP_EQUAL(is_equal(true, true), true, 0.5);
+  STF_ULP_EQUAL(is_equal(false, false), true, 0.5);
 }
 
 

--- a/test/function/scalar/is_equal_with_equal_nans.cpp
+++ b/test/function/scalar/is_equal_with_equal_nans.cpp
@@ -43,11 +43,11 @@ STF_CASE_TPL (" is_equal_with_equal_nans real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t,bs::logical<T>);
 
   // specific values tests
-  STF_EQUAL(is_equal_with_equal_nans(bs::Inf<T>(), bs::Inf<T>()), r_t(true));
-  STF_EQUAL(is_equal_with_equal_nans(bs::Minf<T>(), bs::Minf<T>()), r_t(true));
-  STF_EQUAL(is_equal_with_equal_nans(bs::Nan<T>(), bs::Nan<T>()), r_t(true));
-  STF_EQUAL(is_equal_with_equal_nans(bs::One<T>(),bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_equal_with_equal_nans(bs::Zero<T>(), bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_equal_with_equal_nans(bs::Inf<T>(), bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_equal_with_equal_nans(bs::Minf<T>(), bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_equal_with_equal_nans(bs::Nan<T>(), bs::Nan<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_equal_with_equal_nans(bs::One<T>(),bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_equal_with_equal_nans(bs::Zero<T>(), bs::Zero<T>()), r_t(true), 0.5);
 } // end of test for floating_
 
 
@@ -63,10 +63,10 @@ STF_CASE ( "is_equal_with_equal_nans bool")
   STF_EXPR_IS(is_equal_with_equal_nans(bool(), bool()), bool);
 
   // specific values tests
-  STF_EQUAL(is_equal_with_equal_nans(true, false), false);
-  STF_EQUAL(is_equal_with_equal_nans(false, true), false);
-  STF_EQUAL(is_equal_with_equal_nans(true, true), true);
-  STF_EQUAL(is_equal_with_equal_nans(false, false), true);
+  STF_ULP_EQUAL(is_equal_with_equal_nans(true, false), false, 0.5);
+  STF_ULP_EQUAL(is_equal_with_equal_nans(false, true), false, 0.5);
+  STF_ULP_EQUAL(is_equal_with_equal_nans(true, true), true, 0.5);
+  STF_ULP_EQUAL(is_equal_with_equal_nans(false, false), true, 0.5);
 }
 
 

--- a/test/function/scalar/is_eqz.cpp
+++ b/test/function/scalar/is_eqz.cpp
@@ -32,17 +32,17 @@ STF_CASE_TPL (" is_eqz real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_eqz(bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_eqz(bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_eqz(bs::Nan<T>()), r_t(false));
+  STF_ULP_EQUAL(is_eqz(bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_eqz(bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_eqz(bs::Nan<T>()), r_t(false), 0.5);
 #endif
-  STF_EQUAL(is_eqz(-bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_eqz(bs::Half<T>()), r_t(false));
-  STF_EQUAL(is_eqz(bs::Mone<T>()), r_t(false));
-  STF_EQUAL(is_eqz(bs::One<T>()), r_t(false));
-  STF_EQUAL(is_eqz(bs::Quarter<T>()), r_t(false));
-  STF_EQUAL(is_eqz(bs::Two<T>()), r_t(false));
-  STF_EQUAL(is_eqz(bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_eqz(-bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_eqz(bs::Half<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_eqz(bs::Mone<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_eqz(bs::One<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_eqz(bs::Quarter<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_eqz(bs::Two<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_eqz(bs::Zero<T>()), r_t(true), 0.5);
 }
 
 STF_CASE_TPL (" is_eqz signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_even.cpp
+++ b/test/function/scalar/is_even.cpp
@@ -32,17 +32,17 @@ STF_CASE_TPL (" is_even real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_even(bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_even(bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_even(bs::Nan<T>()), r_t(false));
+  STF_ULP_EQUAL(is_even(bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_even(bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_even(bs::Nan<T>()), r_t(false), 0.5);
 #endif
-  STF_EQUAL(is_even(-bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_even(bs::Half<T>()), r_t(false));
-  STF_EQUAL(is_even(bs::Mone<T>()), r_t(false));
-  STF_EQUAL(is_even(bs::One<T>()), r_t(false));
-  STF_EQUAL(is_even(bs::Quarter<T>()), r_t(false));
-  STF_EQUAL(is_even(bs::Two<T>()), r_t(true));
-  STF_EQUAL(is_even(bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_even(-bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_even(bs::Half<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_even(bs::Mone<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_even(bs::One<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_even(bs::Quarter<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_even(bs::Two<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_even(bs::Zero<T>()), r_t(true), 0.5);
 }
 
 STF_CASE_TPL (" is_even signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_finite.cpp
+++ b/test/function/scalar/is_finite.cpp
@@ -33,17 +33,17 @@ STF_CASE_TPL (" is_finite real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_finite(bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_finite(bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_finite(bs::Nan<T>()), r_t(false));
+  STF_ULP_EQUAL(is_finite(bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_finite(bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_finite(bs::Nan<T>()), r_t(false), 0.5);
 #endif
-  STF_EQUAL(is_finite(-bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_finite(bs::Half<T>()), r_t(true));
-  STF_EQUAL(is_finite(bs::Mone<T>()), r_t(true));
-  STF_EQUAL(is_finite(bs::One<T>()), r_t(true));
-  STF_EQUAL(is_finite(bs::Quarter<T>()), r_t(true));
-  STF_EQUAL(is_finite(bs::Two<T>()), r_t(true));
-  STF_EQUAL(is_finite(bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_finite(-bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_finite(bs::Half<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_finite(bs::Mone<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_finite(bs::One<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_finite(bs::Quarter<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_finite(bs::Two<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_finite(bs::Zero<T>()), r_t(true), 0.5);
 }
 
 STF_CASE_TPL (" is_finite signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_flint.cpp
+++ b/test/function/scalar/is_flint.cpp
@@ -34,17 +34,17 @@ STF_CASE_TPL (" is_flint real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_flint(bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_flint(bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_flint(bs::Nan<T>()), r_t(false));
+  STF_ULP_EQUAL(is_flint(bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_flint(bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_flint(bs::Nan<T>()), r_t(false), 0.5);
 #endif
-  STF_EQUAL(is_flint(-bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_flint(bs::Half<T>()), r_t(false));
-  STF_EQUAL(is_flint(bs::Mone<T>()), r_t(true));
-  STF_EQUAL(is_flint(bs::One<T>()), r_t(true));
-  STF_EQUAL(is_flint(bs::Quarter<T>()), r_t(false));
-  STF_EQUAL(is_flint(bs::Two<T>()), r_t(true));
-  STF_EQUAL(is_flint(bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_flint(-bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_flint(bs::Half<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_flint(bs::Mone<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_flint(bs::One<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_flint(bs::Quarter<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_flint(bs::Two<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_flint(bs::Zero<T>()), r_t(true), 0.5);
 }
 
 STF_CASE_TPL (" is_flint signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_gez.cpp
+++ b/test/function/scalar/is_gez.cpp
@@ -33,17 +33,17 @@ STF_CASE_TPL (" is_gez real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_gez(bs::Inf<T>()), r_t(true));
-  STF_EQUAL(is_gez(bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_gez(bs::Nan<T>()), r_t(false));
+  STF_ULP_EQUAL(is_gez(bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_gez(bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_gez(bs::Nan<T>()), r_t(false), 0.5);
 #endif
-  STF_EQUAL(is_gez(-bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_gez(bs::Half<T>()), r_t(true));
-  STF_EQUAL(is_gez(bs::Mone<T>()), r_t(false));
-  STF_EQUAL(is_gez(bs::One<T>()), r_t(true));
-  STF_EQUAL(is_gez(bs::Quarter<T>()), r_t(true));
-  STF_EQUAL(is_gez(bs::Two<T>()), r_t(true));
-  STF_EQUAL(is_gez(bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_gez(-bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_gez(bs::Half<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_gez(bs::Mone<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_gez(bs::One<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_gez(bs::Quarter<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_gez(bs::Two<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_gez(bs::Zero<T>()), r_t(true), 0.5);
 }
 
 STF_CASE_TPL (" is_gez signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_greater.cpp
+++ b/test/function/scalar/is_greater.cpp
@@ -45,11 +45,11 @@ STF_CASE_TPL (" is_greater real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, bs::logical<T>);
 
   // specific values tests
-  STF_EQUAL(is_greater(bs::Inf<T>(), bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_greater(bs::Minf<T>(), bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_greater(bs::Nan<T>(), bs::Nan<T>()), r_t(false));
-  STF_EQUAL(is_greater(bs::One<T>(),bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_greater(bs::Zero<T>(), bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(is_greater(bs::Inf<T>(), bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_greater(bs::Minf<T>(), bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_greater(bs::Nan<T>(), bs::Nan<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_greater(bs::One<T>(),bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_greater(bs::Zero<T>(), bs::Zero<T>()), r_t(false), 0.5);
 } // end of test for floating_
 
 STF_CASE ( "is_greater bool")
@@ -63,10 +63,10 @@ STF_CASE ( "is_greater bool")
   STF_TYPE_IS(r_t, bool);
 
   // specific values tests
-  STF_EQUAL(is_greater(true, false), true);
-  STF_EQUAL(is_greater(false, true), false);
-  STF_EQUAL(is_greater(true, true), false);
-  STF_EQUAL(is_greater(false, false), false);
+  STF_ULP_EQUAL(is_greater(true, false), true, 0.5);
+  STF_ULP_EQUAL(is_greater(false, true), false, 0.5);
+  STF_ULP_EQUAL(is_greater(true, true), false, 0.5);
+  STF_ULP_EQUAL(is_greater(false, false), false, 0.5);
 }
 
 

--- a/test/function/scalar/is_greater_equal.cpp
+++ b/test/function/scalar/is_greater_equal.cpp
@@ -45,11 +45,11 @@ STF_CASE_TPL (" is_greater_equal real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, bs::logical<T>);
 
   // specific values tests
-  STF_EQUAL(is_greater_equal(bs::Inf<T>(), bs::Inf<T>()), r_t(true));
-  STF_EQUAL(is_greater_equal(bs::Minf<T>(), bs::Minf<T>()), r_t(true));
-  STF_EQUAL(is_greater_equal(bs::Nan<T>(), bs::Nan<T>()), r_t(false));
-  STF_EQUAL(is_greater_equal(bs::One<T>(),bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_greater_equal(bs::Zero<T>(), bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_greater_equal(bs::Inf<T>(), bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_greater_equal(bs::Minf<T>(), bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_greater_equal(bs::Nan<T>(), bs::Nan<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_greater_equal(bs::One<T>(),bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_greater_equal(bs::Zero<T>(), bs::Zero<T>()), r_t(true), 0.5);
 } // end of test for floating_
 
 STF_CASE ( "is_greater_equal bool")
@@ -63,10 +63,10 @@ STF_CASE ( "is_greater_equal bool")
   STF_TYPE_IS(r_t, bool);
 
   // specific values tests
-  STF_EQUAL(is_greater_equal(true, false), true);
-  STF_EQUAL(is_greater_equal(false, true), false);
-  STF_EQUAL(is_greater_equal(true, true), true);
-  STF_EQUAL(is_greater_equal(false, false), true);
+  STF_ULP_EQUAL(is_greater_equal(true, false), true, 0.5);
+  STF_ULP_EQUAL(is_greater_equal(false, true), false, 0.5);
+  STF_ULP_EQUAL(is_greater_equal(true, true), true, 0.5);
+  STF_ULP_EQUAL(is_greater_equal(false, false), true, 0.5);
 }
 
 

--- a/test/function/scalar/is_gtz.cpp
+++ b/test/function/scalar/is_gtz.cpp
@@ -33,17 +33,17 @@ STF_CASE_TPL (" is_gtz real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_gtz(bs::Inf<T>()), r_t(true));
-  STF_EQUAL(is_gtz(bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_gtz(bs::Nan<T>()), r_t(false));
+  STF_ULP_EQUAL(is_gtz(bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_gtz(bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_gtz(bs::Nan<T>()), r_t(false), 0.5);
 #endif
-  STF_EQUAL(is_gtz(-bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_gtz(bs::Half<T>()), r_t(true));
-  STF_EQUAL(is_gtz(bs::Mone<T>()), r_t(false));
-  STF_EQUAL(is_gtz(bs::One<T>()), r_t(true));
-  STF_EQUAL(is_gtz(bs::Quarter<T>()), r_t(true));
-  STF_EQUAL(is_gtz(bs::Two<T>()), r_t(true));
-  STF_EQUAL(is_gtz(bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(is_gtz(-bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_gtz(bs::Half<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_gtz(bs::Mone<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_gtz(bs::One<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_gtz(bs::Quarter<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_gtz(bs::Two<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_gtz(bs::Zero<T>()), r_t(false), 0.5);
 }
 
 STF_CASE_TPL (" is_gtz signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_imag.cpp
+++ b/test/function/scalar/is_imag.cpp
@@ -33,17 +33,17 @@ STF_CASE_TPL (" is_imag real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_imag(bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_imag(bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_imag(bs::Nan<T>()), r_t(false));
+  STF_ULP_EQUAL(is_imag(bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_imag(bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_imag(bs::Nan<T>()), r_t(false), 0.5);
 #endif
-  STF_EQUAL(is_imag(-bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_imag(bs::Half<T>()), r_t(false));
-  STF_EQUAL(is_imag(bs::Mone<T>()), r_t(false));
-  STF_EQUAL(is_imag(bs::One<T>()), r_t(false));
-  STF_EQUAL(is_imag(bs::Quarter<T>()), r_t(false));
-  STF_EQUAL(is_imag(bs::Two<T>()), r_t(false));
-  STF_EQUAL(is_imag(bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_imag(-bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_imag(bs::Half<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_imag(bs::Mone<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_imag(bs::One<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_imag(bs::Quarter<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_imag(bs::Two<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_imag(bs::Zero<T>()), r_t(true), 0.5);
 }
 
 STF_CASE_TPL (" is_imag signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_inf.cpp
+++ b/test/function/scalar/is_inf.cpp
@@ -33,17 +33,17 @@ STF_CASE_TPL (" is_inf real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_inf(bs::Inf<T>()), r_t(true));
-  STF_EQUAL(is_inf(bs::Minf<T>()), r_t(true));
-  STF_EQUAL(is_inf(bs::Nan<T>()), r_t(false));
+  STF_ULP_EQUAL(is_inf(bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_inf(bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_inf(bs::Nan<T>()), r_t(false), 0.5);
 #endif
-  STF_EQUAL(is_inf(-bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_inf(bs::Half<T>()), r_t(false));
-  STF_EQUAL(is_inf(bs::Mone<T>()), r_t(false));
-  STF_EQUAL(is_inf(bs::One<T>()), r_t(false));
-  STF_EQUAL(is_inf(bs::Quarter<T>()), r_t(false));
-  STF_EQUAL(is_inf(bs::Two<T>()), r_t(false));
-  STF_EQUAL(is_inf(bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(is_inf(-bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_inf(bs::Half<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_inf(bs::Mone<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_inf(bs::One<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_inf(bs::Quarter<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_inf(bs::Two<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_inf(bs::Zero<T>()), r_t(false), 0.5);
 }
 
 STF_CASE_TPL (" is_inf signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_invalid.cpp
+++ b/test/function/scalar/is_invalid.cpp
@@ -33,17 +33,17 @@ STF_CASE_TPL (" is_invalid real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_invalid(bs::Inf<T>()), r_t(true));
-  STF_EQUAL(is_invalid(bs::Minf<T>()), r_t(true));
-  STF_EQUAL(is_invalid(bs::Nan<T>()), r_t(true));
+  STF_ULP_EQUAL(is_invalid(bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_invalid(bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_invalid(bs::Nan<T>()), r_t(true), 0.5);
 #endif
-  STF_EQUAL(is_invalid(-bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_invalid(bs::Half<T>()), r_t(false));
-  STF_EQUAL(is_invalid(bs::Mone<T>()), r_t(false));
-  STF_EQUAL(is_invalid(bs::One<T>()), r_t(false));
-  STF_EQUAL(is_invalid(bs::Quarter<T>()), r_t(false));
-  STF_EQUAL(is_invalid(bs::Two<T>()), r_t(false));
-  STF_EQUAL(is_invalid(bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(is_invalid(-bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_invalid(bs::Half<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_invalid(bs::Mone<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_invalid(bs::One<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_invalid(bs::Quarter<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_invalid(bs::Two<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_invalid(bs::Zero<T>()), r_t(false), 0.5);
 }
 
 STF_CASE_TPL (" is_invalid signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_less.cpp
+++ b/test/function/scalar/is_less.cpp
@@ -45,11 +45,11 @@ STF_CASE_TPL (" is_less real",  STF_IEEE_TYPES)
  STF_TYPE_IS(r_t, bs::logical<T>);
 
   // specific values tests
-  STF_EQUAL(is_less(bs::Inf<T>(), bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_less(bs::Minf<T>(), bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_less(bs::Nan<T>(), bs::Nan<T>()), r_t(false));
-  STF_EQUAL(is_less(bs::One<T>(),bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_less(bs::Zero<T>(), bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(is_less(bs::Inf<T>(), bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_less(bs::Minf<T>(), bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_less(bs::Nan<T>(), bs::Nan<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_less(bs::One<T>(),bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_less(bs::Zero<T>(), bs::Zero<T>()), r_t(false), 0.5);
 } // end of test for floating_
 
 STF_CASE ( "is_less bool")
@@ -65,10 +65,10 @@ STF_CASE ( "is_less bool")
 
 
   // specific values tests
-  STF_EQUAL(is_less(true, false), false);
-  STF_EQUAL(is_less(false, true), true);
-  STF_EQUAL(is_less(true, true), false);
-  STF_EQUAL(is_less(false, false), false);
+  STF_ULP_EQUAL(is_less(true, false), false, 0.5);
+  STF_ULP_EQUAL(is_less(false, true), true, 0.5);
+  STF_ULP_EQUAL(is_less(true, true), false, 0.5);
+  STF_ULP_EQUAL(is_less(false, false), false, 0.5);
 }
 
 

--- a/test/function/scalar/is_less_equal.cpp
+++ b/test/function/scalar/is_less_equal.cpp
@@ -45,11 +45,11 @@ STF_CASE_TPL (" is_less_equal real",  STF_IEEE_TYPES)
  STF_TYPE_IS(r_t, bs::logical<T>);
 
   // specific values tests
-  STF_EQUAL(is_less_equal(bs::Inf<T>(), bs::Inf<T>()), r_t(true));
-  STF_EQUAL(is_less_equal(bs::Minf<T>(), bs::Minf<T>()), r_t(true));
-  STF_EQUAL(is_less_equal(bs::Nan<T>(), bs::Nan<T>()), r_t(false));
-  STF_EQUAL(is_less_equal(bs::One<T>(),bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_less_equal(bs::Zero<T>(), bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_less_equal(bs::Inf<T>(), bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_less_equal(bs::Minf<T>(), bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_less_equal(bs::Nan<T>(), bs::Nan<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_less_equal(bs::One<T>(),bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_less_equal(bs::Zero<T>(), bs::Zero<T>()), r_t(true), 0.5);
 } // end of test for floating_
 
 STF_CASE ( "is_less_equal bool")
@@ -65,10 +65,10 @@ STF_CASE ( "is_less_equal bool")
 
 
   // specific values tests
-  STF_EQUAL(is_less_equal(true, false), false);
-  STF_EQUAL(is_less_equal(false, true), true);
-  STF_EQUAL(is_less_equal(true, true), true);
-  STF_EQUAL(is_less_equal(false, false), true);
+  STF_ULP_EQUAL(is_less_equal(true, false), false, 0.5);
+  STF_ULP_EQUAL(is_less_equal(false, true), true, 0.5);
+  STF_ULP_EQUAL(is_less_equal(true, true), true, 0.5);
+  STF_ULP_EQUAL(is_less_equal(false, false), true, 0.5);
 }
 
 

--- a/test/function/scalar/is_lessgreater.cpp
+++ b/test/function/scalar/is_lessgreater.cpp
@@ -33,19 +33,19 @@ STF_CASE_TPL (" is_lessgreater real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_lessgreater(bs::Inf<T>(), bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_lessgreater(bs::Minf<T>(), bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_lessgreater(bs::Nan<T>(), bs::Nan<T>()), r_t(false));
+  STF_ULP_EQUAL(is_lessgreater(bs::Inf<T>(), bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_lessgreater(bs::Minf<T>(), bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_lessgreater(bs::Nan<T>(), bs::Nan<T>()), r_t(false), 0.5);
 #endif
-  STF_EQUAL(is_lessgreater(-bs::Zero<T>(), -bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_lessgreater(bs::Half<T>(), bs::Half<T>()), r_t(false));
-  STF_EQUAL(is_lessgreater(bs::Mone<T>(), bs::Mone<T>()), r_t(false));
-  STF_EQUAL(is_lessgreater(bs::One<T>(), bs::One<T>()), r_t(false));
-  STF_EQUAL(is_lessgreater(bs::Quarter<T>(), bs::Quarter<T>()), r_t(false));
-  STF_EQUAL(is_lessgreater(bs::Two<T>(), bs::Two<T>()), r_t(false));
-  STF_EQUAL(is_lessgreater(bs::Zero<T>(), bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_lessgreater(-bs::Zero<T>(), -bs::One<T>()), r_t(true));
-  STF_EQUAL(is_lessgreater(bs::One<T>(), bs::Half<T>()), r_t(true));
+  STF_ULP_EQUAL(is_lessgreater(-bs::Zero<T>(), -bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_lessgreater(bs::Half<T>(), bs::Half<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_lessgreater(bs::Mone<T>(), bs::Mone<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_lessgreater(bs::One<T>(), bs::One<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_lessgreater(bs::Quarter<T>(), bs::Quarter<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_lessgreater(bs::Two<T>(), bs::Two<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_lessgreater(bs::Zero<T>(), bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_lessgreater(-bs::Zero<T>(), -bs::One<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_lessgreater(bs::One<T>(), bs::Half<T>()), r_t(true), 0.5);
 }
 
 STF_CASE_TPL (" is_lessgreater signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_lez.cpp
+++ b/test/function/scalar/is_lez.cpp
@@ -33,17 +33,17 @@ STF_CASE_TPL (" is_lez  _real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_lez(bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_lez(bs::Minf<T>()), r_t(true));
-  STF_EQUAL(is_lez(bs::Nan<T>()), r_t(false));
+  STF_ULP_EQUAL(is_lez(bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_lez(bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_lez(bs::Nan<T>()), r_t(false), 0.5);
 #endif
-  STF_EQUAL(is_lez(-bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_lez(bs::Half<T>()), r_t(false));
-  STF_EQUAL(is_lez(bs::Mone<T>()), r_t(true));
-  STF_EQUAL(is_lez(bs::One<T>()), r_t(false));
-  STF_EQUAL(is_lez(bs::Quarter<T>()), r_t(false));
-  STF_EQUAL(is_lez(bs::Two<T>()), r_t(false));
-  STF_EQUAL(is_lez(bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_lez(-bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_lez(bs::Half<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_lez(bs::Mone<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_lez(bs::One<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_lez(bs::Quarter<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_lez(bs::Two<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_lez(bs::Zero<T>()), r_t(true), 0.5);
 }
 
 STF_CASE_TPL (" is_lez _signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_ltz.cpp
+++ b/test/function/scalar/is_ltz.cpp
@@ -34,17 +34,17 @@ STF_CASE_TPL (" is_ltz  _real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_ltz(bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_ltz(bs::Minf<T>()), r_t(true));
-  STF_EQUAL(is_ltz(bs::Nan<T>()), r_t(false));
+  STF_ULP_EQUAL(is_ltz(bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_ltz(bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_ltz(bs::Nan<T>()), r_t(false), 0.5);
 #endif
-  STF_EQUAL(is_ltz(bs::Mzero<T>()), r_t(false));
-  STF_EQUAL(is_ltz(bs::Half<T>()), r_t(false));
-  STF_EQUAL(is_ltz(bs::Mone<T>()), r_t(true));
-  STF_EQUAL(is_ltz(bs::One<T>()), r_t(false));
-  STF_EQUAL(is_ltz(bs::Quarter<T>()), r_t(false));
-  STF_EQUAL(is_ltz(bs::Two<T>()), r_t(false));
-  STF_EQUAL(is_ltz(bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(is_ltz(bs::Mzero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_ltz(bs::Half<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_ltz(bs::Mone<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_ltz(bs::One<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_ltz(bs::Quarter<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_ltz(bs::Two<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_ltz(bs::Zero<T>()), r_t(false), 0.5);
 }
 
 STF_CASE_TPL (" is_ltz _signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_nan.cpp
+++ b/test/function/scalar/is_nan.cpp
@@ -34,17 +34,17 @@ STF_CASE_TPL (" is_nan  _real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_nan(bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_nan(bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_nan(bs::Nan<T>()), r_t(true));
+  STF_ULP_EQUAL(is_nan(bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_nan(bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_nan(bs::Nan<T>()), r_t(true), 0.5);
 #endif
-  STF_EQUAL(is_nan(bs::Mzero<T>()), r_t(false));
-  STF_EQUAL(is_nan(bs::Half<T>()), r_t(false));
-  STF_EQUAL(is_nan(bs::Mone<T>()), r_t(false));
-  STF_EQUAL(is_nan(bs::One<T>()), r_t(false));
-  STF_EQUAL(is_nan(bs::Quarter<T>()), r_t(false));
-  STF_EQUAL(is_nan(bs::Two<T>()), r_t(false));
-  STF_EQUAL(is_nan(bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(is_nan(bs::Mzero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_nan(bs::Half<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_nan(bs::Mone<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_nan(bs::One<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_nan(bs::Quarter<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_nan(bs::Two<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_nan(bs::Zero<T>()), r_t(false), 0.5);
 }
 
 STF_CASE_TPL (" is_nan _signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_negative.cpp
+++ b/test/function/scalar/is_negative.cpp
@@ -34,18 +34,18 @@ STF_CASE_TPL (" is_negative  _real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_negative(bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_negative(bs::Minf<T>()), r_t(true));
-  STF_EQUAL(is_negative(bs::Nan<T>()), r_t(true));
+  STF_ULP_EQUAL(is_negative(bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_negative(bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_negative(bs::Nan<T>()), r_t(true), 0.5);
 #endif
-  STF_EQUAL(is_negative(-bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_negative(bs::Half<T>()), r_t(false));
-  STF_EQUAL(is_negative(bs::Mone<T>()), r_t(true));
-  STF_EQUAL(is_negative(bs::One<T>()), r_t(false));
-  STF_EQUAL(is_negative(bs::Quarter<T>()), r_t(false));
-  STF_EQUAL(is_negative(bs::Two<T>()), r_t(false));
-  STF_EQUAL(is_negative(bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_negative(bs::Mzero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_negative(-bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_negative(bs::Half<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_negative(bs::Mone<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_negative(bs::One<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_negative(bs::Quarter<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_negative(bs::Two<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_negative(bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_negative(bs::Mzero<T>()), r_t(true), 0.5);
 }
 
 STF_CASE_TPL (" is_negative _signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_nez.cpp
+++ b/test/function/scalar/is_nez.cpp
@@ -34,17 +34,17 @@ STF_CASE_TPL (" is_lez  _real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_nez(bs::Inf<T>()), r_t(true));
-  STF_EQUAL(is_nez(bs::Minf<T>()), r_t(true));
-  STF_EQUAL(is_nez(bs::Nan<T>()), r_t(true));
+  STF_ULP_EQUAL(is_nez(bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_nez(bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_nez(bs::Nan<T>()), r_t(true), 0.5);
 #endif
-  STF_EQUAL(is_nez(bs::Half<T>()), r_t(true));
-  STF_EQUAL(is_nez(bs::Mone<T>()), r_t(true));
-  STF_EQUAL(is_nez(bs::One<T>()), r_t(true));
-  STF_EQUAL(is_nez(bs::Quarter<T>()), r_t(true));
-  STF_EQUAL(is_nez(bs::Two<T>()), r_t(true));
-  STF_EQUAL(is_nez(bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_nez(bs::Mzero<T>()), r_t(false));
+  STF_ULP_EQUAL(is_nez(bs::Half<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_nez(bs::Mone<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_nez(bs::One<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_nez(bs::Quarter<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_nez(bs::Two<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_nez(bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_nez(bs::Mzero<T>()), r_t(false), 0.5);
 }
 
 STF_CASE_TPL (" is_nez _signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_ngez.cpp
+++ b/test/function/scalar/is_ngez.cpp
@@ -36,17 +36,17 @@ STF_CASE_TPL (" is_ngez  _real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_ngez(bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_ngez(bs::Minf<T>()), r_t(true));
-  STF_EQUAL(is_ngez(bs::Nan<T>()), r_t(true));
+  STF_ULP_EQUAL(is_ngez(bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_ngez(bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_ngez(bs::Nan<T>()), r_t(true), 0.5);
 #endif
-  STF_EQUAL(is_ngez(bs::Mzero<T>()), r_t(false));
-  STF_EQUAL(is_ngez(bs::Half<T>()), r_t(false));
-  STF_EQUAL(is_ngez(bs::Mone<T>()), r_t(true));
-  STF_EQUAL(is_ngez(bs::One<T>()), r_t(false));
-  STF_EQUAL(is_ngez(bs::Quarter<T>()), r_t(false));
-  STF_EQUAL(is_ngez(bs::Two<T>()), r_t(false));
-  STF_EQUAL(is_ngez(bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(is_ngez(bs::Mzero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_ngez(bs::Half<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_ngez(bs::Mone<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_ngez(bs::One<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_ngez(bs::Quarter<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_ngez(bs::Two<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_ngez(bs::Zero<T>()), r_t(false), 0.5);
 }
 
 STF_CASE_TPL (" is_ngez _signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_ngtz.cpp
+++ b/test/function/scalar/is_ngtz.cpp
@@ -33,17 +33,17 @@ STF_CASE_TPL (" is_ngtz  _real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_ngtz(bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_ngtz(bs::Minf<T>()), r_t(true));
-  STF_EQUAL(is_ngtz(bs::Nan<T>()), r_t(true));
+  STF_ULP_EQUAL(is_ngtz(bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_ngtz(bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_ngtz(bs::Nan<T>()), r_t(true), 0.5);
 #endif
-  STF_EQUAL(is_ngtz(-bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_ngtz(bs::Half<T>()), r_t(false));
-  STF_EQUAL(is_ngtz(bs::Mone<T>()), r_t(true));
-  STF_EQUAL(is_ngtz(bs::One<T>()), r_t(false));
-  STF_EQUAL(is_ngtz(bs::Quarter<T>()), r_t(false));
-  STF_EQUAL(is_ngtz(bs::Two<T>()), r_t(false));
-  STF_EQUAL(is_ngtz(bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_ngtz(-bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_ngtz(bs::Half<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_ngtz(bs::Mone<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_ngtz(bs::One<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_ngtz(bs::Quarter<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_ngtz(bs::Two<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_ngtz(bs::Zero<T>()), r_t(true), 0.5);
 }
 
 STF_CASE_TPL (" is_ngtz _signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_nlez.cpp
+++ b/test/function/scalar/is_nlez.cpp
@@ -33,17 +33,17 @@ STF_CASE_TPL (" is_nlez real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_nlez(bs::Inf<T>()), r_t(true));
-  STF_EQUAL(is_nlez(bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_nlez(bs::Nan<T>()), r_t(true));
+  STF_ULP_EQUAL(is_nlez(bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_nlez(bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_nlez(bs::Nan<T>()), r_t(true), 0.5);
 #endif
-  STF_EQUAL(is_nlez(-bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_nlez(bs::Half<T>()), r_t(true));
-  STF_EQUAL(is_nlez(bs::Mone<T>()), r_t(false));
-  STF_EQUAL(is_nlez(bs::One<T>()), r_t(true));
-  STF_EQUAL(is_nlez(bs::Quarter<T>()), r_t(true));
-  STF_EQUAL(is_nlez(bs::Two<T>()), r_t(true));
-  STF_EQUAL(is_nlez(bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(is_nlez(-bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_nlez(bs::Half<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_nlez(bs::Mone<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_nlez(bs::One<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_nlez(bs::Quarter<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_nlez(bs::Two<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_nlez(bs::Zero<T>()), r_t(false), 0.5);
 }
 
 STF_CASE_TPL (" is_nlez signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_nltz.cpp
+++ b/test/function/scalar/is_nltz.cpp
@@ -34,17 +34,17 @@ STF_CASE_TPL (" is_nltz real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_nltz(bs::Inf<T>()), r_t(true));
-  STF_EQUAL(is_nltz(bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_nltz(bs::Nan<T>()), r_t(true));
+  STF_ULP_EQUAL(is_nltz(bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_nltz(bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_nltz(bs::Nan<T>()), r_t(true), 0.5);
 #endif
-  STF_EQUAL(is_nltz(-bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_nltz(bs::Half<T>()), r_t(true));
-  STF_EQUAL(is_nltz(bs::Mone<T>()), r_t(false));
-  STF_EQUAL(is_nltz(bs::One<T>()), r_t(true));
-  STF_EQUAL(is_nltz(bs::Quarter<T>()), r_t(true));
-  STF_EQUAL(is_nltz(bs::Two<T>()), r_t(true));
-  STF_EQUAL(is_nltz(bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_nltz(-bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_nltz(bs::Half<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_nltz(bs::Mone<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_nltz(bs::One<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_nltz(bs::Quarter<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_nltz(bs::Two<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_nltz(bs::Zero<T>()), r_t(true), 0.5);
 }
 
 STF_CASE_TPL (" is_nltz signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_normal.cpp
+++ b/test/function/scalar/is_normal.cpp
@@ -39,21 +39,21 @@ STF_CASE_TPL (" is_normal",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_normal(bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_normal(bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_normal(bs::Nan<T>()), r_t(false));
+  STF_ULP_EQUAL(is_normal(bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_normal(bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_normal(bs::Nan<T>()), r_t(false), 0.5);
 #endif
-  STF_EQUAL(is_normal(-bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_normal(bs::Half<T>()), r_t(true));
-  STF_EQUAL(is_normal(bs::Mone<T>()), r_t(true));
-  STF_EQUAL(is_normal(bs::One<T>()), r_t(true));
-  STF_EQUAL(is_normal(bs::Quarter<T>()), r_t(true));
-  STF_EQUAL(is_normal(bs::Two<T>()), r_t(true));
-  STF_EQUAL(is_normal(bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_normal(bs::Smallestposval<T>()),  r_t(true));
+  STF_ULP_EQUAL(is_normal(-bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_normal(bs::Half<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_normal(bs::Mone<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_normal(bs::One<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_normal(bs::Quarter<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_normal(bs::Two<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_normal(bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_normal(bs::Smallestposval<T>()),  r_t(true), 0.5);
 #ifndef STF_NO_NORMAL
-  STF_EQUAL(is_normal(bs::Mindenormal<T>()), r_t(false));
-  STF_EQUAL(is_normal(bs::Smallestposval<T>()/bs::Two<T>()), r_t(false));
+  STF_ULP_EQUAL(is_normal(bs::Mindenormal<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_normal(bs::Smallestposval<T>()/bs::Two<T>()), r_t(false), 0.5);
 #endif
 }
 
@@ -137,20 +137,20 @@ STF_CASE_TPL (" is_normal std",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bs::std_(is_normal)(bs::Inf<T>()), r_t(false));
-  STF_EQUAL(bs::std_(is_normal)(bs::Minf<T>()), r_t(false));
-  STF_EQUAL(bs::std_(is_normal)(bs::Nan<T>()), r_t(false));
+  STF_ULP_EQUAL(bs::std_(is_normal)(bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(bs::std_(is_normal)(bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(bs::std_(is_normal)(bs::Nan<T>()), r_t(false), 0.5);
 #endif
-  STF_EQUAL(bs::std_(is_normal)(-bs::Zero<T>()), r_t(false));
-  STF_EQUAL(bs::std_(is_normal)(bs::Half<T>()), r_t(true));
-  STF_EQUAL(bs::std_(is_normal)(bs::Mone<T>()), r_t(true));
-  STF_EQUAL(bs::std_(is_normal)(bs::One<T>()), r_t(true));
-  STF_EQUAL(bs::std_(is_normal)(bs::Quarter<T>()), r_t(true));
-  STF_EQUAL(bs::std_(is_normal)(bs::Two<T>()), r_t(true));
-  STF_EQUAL(bs::std_(is_normal)(bs::Zero<T>()), r_t(false));
-  STF_EQUAL(bs::std_(is_normal)(bs::Smallestposval<T>()),  r_t(true));
+  STF_ULP_EQUAL(bs::std_(is_normal)(-bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(bs::std_(is_normal)(bs::Half<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(bs::std_(is_normal)(bs::Mone<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(bs::std_(is_normal)(bs::One<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(bs::std_(is_normal)(bs::Quarter<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(bs::std_(is_normal)(bs::Two<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(bs::std_(is_normal)(bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(bs::std_(is_normal)(bs::Smallestposval<T>()),  r_t(true), 0.5);
 #ifndef STF_NO_NORMAL
-  STF_EQUAL(bs::std_(is_normal)(bs::Mindenormal<T>()), r_t(false));
-  STF_EQUAL(bs::std_(is_normal)(bs::Smallestposval<T>()/bs::Two<T>()), r_t(false));
+  STF_ULP_EQUAL(bs::std_(is_normal)(bs::Mindenormal<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(bs::std_(is_normal)(bs::Smallestposval<T>()/bs::Two<T>()), r_t(false), 0.5);
 #endif
 }

--- a/test/function/scalar/is_not_denormal.cpp
+++ b/test/function/scalar/is_not_denormal.cpp
@@ -36,21 +36,21 @@ STF_CASE_TPL (" is_not_denormal",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_not_denormal(bs::Inf<T>()), r_t(true));
-  STF_EQUAL(is_not_denormal(bs::Minf<T>()), r_t(true));
-  STF_EQUAL(is_not_denormal(bs::Nan<T>()), r_t(true));
+  STF_ULP_EQUAL(is_not_denormal(bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_denormal(bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_denormal(bs::Nan<T>()), r_t(true), 0.5);
 #endif
-  STF_EQUAL(is_not_denormal(-bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_not_denormal(bs::Half<T>()), r_t(true));
-  STF_EQUAL(is_not_denormal(bs::Mone<T>()), r_t(true));
-  STF_EQUAL(is_not_denormal(bs::One<T>()), r_t(true));
-  STF_EQUAL(is_not_denormal(bs::Quarter<T>()), r_t(true));
-  STF_EQUAL(is_not_denormal(bs::Two<T>()), r_t(true));
-  STF_EQUAL(is_not_denormal(bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_not_denormal(bs::Smallestposval<T>()),  r_t(true));
+  STF_ULP_EQUAL(is_not_denormal(-bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_denormal(bs::Half<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_denormal(bs::Mone<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_denormal(bs::One<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_denormal(bs::Quarter<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_denormal(bs::Two<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_denormal(bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_denormal(bs::Smallestposval<T>()),  r_t(true), 0.5);
 #ifndef STF_NO_DENORMAL
-  STF_EQUAL(is_not_denormal(bs::Mindenormal<T>()), r_t(false));
-  STF_EQUAL(is_not_denormal(bs::Smallestposval<T>()/bs::Two<T>()), r_t(false));
+  STF_ULP_EQUAL(is_not_denormal(bs::Mindenormal<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_denormal(bs::Smallestposval<T>()/bs::Two<T>()), r_t(false), 0.5);
 #endif
 }
 

--- a/test/function/scalar/is_not_equal.cpp
+++ b/test/function/scalar/is_not_equal.cpp
@@ -45,11 +45,11 @@ STF_CASE_TPL (" is_not_equal real",  STF_IEEE_TYPES)
  STF_TYPE_IS(r_t, bs::logical<T>);
 
   // specific values tests
-  STF_EQUAL(is_not_equal(bs::Inf<T>(), bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_not_equal(bs::Minf<T>(), bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_not_equal(bs::Nan<T>(), bs::Nan<T>()), r_t(true));
-  STF_EQUAL(is_not_equal(bs::One<T>(),bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_not_equal(bs::Zero<T>(), bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(is_not_equal(bs::Inf<T>(), bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_equal(bs::Minf<T>(), bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_equal(bs::Nan<T>(), bs::Nan<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_equal(bs::One<T>(),bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_equal(bs::Zero<T>(), bs::Zero<T>()), r_t(false), 0.5);
 } // end of test for floating_
 
 STF_CASE ( "is_not_equal bool")
@@ -65,10 +65,10 @@ STF_CASE ( "is_not_equal bool")
 
 
   // specific values tests
-  STF_EQUAL(is_not_equal(true, false), true);
-  STF_EQUAL(is_not_equal(false, true), true);
-  STF_EQUAL(is_not_equal(true, true), false);
-  STF_EQUAL(is_not_equal(false, false), false);
+  STF_ULP_EQUAL(is_not_equal(true, false), true, 0.5);
+  STF_ULP_EQUAL(is_not_equal(false, true), true, 0.5);
+  STF_ULP_EQUAL(is_not_equal(true, true), false, 0.5);
+  STF_ULP_EQUAL(is_not_equal(false, false), false, 0.5);
 }
 
 

--- a/test/function/scalar/is_not_equal_with_equal_nans.cpp
+++ b/test/function/scalar/is_not_equal_with_equal_nans.cpp
@@ -43,11 +43,11 @@ STF_CASE_TPL (" is_not_equal_with_equal_nans real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t,bs::logical<T>);
 
   // specific values tests
-  STF_EQUAL(is_not_equal_with_equal_nans(bs::Inf<T>(), bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_not_equal_with_equal_nans(bs::Minf<T>(), bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_not_equal_with_equal_nans(bs::Nan<T>(), bs::Nan<T>()), r_t(false));
-  STF_EQUAL(is_not_equal_with_equal_nans(bs::One<T>(),bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_not_equal_with_equal_nans(bs::Zero<T>(), bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(is_not_equal_with_equal_nans(bs::Inf<T>(), bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_equal_with_equal_nans(bs::Minf<T>(), bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_equal_with_equal_nans(bs::Nan<T>(), bs::Nan<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_equal_with_equal_nans(bs::One<T>(),bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_equal_with_equal_nans(bs::Zero<T>(), bs::Zero<T>()), r_t(false), 0.5);
 } // end of test for floating_
 
 
@@ -63,10 +63,10 @@ STF_CASE ( "is_not_equal_with_equal_nans bool")
   STF_EXPR_IS(is_not_equal_with_equal_nans(bool(), bool()), bool);
 
   // specific values tests
-  STF_EQUAL(is_not_equal_with_equal_nans(true, false), true);
-  STF_EQUAL(is_not_equal_with_equal_nans(false, true), true);
-  STF_EQUAL(is_not_equal_with_equal_nans(true, true), false);
-  STF_EQUAL(is_not_equal_with_equal_nans(false, false), false);
+  STF_ULP_EQUAL(is_not_equal_with_equal_nans(true, false), true, 0.5);
+  STF_ULP_EQUAL(is_not_equal_with_equal_nans(false, true), true, 0.5);
+  STF_ULP_EQUAL(is_not_equal_with_equal_nans(true, true), false, 0.5);
+  STF_ULP_EQUAL(is_not_equal_with_equal_nans(false, false), false, 0.5);
 }
 
 

--- a/test/function/scalar/is_not_greater.cpp
+++ b/test/function/scalar/is_not_greater.cpp
@@ -45,11 +45,11 @@ STF_CASE_TPL (" is_not_greater real",  STF_IEEE_TYPES)
  STF_TYPE_IS(r_t, bs::logical<T>);
 
   // specific values tests
-  STF_EQUAL(is_not_greater(bs::Inf<T>(), bs::Inf<T>()), r_t(true));
-  STF_EQUAL(is_not_greater(bs::Minf<T>(), bs::Minf<T>()), r_t(true));
-  STF_EQUAL(is_not_greater(bs::Nan<T>(), bs::Nan<T>()), r_t(true));
-  STF_EQUAL(is_not_greater(bs::One<T>(),bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_not_greater(bs::Zero<T>(), bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_not_greater(bs::Inf<T>(), bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_greater(bs::Minf<T>(), bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_greater(bs::Nan<T>(), bs::Nan<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_greater(bs::One<T>(),bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_greater(bs::Zero<T>(), bs::Zero<T>()), r_t(true), 0.5);
 } // end of test for floating_
 
 STF_CASE ( "is_not_greater bool")
@@ -65,8 +65,8 @@ STF_CASE ( "is_not_greater bool")
 
 
   // specific values tests
-  STF_EQUAL(is_not_greater(true, false), false);
-  STF_EQUAL(is_not_greater(false, true), true);
-  STF_EQUAL(is_not_greater(true, true), true);
-  STF_EQUAL(is_not_greater(false, false), true);
+  STF_ULP_EQUAL(is_not_greater(true, false), false, 0.5);
+  STF_ULP_EQUAL(is_not_greater(false, true), true, 0.5);
+  STF_ULP_EQUAL(is_not_greater(true, true), true, 0.5);
+  STF_ULP_EQUAL(is_not_greater(false, false), true, 0.5);
 }

--- a/test/function/scalar/is_not_greater_equal.cpp
+++ b/test/function/scalar/is_not_greater_equal.cpp
@@ -45,11 +45,11 @@ STF_CASE_TPL (" is_not_greater_equal real",  STF_IEEE_TYPES)
  STF_TYPE_IS(r_t, bs::logical<T>);
 
   // specific values tests
-  STF_EQUAL(is_not_greater_equal(bs::Inf<T>(), bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_not_greater_equal(bs::Minf<T>(), bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_not_greater_equal(bs::Nan<T>(), bs::Nan<T>()), r_t(true));
-  STF_EQUAL(is_not_greater_equal(bs::One<T>(),bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_not_greater_equal(bs::Zero<T>(), bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(is_not_greater_equal(bs::Inf<T>(), bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_greater_equal(bs::Minf<T>(), bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_greater_equal(bs::Nan<T>(), bs::Nan<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_greater_equal(bs::One<T>(),bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_greater_equal(bs::Zero<T>(), bs::Zero<T>()), r_t(false), 0.5);
 } // end of test for floating_
 
 STF_CASE ( "is_not_greater_equal bool")
@@ -65,8 +65,8 @@ STF_CASE ( "is_not_greater_equal bool")
 
 
   // specific values tests
-  STF_EQUAL(is_not_greater_equal(true, false), false);
-  STF_EQUAL(is_not_greater_equal(false, true), true);
-  STF_EQUAL(is_not_greater_equal(true, true), false);
-  STF_EQUAL(is_not_greater_equal(false, false), false);
+  STF_ULP_EQUAL(is_not_greater_equal(true, false), false, 0.5);
+  STF_ULP_EQUAL(is_not_greater_equal(false, true), true, 0.5);
+  STF_ULP_EQUAL(is_not_greater_equal(true, true), false, 0.5);
+  STF_ULP_EQUAL(is_not_greater_equal(false, false), false, 0.5);
 }

--- a/test/function/scalar/is_not_imag.cpp
+++ b/test/function/scalar/is_not_imag.cpp
@@ -33,17 +33,17 @@ STF_CASE_TPL (" is_not_imag real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_not_imag(bs::Inf<T>()), r_t(true));
-  STF_EQUAL(is_not_imag(bs::Minf<T>()), r_t(true));
-  STF_EQUAL(is_not_imag(bs::Nan<T>()), r_t(true));
+  STF_ULP_EQUAL(is_not_imag(bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_imag(bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_imag(bs::Nan<T>()), r_t(true), 0.5);
 #endif
-  STF_EQUAL(is_not_imag(-bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_not_imag(bs::Half<T>()), r_t(true));
-  STF_EQUAL(is_not_imag(bs::Mone<T>()), r_t(true));
-  STF_EQUAL(is_not_imag(bs::One<T>()), r_t(true));
-  STF_EQUAL(is_not_imag(bs::Quarter<T>()), r_t(true));
-  STF_EQUAL(is_not_imag(bs::Two<T>()), r_t(true));
-  STF_EQUAL(is_not_imag(bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(is_not_imag(-bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_imag(bs::Half<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_imag(bs::Mone<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_imag(bs::One<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_imag(bs::Quarter<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_imag(bs::Two<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_imag(bs::Zero<T>()), r_t(false), 0.5);
 }
 
 STF_CASE_TPL (" is_not_imag signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_not_infinite.cpp
+++ b/test/function/scalar/is_not_infinite.cpp
@@ -33,17 +33,17 @@ STF_CASE_TPL (" is_not_infinite real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_not_infinite(bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_not_infinite(bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_not_infinite(bs::Nan<T>()), r_t(true));
+  STF_ULP_EQUAL(is_not_infinite(bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_infinite(bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_infinite(bs::Nan<T>()), r_t(true), 0.5);
 #endif
-  STF_EQUAL(is_not_infinite(-bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_not_infinite(bs::Half<T>()), r_t(true));
-  STF_EQUAL(is_not_infinite(bs::Mone<T>()), r_t(true));
-  STF_EQUAL(is_not_infinite(bs::One<T>()), r_t(true));
-  STF_EQUAL(is_not_infinite(bs::Quarter<T>()), r_t(true));
-  STF_EQUAL(is_not_infinite(bs::Two<T>()), r_t(true));
-  STF_EQUAL(is_not_infinite(bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_not_infinite(-bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_infinite(bs::Half<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_infinite(bs::Mone<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_infinite(bs::One<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_infinite(bs::Quarter<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_infinite(bs::Two<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_infinite(bs::Zero<T>()), r_t(true), 0.5);
 }
 
 STF_CASE_TPL (" is_not_infinite signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_not_less.cpp
+++ b/test/function/scalar/is_not_less.cpp
@@ -46,11 +46,11 @@ STF_CASE_TPL (" is_not_less real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, bs::logical<T>);
 
   // specific values tests
-  STF_EQUAL(is_not_less(bs::Inf<T>(), bs::Inf<T>()), r_t(true));
-  STF_EQUAL(is_not_less(bs::Minf<T>(), bs::Minf<T>()), r_t(true));
-  STF_EQUAL(is_not_less(bs::Nan<T>(), bs::Nan<T>()), r_t(true));
-  STF_EQUAL(is_not_less(bs::One<T>(),bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_not_less(bs::Zero<T>(), bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_not_less(bs::Inf<T>(), bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_less(bs::Minf<T>(), bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_less(bs::Nan<T>(), bs::Nan<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_less(bs::One<T>(),bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_less(bs::Zero<T>(), bs::Zero<T>()), r_t(true), 0.5);
 } // end of test for floating_
 
 STF_CASE ( "is_not_less bool")
@@ -64,8 +64,8 @@ STF_CASE ( "is_not_less bool")
   STF_TYPE_IS(r_t, bool);
 
   // specific values tests
-  STF_EQUAL(is_not_less(true, false), true);
-  STF_EQUAL(is_not_less(false, true), false);
-  STF_EQUAL(is_not_less(true, true), true);
-  STF_EQUAL(is_not_less(false, false), true);
+  STF_ULP_EQUAL(is_not_less(true, false), true, 0.5);
+  STF_ULP_EQUAL(is_not_less(false, true), false, 0.5);
+  STF_ULP_EQUAL(is_not_less(true, true), true, 0.5);
+  STF_ULP_EQUAL(is_not_less(false, false), true, 0.5);
 }

--- a/test/function/scalar/is_not_less_equal.cpp
+++ b/test/function/scalar/is_not_less_equal.cpp
@@ -46,11 +46,11 @@ STF_CASE_TPL (" is_not_less_equal real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, bs::logical<T>);
 
   // specific values tests
-  STF_EQUAL(is_not_less_equal(bs::Inf<T>(), bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_not_less_equal(bs::Minf<T>(), bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_not_less_equal(bs::Nan<T>(), bs::Nan<T>()), r_t(true));
-  STF_EQUAL(is_not_less_equal(bs::One<T>(),bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_not_less_equal(bs::Zero<T>(), bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(is_not_less_equal(bs::Inf<T>(), bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_less_equal(bs::Minf<T>(), bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_less_equal(bs::Nan<T>(), bs::Nan<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_less_equal(bs::One<T>(),bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_less_equal(bs::Zero<T>(), bs::Zero<T>()), r_t(false), 0.5);
 } // end of test for floating_
 
 STF_CASE ( "is_not_less_equal bool")
@@ -64,8 +64,8 @@ STF_CASE ( "is_not_less_equal bool")
   STF_TYPE_IS(r_t, bool);
 
   // specific values tests
-  STF_EQUAL(is_not_less_equal(true, false), true);
-  STF_EQUAL(is_not_less_equal(false, true), false);
-  STF_EQUAL(is_not_less_equal(true, true), false);
-  STF_EQUAL(is_not_less_equal(false, false), false);
+  STF_ULP_EQUAL(is_not_less_equal(true, false), true, 0.5);
+  STF_ULP_EQUAL(is_not_less_equal(false, true), false, 0.5);
+  STF_ULP_EQUAL(is_not_less_equal(true, true), false, 0.5);
+  STF_ULP_EQUAL(is_not_less_equal(false, false), false, 0.5);
 }

--- a/test/function/scalar/is_not_nan.cpp
+++ b/test/function/scalar/is_not_nan.cpp
@@ -34,17 +34,17 @@ STF_CASE_TPL (" is_not_nan  _real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_not_nan(bs::Inf<T>()), r_t(true));
-  STF_EQUAL(is_not_nan(bs::Minf<T>()), r_t(true));
-  STF_EQUAL(is_not_nan(bs::Nan<T>()), r_t(false));
+  STF_ULP_EQUAL(is_not_nan(bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_nan(bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_nan(bs::Nan<T>()), r_t(false), 0.5);
 #endif
-  STF_EQUAL(is_not_nan(bs::Mzero<T>()), r_t(true));
-  STF_EQUAL(is_not_nan(bs::Half<T>()), r_t(true));
-  STF_EQUAL(is_not_nan(bs::Mone<T>()), r_t(true));
-  STF_EQUAL(is_not_nan(bs::One<T>()), r_t(true));
-  STF_EQUAL(is_not_nan(bs::Quarter<T>()), r_t(true));
-  STF_EQUAL(is_not_nan(bs::Two<T>()), r_t(true));
-  STF_EQUAL(is_not_nan(bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_not_nan(bs::Mzero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_nan(bs::Half<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_nan(bs::Mone<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_nan(bs::One<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_nan(bs::Quarter<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_nan(bs::Two<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_not_nan(bs::Zero<T>()), r_t(true), 0.5);
 }
 
 STF_CASE_TPL (" is_not_nan _signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_not_real.cpp
+++ b/test/function/scalar/is_not_real.cpp
@@ -33,17 +33,17 @@ STF_CASE_TPL (" is_not_real real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_not_real(bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_not_real(bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_not_real(bs::Nan<T>()), r_t(false));
+  STF_ULP_EQUAL(is_not_real(bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_real(bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_real(bs::Nan<T>()), r_t(false), 0.5);
 #endif
-  STF_EQUAL(is_not_real(-bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_not_real(bs::Half<T>()), r_t(false));
-  STF_EQUAL(is_not_real(bs::Mone<T>()), r_t(false));
-  STF_EQUAL(is_not_real(bs::One<T>()), r_t(false));
-  STF_EQUAL(is_not_real(bs::Quarter<T>()), r_t(false));
-  STF_EQUAL(is_not_real(bs::Two<T>()), r_t(false));
-  STF_EQUAL(is_not_real(bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(is_not_real(-bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_real(bs::Half<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_real(bs::Mone<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_real(bs::One<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_real(bs::Quarter<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_real(bs::Two<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_not_real(bs::Zero<T>()), r_t(false), 0.5);
 }
 
 STF_CASE_TPL (" is_not_real signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_odd.cpp
+++ b/test/function/scalar/is_odd.cpp
@@ -32,17 +32,17 @@ STF_CASE_TPL (" is_odd real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_odd(bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_odd(bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_odd(bs::Nan<T>()), r_t(false));
+  STF_ULP_EQUAL(is_odd(bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_odd(bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_odd(bs::Nan<T>()), r_t(false), 0.5);
 #endif
-  STF_EQUAL(is_odd(-bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_odd(bs::Half<T>()), r_t(false));
-  STF_EQUAL(is_odd(bs::Mone<T>()), r_t(true));
-  STF_EQUAL(is_odd(bs::One<T>()), r_t(true));
-  STF_EQUAL(is_odd(bs::Quarter<T>()), r_t(false));
-  STF_EQUAL(is_odd(bs::Two<T>()), r_t(false));
-  STF_EQUAL(is_odd(bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(is_odd(-bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_odd(bs::Half<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_odd(bs::Mone<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_odd(bs::One<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_odd(bs::Quarter<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_odd(bs::Two<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_odd(bs::Zero<T>()), r_t(false), 0.5);
 }
 
 STF_CASE_TPL (" is_odd signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_ord.cpp
+++ b/test/function/scalar/is_ord.cpp
@@ -32,17 +32,17 @@ STF_CASE_TPL (" is_ord real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_ord(bs::Inf<T>(), bs::Inf<T>()), r_t(true));
-  STF_EQUAL(is_ord(bs::Minf<T>(), bs::Minf<T>()), r_t(true));
-  STF_EQUAL(is_ord(bs::Nan<T>(), bs::Nan<T>()), r_t(false));
+  STF_ULP_EQUAL(is_ord(bs::Inf<T>(), bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_ord(bs::Minf<T>(), bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_ord(bs::Nan<T>(), bs::Nan<T>()), r_t(false), 0.5);
 #endif
-  STF_EQUAL(is_ord(-bs::Zero<T>(), -bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_ord(bs::Half<T>(), bs::Half<T>()), r_t(true));
-  STF_EQUAL(is_ord(bs::Mone<T>(), bs::Mone<T>()), r_t(true));
-  STF_EQUAL(is_ord(bs::One<T>(), bs::One<T>()), r_t(true));
-  STF_EQUAL(is_ord(bs::Quarter<T>(), bs::Quarter<T>()), r_t(true));
-  STF_EQUAL(is_ord(bs::Two<T>(), bs::Two<T>()), r_t(true));
-  STF_EQUAL(is_ord(bs::Zero<T>(), bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_ord(-bs::Zero<T>(), -bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_ord(bs::Half<T>(), bs::Half<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_ord(bs::Mone<T>(), bs::Mone<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_ord(bs::One<T>(), bs::One<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_ord(bs::Quarter<T>(), bs::Quarter<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_ord(bs::Two<T>(), bs::Two<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_ord(bs::Zero<T>(), bs::Zero<T>()), r_t(true), 0.5);
 }
 
 STF_CASE_TPL (" is_ord signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_positive.cpp
+++ b/test/function/scalar/is_positive.cpp
@@ -33,17 +33,17 @@ STF_CASE_TPL (" is_positive real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_positive(bs::Inf<T>()), r_t(true));
-  STF_EQUAL(is_positive(bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_positive(bs::Nan<T>()), r_t(false));
+  STF_ULP_EQUAL(is_positive(bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_positive(bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_positive(bs::Nan<T>()), r_t(false), 0.5);
 #endif
-  STF_EQUAL(is_positive(-bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_positive(bs::Half<T>()), r_t(true));
-  STF_EQUAL(is_positive(bs::Mone<T>()), r_t(false));
-  STF_EQUAL(is_positive(bs::One<T>()), r_t(true));
-  STF_EQUAL(is_positive(bs::Quarter<T>()), r_t(true));
-  STF_EQUAL(is_positive(bs::Two<T>()), r_t(true));
-  STF_EQUAL(is_positive(bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_positive(-bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_positive(bs::Half<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_positive(bs::Mone<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_positive(bs::One<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_positive(bs::Quarter<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_positive(bs::Two<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_positive(bs::Zero<T>()), r_t(true), 0.5);
 }
 
 STF_CASE_TPL (" is_positive signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_real.cpp
+++ b/test/function/scalar/is_real.cpp
@@ -33,17 +33,17 @@ STF_CASE_TPL (" is_real real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_real(bs::Inf<T>()), r_t(true));
-  STF_EQUAL(is_real(bs::Minf<T>()), r_t(true));
-  STF_EQUAL(is_real(bs::Nan<T>()), r_t(true));
+  STF_ULP_EQUAL(is_real(bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_real(bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_real(bs::Nan<T>()), r_t(true), 0.5);
 #endif
-  STF_EQUAL(is_real(-bs::Zero<T>()), r_t(true));
-  STF_EQUAL(is_real(bs::Half<T>()), r_t(true));
-  STF_EQUAL(is_real(bs::Mone<T>()), r_t(true));
-  STF_EQUAL(is_real(bs::One<T>()), r_t(true));
-  STF_EQUAL(is_real(bs::Quarter<T>()), r_t(true));
-  STF_EQUAL(is_real(bs::Two<T>()), r_t(true));
-  STF_EQUAL(is_real(bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_real(-bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_real(bs::Half<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_real(bs::Mone<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_real(bs::One<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_real(bs::Quarter<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_real(bs::Two<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_real(bs::Zero<T>()), r_t(true), 0.5);
 }
 
 STF_CASE_TPL (" is_real signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_simd_logical.cpp
+++ b/test/function/scalar/is_simd_logical.cpp
@@ -26,13 +26,13 @@ STF_CASE_TPL (" is_simd_logical real",  STF_IEEE_TYPES)
   using r_t = decltype(is_simd_logical(T()));
 
   // specific values tests
-  STF_EQUAL(is_simd_logical(-bs::Nan<T>()), r_t(false));
-  STF_EQUAL(is_simd_logical(bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_simd_logical(bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_simd_logical(bs::Mone<T>()), r_t(false));
-  STF_EQUAL(is_simd_logical(bs::Nan<T>()), r_t(true));
-  STF_EQUAL(is_simd_logical(bs::One<T>()), r_t(false));
-  STF_EQUAL(is_simd_logical(bs::Zero<T>()), r_t(true));
+  STF_ULP_EQUAL(is_simd_logical(-bs::Nan<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_simd_logical(bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_simd_logical(bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_simd_logical(bs::Mone<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_simd_logical(bs::Nan<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(is_simd_logical(bs::One<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_simd_logical(bs::Zero<T>()), r_t(true), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" is_simd_logical integer",   STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/is_unord.cpp
+++ b/test/function/scalar/is_unord.cpp
@@ -32,17 +32,17 @@ STF_CASE_TPL (" is_unord real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(is_unord(bs::Inf<T>(), bs::Inf<T>()), r_t(false));
-  STF_EQUAL(is_unord(bs::Minf<T>(), bs::Minf<T>()), r_t(false));
-  STF_EQUAL(is_unord(bs::Nan<T>(), bs::Nan<T>()), r_t(true));
+  STF_ULP_EQUAL(is_unord(bs::Inf<T>(), bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_unord(bs::Minf<T>(), bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_unord(bs::Nan<T>(), bs::Nan<T>()), r_t(true), 0.5);
 #endif
-  STF_EQUAL(is_unord(-bs::Zero<T>(), -bs::Zero<T>()), r_t(false));
-  STF_EQUAL(is_unord(bs::Half<T>(), bs::Half<T>()), r_t(false));
-  STF_EQUAL(is_unord(bs::Mone<T>(), bs::Mone<T>()), r_t(false));
-  STF_EQUAL(is_unord(bs::One<T>(), bs::One<T>()), r_t(false));
-  STF_EQUAL(is_unord(bs::Quarter<T>(), bs::Quarter<T>()), r_t(false));
-  STF_EQUAL(is_unord(bs::Two<T>(), bs::Two<T>()), r_t(false));
-  STF_EQUAL(is_unord(bs::Zero<T>(), bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(is_unord(-bs::Zero<T>(), -bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_unord(bs::Half<T>(), bs::Half<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_unord(bs::Mone<T>(), bs::Mone<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_unord(bs::One<T>(), bs::One<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_unord(bs::Quarter<T>(), bs::Quarter<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_unord(bs::Two<T>(), bs::Two<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(is_unord(bs::Zero<T>(), bs::Zero<T>()), r_t(false), 0.5);
 }
 
 STF_CASE_TPL (" is_unord signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/ldexp.cpp
+++ b/test/function/scalar/ldexp.cpp
@@ -41,24 +41,24 @@ STF_CASE_TPL("ldexp", STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, T);
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(ldexp(bs::Inf<T>(),  2), bs::Inf<r_t>());
-  STF_EQUAL(ldexp(bs::Minf<T>(), 2), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(ldexp(bs::Nan<T>(),  2), bs::Nan<r_t>());
+  STF_ULP_EQUAL(ldexp(bs::Inf<T>(),  2), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(ldexp(bs::Minf<T>(), 2), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(ldexp(bs::Nan<T>(),  2), bs::Nan<r_t>(), 0.5);
 #endif
 
-  STF_EQUAL(ldexp(bs::Mone<T>(), 2), -bs::Four<r_t>());
-  STF_EQUAL(ldexp(bs::One<T>(),  2), bs::Four<r_t>());
-  STF_EQUAL(ldexp(bs::Zero<T>(), 2), bs::Zero<r_t>());
-  STF_EQUAL(ldexp(bs::One <T>(), bs::Minexponent<T>()), bs::Smallestposval<r_t>());
-  STF_EQUAL(ldexp(bs::One<T>()-bs::Halfeps<T>(),  bs::Maxexponent<T>()), bs::Valmax<T>()/2);
-  STF_EQUAL(ldexp(bs::One<T>()-bs::Halfeps<T>(),  bs::Limitexponent<T>()), bs::Valmax<T>());
+  STF_ULP_EQUAL(ldexp(bs::Mone<T>(), 2), -bs::Four<r_t>(), 0.5);
+  STF_ULP_EQUAL(ldexp(bs::One<T>(),  2), bs::Four<r_t>(), 0.5);
+  STF_ULP_EQUAL(ldexp(bs::Zero<T>(), 2), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(ldexp(bs::One <T>(), bs::Minexponent<T>()), bs::Smallestposval<r_t>(), 0.5);
+  STF_ULP_EQUAL(ldexp(bs::One<T>()-bs::Halfeps<T>(),  bs::Maxexponent<T>()), bs::Valmax<T>()/2, 0.5);
+  STF_ULP_EQUAL(ldexp(bs::One<T>()-bs::Halfeps<T>(),  bs::Limitexponent<T>()), bs::Valmax<T>(), 0.5);
 
 #ifndef BOOST_SIMD_NO_DENORMALS
   using bs::dec;
-  STF_EQUAL(ldexp(bs::One <T>(), dec(bs::Minexponent<T>())), bs::Smallestposval<T>()/2);
-  STF_EQUAL(ldexp(bs::Two <T>(), dec(bs::Minexponent<T>())), bs::Smallestposval<T>());
-  STF_EQUAL(ldexp(bs::Two <T>(), dec(bs::Minexponent<T>()-1)), bs::Smallestposval<T>()/2);
-  STF_EQUAL(ldexp(bs::One <T>(), bs::Minexponent<T>()-5), bs::Smallestposval<T>()/32);
+  STF_ULP_EQUAL(ldexp(bs::One <T>(), dec(bs::Minexponent<T>())), bs::Smallestposval<T>()/2, 0.5);
+  STF_ULP_EQUAL(ldexp(bs::Two <T>(), dec(bs::Minexponent<T>())), bs::Smallestposval<T>(), 0.5);
+  STF_ULP_EQUAL(ldexp(bs::Two <T>(), dec(bs::Minexponent<T>()-1)), bs::Smallestposval<T>()/2, 0.5);
+  STF_ULP_EQUAL(ldexp(bs::One <T>(), bs::Minexponent<T>()-5), bs::Smallestposval<T>()/32, 0.5);
 #endif
 }
 
@@ -92,15 +92,15 @@ STF_CASE_TPL("ldexp fast", STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, T);
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bs::fast_(ldexp)(bs::Inf<T>(),  2), bs::Inf<r_t>());
-  STF_EQUAL(bs::fast_(ldexp)(bs::Minf<T>(), 2), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(bs::fast_(ldexp)(bs::Nan<T>(),  2), bs::Nan<r_t>());
+  STF_ULP_EQUAL(bs::fast_(ldexp)(bs::Inf<T>(),  2), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(ldexp)(bs::Minf<T>(), 2), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(ldexp)(bs::Nan<T>(),  2), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(bs::fast_(ldexp)(bs::Mone<T>(), 2), -bs::Four<r_t>());
-  STF_EQUAL(bs::fast_(ldexp)(bs::One<T>(),  2), bs::Four<r_t>());
-  STF_EQUAL(bs::fast_(ldexp)(bs::Zero<T>(), 2), bs::Zero<r_t>());
-  STF_EQUAL(bs::fast_(ldexp)(bs::One <T>(), bs::Minexponent<T>()), bs::Smallestposval<r_t>());
-  STF_EQUAL(bs::fast_(ldexp)(bs::One<T>()-bs::Halfeps<T>(),  bs::Maxexponent<T>()), bs::Valmax<T>()/2);
+  STF_ULP_EQUAL(bs::fast_(ldexp)(bs::Mone<T>(), 2), -bs::Four<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(ldexp)(bs::One<T>(),  2), bs::Four<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(ldexp)(bs::Zero<T>(), 2), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(ldexp)(bs::One <T>(), bs::Minexponent<T>()), bs::Smallestposval<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(ldexp)(bs::One<T>()-bs::Halfeps<T>(),  bs::Maxexponent<T>()), bs::Valmax<T>()/2, 0.5);
 }
 
 STF_CASE_TPL("ldexp std", STF_IEEE_TYPES)
@@ -116,21 +116,21 @@ STF_CASE_TPL("ldexp std", STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, T);
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bs::std_(ldexp)(bs::Inf<T>(),  2), bs::Inf<r_t>());
-  STF_EQUAL(bs::std_(ldexp)(bs::Minf<T>(), 2), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(bs::std_(ldexp)(bs::Nan<T>(),  2), bs::Nan<r_t>());
+  STF_ULP_EQUAL(bs::std_(ldexp)(bs::Inf<T>(),  2), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(ldexp)(bs::Minf<T>(), 2), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(ldexp)(bs::Nan<T>(),  2), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(bs::std_(ldexp)(bs::Mone<T>(), 2), -bs::Four<r_t>());
-  STF_EQUAL(bs::std_(ldexp)(bs::One<T>(),  2), bs::Four<r_t>());
-  STF_EQUAL(bs::std_(ldexp)(bs::Zero<T>(), 2), bs::Zero<r_t>());
-  STF_EQUAL(bs::std_(ldexp)(bs::One <T>(), bs::Minexponent<T>()), bs::Smallestposval<r_t>());
-  STF_EQUAL(bs::std_(ldexp)(bs::One<T>()-bs::Halfeps<T>(),  bs::Maxexponent<T>()), bs::Valmax<T>()/2);
-  STF_EQUAL(bs::std_(ldexp)(bs::One<T>()-bs::Halfeps<T>(),  bs::Limitexponent<T>()), bs::Valmax<T>());
+  STF_ULP_EQUAL(bs::std_(ldexp)(bs::Mone<T>(), 2), -bs::Four<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(ldexp)(bs::One<T>(),  2), bs::Four<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(ldexp)(bs::Zero<T>(), 2), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(ldexp)(bs::One <T>(), bs::Minexponent<T>()), bs::Smallestposval<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(ldexp)(bs::One<T>()-bs::Halfeps<T>(),  bs::Maxexponent<T>()), bs::Valmax<T>()/2, 0.5);
+  STF_ULP_EQUAL(bs::std_(ldexp)(bs::One<T>()-bs::Halfeps<T>(),  bs::Limitexponent<T>()), bs::Valmax<T>(), 0.5);
 #ifndef BOOST_SIMD_NO_DENORMALS
   using bs::dec;
-  STF_EQUAL(bs::std_(ldexp)(bs::One <T>(), dec(bs::Minexponent<T>())), bs::Smallestposval<T>()/2);
-  STF_EQUAL(bs::std_(ldexp)(bs::Two <T>(), dec(bs::Minexponent<T>())), bs::Smallestposval<T>());
-  STF_EQUAL(bs::std_(ldexp)(bs::Two <T>(), dec(bs::Minexponent<T>()-1)), bs::Smallestposval<T>()/2);
-  STF_EQUAL(bs::std_(ldexp)(bs::One <T>(), bs::Minexponent<T>()-5), bs::Smallestposval<T>()/32);
+  STF_ULP_EQUAL(bs::std_(ldexp)(bs::One <T>(), dec(bs::Minexponent<T>())), bs::Smallestposval<T>()/2, 0.5);
+  STF_ULP_EQUAL(bs::std_(ldexp)(bs::Two <T>(), dec(bs::Minexponent<T>())), bs::Smallestposval<T>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(ldexp)(bs::Two <T>(), dec(bs::Minexponent<T>()-1)), bs::Smallestposval<T>()/2, 0.5);
+  STF_ULP_EQUAL(bs::std_(ldexp)(bs::One <T>(), bs::Minexponent<T>()-5), bs::Smallestposval<T>()/32, 0.5);
 #endif
 }

--- a/test/function/scalar/logical_and.cpp
+++ b/test/function/scalar/logical_and.cpp
@@ -47,11 +47,11 @@ STF_CASE_TPL (" logical_and real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, bs::logical<T>);
 
   // specific values tests
-  STF_EQUAL(logical_and(bs::Inf<T>(), bs::Inf<T>()), r_t(true));
-  STF_EQUAL(logical_and(bs::Minf<T>(), bs::Minf<T>()), r_t(true));
-  STF_EQUAL(logical_and(bs::Nan<T>(), bs::Nan<T>()), r_t(true));
-  STF_EQUAL(logical_and(bs::One<T>(),bs::Zero<T>()), r_t(false));
-  STF_EQUAL(logical_and(bs::Zero<T>(), bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(logical_and(bs::Inf<T>(), bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_and(bs::Minf<T>(), bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_and(bs::Nan<T>(), bs::Nan<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_and(bs::One<T>(),bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_and(bs::Zero<T>(), bs::Zero<T>()), r_t(false), 0.5);
 } // end of test for floating_
 
 STF_CASE ( "logical_and bool")
@@ -65,10 +65,10 @@ STF_CASE ( "logical_and bool")
   STF_TYPE_IS(r_t, bool);
 
   // specific values tests
-  STF_EQUAL(logical_and(true, false), false);
-  STF_EQUAL(logical_and(false, true), false);
-  STF_EQUAL(logical_and(true, true), true);
-  STF_EQUAL(logical_and(false, false), false);
+  STF_ULP_EQUAL(logical_and(true, false), false, 0.5);
+  STF_ULP_EQUAL(logical_and(false, true), false, 0.5);
+  STF_ULP_EQUAL(logical_and(true, true), true, 0.5);
+  STF_ULP_EQUAL(logical_and(false, false), false, 0.5);
 }
 
 STF_CASE_TPL ( "logical_and logical", STF_NUMERIC_TYPES)

--- a/test/function/scalar/logical_andnot.cpp
+++ b/test/function/scalar/logical_andnot.cpp
@@ -32,14 +32,14 @@ STF_CASE_TPL (" logical_andnot real",  STF_IEEE_TYPES)
   STF_TYPE_IS( r_t, logical<T>);
 
   // specific values tests
-  STF_EQUAL(logical_andnot(T(0), T(1)), r_t(false));
-  STF_EQUAL(logical_andnot(T(1), T(0)), r_t(true));
-  STF_EQUAL(logical_andnot(bs::Inf<T>(),  T(0)), r_t(true));
-  STF_EQUAL(logical_andnot(bs::Minf<T>(), T(0)), r_t(true));
-  STF_EQUAL(logical_andnot(bs::Nan<T>(),  T(0)), r_t(true));
-  STF_EQUAL(logical_andnot(bs::Zero<T>(), T(1)), r_t(false));
-  STF_EQUAL(logical_andnot(r_t(false), T(1)), r_t(false));
-  STF_EQUAL(logical_andnot(r_t(true), T(1)), r_t(false));
+  STF_ULP_EQUAL(logical_andnot(T(0), T(1)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_andnot(T(1), T(0)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_andnot(bs::Inf<T>(),  T(0)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_andnot(bs::Minf<T>(), T(0)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_andnot(bs::Nan<T>(),  T(0)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_andnot(bs::Zero<T>(), T(1)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_andnot(r_t(false), T(1)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_andnot(r_t(true), T(1)), r_t(false), 0.5);
 
 
 } // end of test for floating_
@@ -77,14 +77,14 @@ STF_CASE_TPL (" logical_andnot mix",  STF_IEEE_TYPES)
   STF_TYPE_IS( r_t, logical<T> );
 
   // specific values tests
-  STF_EQUAL(logical_andnot(T(0), iT(1)), r_t(false));
-  STF_EQUAL(logical_andnot(T(1), iT(0)), r_t(true));
-  STF_EQUAL(logical_andnot(bs::Inf<T>(),  iT(0)), r_t(true));
-  STF_EQUAL(logical_andnot(bs::Minf<T>(), iT(0)), r_t(true));
-  STF_EQUAL(logical_andnot(bs::Nan<T>(),  iT(0)), r_t(true));
-  STF_EQUAL(logical_andnot(bs::Zero<T>(), iT(1)), r_t(false));
-  STF_EQUAL(logical_andnot(r_t(false), iT(1)), r_t(false));
-  STF_EQUAL(logical_andnot(r_t(true), iT(1)), r_t(false));
+  STF_ULP_EQUAL(logical_andnot(T(0), iT(1)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_andnot(T(1), iT(0)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_andnot(bs::Inf<T>(),  iT(0)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_andnot(bs::Minf<T>(), iT(0)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_andnot(bs::Nan<T>(),  iT(0)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_andnot(bs::Zero<T>(), iT(1)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_andnot(r_t(false), iT(1)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_andnot(r_t(true), iT(1)), r_t(false), 0.5);
 
 
 } // end of test for floating_STF_CASE

--- a/test/function/scalar/logical_notand.cpp
+++ b/test/function/scalar/logical_notand.cpp
@@ -33,14 +33,14 @@ STF_CASE_TPL (" logical_notand real",  STF_IEEE_TYPES)
  STF_TYPE_IS( r_t, logical<T> );
 
   // specific values tests
-  STF_EQUAL(logical_notand(T(0), T(1)), r_t(true));
-  STF_EQUAL(logical_notand(T(1), T(0)), r_t(false));
-  STF_EQUAL(logical_notand(bs::Inf<T>(),  T(0)), r_t(false));
-  STF_EQUAL(logical_notand(bs::Minf<T>(), T(0)), r_t(false));
-  STF_EQUAL(logical_notand(bs::Nan<T>(),  T(0)), r_t(false));
-  STF_EQUAL(logical_notand(bs::Zero<T>(), T(1)), r_t(true));
-  STF_EQUAL(logical_notand(r_t(false), T(1)), r_t(true));
-  STF_EQUAL(logical_notand(r_t(true), T(1)), r_t(false));
+  STF_ULP_EQUAL(logical_notand(T(0), T(1)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_notand(T(1), T(0)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_notand(bs::Inf<T>(),  T(0)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_notand(bs::Minf<T>(), T(0)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_notand(bs::Nan<T>(),  T(0)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_notand(bs::Zero<T>(), T(1)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_notand(r_t(false), T(1)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_notand(r_t(true), T(1)), r_t(false), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" logical_notand signed_int",  STF_SIGNED_INTEGRAL_TYPES)
@@ -74,14 +74,14 @@ STF_CASE_TPL (" logical_notandmix",  STF_IEEE_TYPES)
   STF_TYPE_IS( r_t, logical<T> );
 
   // specific values tests
-  STF_EQUAL(logical_notand(T(0), iT(1)), r_t(true));
-  STF_EQUAL(logical_notand(T(1), iT(0)), r_t(false));
-  STF_EQUAL(logical_notand(bs::Inf<T>(),  iT(0)), r_t(false));
-  STF_EQUAL(logical_notand(bs::Minf<T>(), iT(0)), r_t(false));
-  STF_EQUAL(logical_notand(bs::Nan<T>(),  iT(0)), r_t(false));
-  STF_EQUAL(logical_notand(bs::Zero<T>(), iT(1)), r_t(true));
-  STF_EQUAL(logical_notand(r_t(false), iT(1)), r_t(true));
-  STF_EQUAL(logical_notand(r_t(true), iT(1)), r_t(false));
+  STF_ULP_EQUAL(logical_notand(T(0), iT(1)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_notand(T(1), iT(0)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_notand(bs::Inf<T>(),  iT(0)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_notand(bs::Minf<T>(), iT(0)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_notand(bs::Nan<T>(),  iT(0)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_notand(bs::Zero<T>(), iT(1)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_notand(r_t(false), iT(1)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_notand(r_t(true), iT(1)), r_t(false), 0.5);
 } // end of test for floating_
 
 

--- a/test/function/scalar/logical_notor.cpp
+++ b/test/function/scalar/logical_notor.cpp
@@ -31,14 +31,14 @@ STF_CASE_TPL (" logical_notor real",  STF_IEEE_TYPES)
   STF_TYPE_IS( r_t, logical<T>);
 
   // specific values tests
-  STF_EQUAL(logical_notor(T(0), T(1)), r_t(true));
-  STF_EQUAL(logical_notor(T(1), T(0)), r_t(false));
-  STF_EQUAL(logical_notor(bs::Inf<T>(),  T(0)), r_t(false));
-  STF_EQUAL(logical_notor(bs::Minf<T>(), T(0)), r_t(false));
-  STF_EQUAL(logical_notor(bs::Nan<T>(),  T(0)), r_t(false));
-  STF_EQUAL(logical_notor(bs::Zero<T>(), T(1)), r_t(true));
-  STF_EQUAL(logical_notor(r_t(false), T(1)), r_t(true));
-  STF_EQUAL(logical_notor(r_t(true), T(1)), r_t(true));
+  STF_ULP_EQUAL(logical_notor(T(0), T(1)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_notor(T(1), T(0)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_notor(bs::Inf<T>(),  T(0)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_notor(bs::Minf<T>(), T(0)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_notor(bs::Nan<T>(),  T(0)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_notor(bs::Zero<T>(), T(1)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_notor(r_t(false), T(1)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_notor(r_t(true), T(1)), r_t(true), 0.5);
 
 
 } // end of test for floating_
@@ -74,14 +74,14 @@ STF_CASE_TPL (" logical_notor mix",  STF_IEEE_TYPES)
   STF_TYPE_IS( r_t, logical<T>);
 
   // specific values tests
-  STF_EQUAL(logical_notor(T(0), iT(1)), r_t(true));
-  STF_EQUAL(logical_notor(T(1), iT(0)), r_t(false));
-  STF_EQUAL(logical_notor(bs::Inf<T>(),  iT(0)), r_t(false));
-  STF_EQUAL(logical_notor(bs::Minf<T>(), iT(0)), r_t(false));
-  STF_EQUAL(logical_notor(bs::Nan<T>(),  iT(0)), r_t(false));
-  STF_EQUAL(logical_notor(bs::Zero<T>(), iT(1)), r_t(true));
-  STF_EQUAL(logical_notor(r_t(false), iT(1)), r_t(true));
-  STF_EQUAL(logical_notor(r_t(true), iT(1)), r_t(true));
+  STF_ULP_EQUAL(logical_notor(T(0), iT(1)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_notor(T(1), iT(0)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_notor(bs::Inf<T>(),  iT(0)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_notor(bs::Minf<T>(), iT(0)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_notor(bs::Nan<T>(),  iT(0)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_notor(bs::Zero<T>(), iT(1)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_notor(r_t(false), iT(1)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_notor(r_t(true), iT(1)), r_t(true), 0.5);
 
 
 } // end of test for floating_

--- a/test/function/scalar/logical_or.cpp
+++ b/test/function/scalar/logical_or.cpp
@@ -47,11 +47,11 @@ STF_CASE_TPL (" logical_or real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, bs::logical<T>);
 
   // specific values tests
-  STF_EQUAL(logical_or(bs::Inf<T>(), bs::Inf<T>()), r_t(true));
-  STF_EQUAL(logical_or(bs::Minf<T>(), bs::Minf<T>()), r_t(true));
-  STF_EQUAL(logical_or(bs::Nan<T>(), bs::Nan<T>()), r_t(true));
-  STF_EQUAL(logical_or(bs::One<T>(),bs::Zero<T>()), r_t(true));
-  STF_EQUAL(logical_or(bs::Zero<T>(), bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(logical_or(bs::Inf<T>(), bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_or(bs::Minf<T>(), bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_or(bs::Nan<T>(), bs::Nan<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_or(bs::One<T>(),bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_or(bs::Zero<T>(), bs::Zero<T>()), r_t(false), 0.5);
 } // end of test for floating_
 
 STF_CASE ( "logical_or bool")
@@ -65,10 +65,10 @@ STF_CASE ( "logical_or bool")
  STF_TYPE_IS(r_t, bool);
 
   // specific values tests
-  STF_EQUAL(logical_or(true, false), true);
-  STF_EQUAL(logical_or(false, true), true);
-  STF_EQUAL(logical_or(true, true), true);
-  STF_EQUAL(logical_or(false, false), false);
+  STF_ULP_EQUAL(logical_or(true, false), true, 0.5);
+  STF_ULP_EQUAL(logical_or(false, true), true, 0.5);
+  STF_ULP_EQUAL(logical_or(true, true), true, 0.5);
+  STF_ULP_EQUAL(logical_or(false, false), false, 0.5);
 }
 
 

--- a/test/function/scalar/logical_ornot.cpp
+++ b/test/function/scalar/logical_ornot.cpp
@@ -32,14 +32,14 @@ STF_CASE_TPL (" logical_ornotreal",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, bs::logical<T>);
 
   // specific values tests
-  STF_EQUAL(logical_ornot(T(0), T(1)), r_t(false));
-  STF_EQUAL(logical_ornot(T(1), T(0)), r_t(true));
-  STF_EQUAL(logical_ornot(bs::Inf<T>(),  T(0)), r_t(true));
-  STF_EQUAL(logical_ornot(bs::Minf<T>(), T(0)), r_t(true));
-  STF_EQUAL(logical_ornot(bs::Nan<T>(),  T(0)), r_t(true));
-  STF_EQUAL(logical_ornot(bs::Zero<T>(), T(1)), r_t(false));
-  STF_EQUAL(logical_ornot(r_t(false), T(1)), r_t(false));
-  STF_EQUAL(logical_ornot(r_t(true), T(1)), r_t(true));
+  STF_ULP_EQUAL(logical_ornot(T(0), T(1)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_ornot(T(1), T(0)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_ornot(bs::Inf<T>(),  T(0)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_ornot(bs::Minf<T>(), T(0)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_ornot(bs::Nan<T>(),  T(0)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_ornot(bs::Zero<T>(), T(1)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_ornot(r_t(false), T(1)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_ornot(r_t(true), T(1)), r_t(true), 0.5);
 
 
 } // end of test for floating_
@@ -75,14 +75,14 @@ STF_CASE_TPL (" logical_ornot mix",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, bs::logical<T>);
 
   // specific values tests
-  STF_EQUAL(logical_ornot(T(0), iT(1)), r_t(false));
-  STF_EQUAL(logical_ornot(T(1), iT(0)), r_t(true));
-  STF_EQUAL(logical_ornot(bs::Inf<T>(),  iT(0)), r_t(true));
-  STF_EQUAL(logical_ornot(bs::Minf<T>(), iT(0)), r_t(true));
-  STF_EQUAL(logical_ornot(bs::Nan<T>(),  iT(0)), r_t(true));
-  STF_EQUAL(logical_ornot(bs::Zero<T>(), iT(1)), r_t(false));
-  STF_EQUAL(logical_ornot(r_t(false), iT(1)), r_t(false));
-  STF_EQUAL(logical_ornot(r_t(true), iT(1)), r_t(true));
+  STF_ULP_EQUAL(logical_ornot(T(0), iT(1)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_ornot(T(1), iT(0)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_ornot(bs::Inf<T>(),  iT(0)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_ornot(bs::Minf<T>(), iT(0)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_ornot(bs::Nan<T>(),  iT(0)), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_ornot(bs::Zero<T>(), iT(1)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_ornot(r_t(false), iT(1)), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_ornot(r_t(true), iT(1)), r_t(true), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL ( "logical_ornot logical", STF_NUMERIC_TYPES)

--- a/test/function/scalar/logical_xor.cpp
+++ b/test/function/scalar/logical_xor.cpp
@@ -45,11 +45,11 @@ STF_CASE_TPL (" logical_xor real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, bs::logical<T>);
 
   // specific values tests
-  STF_EQUAL(logical_xor(bs::Inf<T>(), bs::Inf<T>()), r_t(false));
-  STF_EQUAL(logical_xor(bs::Minf<T>(), bs::Minf<T>()), r_t(false));
-  STF_EQUAL(logical_xor(bs::Nan<T>(), bs::Nan<T>()), r_t(false));
-  STF_EQUAL(logical_xor(bs::One<T>(),bs::Zero<T>()), r_t(true));
-  STF_EQUAL(logical_xor(bs::Zero<T>(), bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(logical_xor(bs::Inf<T>(), bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_xor(bs::Minf<T>(), bs::Minf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_xor(bs::Nan<T>(), bs::Nan<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(logical_xor(bs::One<T>(),bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(logical_xor(bs::Zero<T>(), bs::Zero<T>()), r_t(false), 0.5);
 } // end of test for floating_
 
 STF_CASE ( "logical_xor bool")
@@ -63,8 +63,8 @@ STF_CASE ( "logical_xor bool")
   STF_TYPE_IS(r_t, bool);
 
   // specific values tests
-  STF_EQUAL(logical_xor(true, false), true);
-  STF_EQUAL(logical_xor(false, true), true);
-  STF_EQUAL(logical_xor(true, true), false);
-  STF_EQUAL(logical_xor(false, false), false);
+  STF_ULP_EQUAL(logical_xor(true, false), true, 0.5);
+  STF_ULP_EQUAL(logical_xor(false, true), true, 0.5);
+  STF_ULP_EQUAL(logical_xor(true, true), false, 0.5);
+  STF_ULP_EQUAL(logical_xor(false, false), false, 0.5);
 }

--- a/test/function/scalar/majority.cpp
+++ b/test/function/scalar/majority.cpp
@@ -34,17 +34,17 @@ STF_CASE_TPL (" majorityreal",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(majority(bs::Inf<T>(), bs::Inf<T>(), bs::Inf<T>()), r_t(true));
-  STF_EQUAL(majority(bs::Minf<T>(), bs::Minf<T>(), bs::Minf<T>()), r_t(true));
-  STF_EQUAL(majority(bs::Nan<T>(), bs::Nan<T>(), bs::Nan<T>()), r_t(true));
+  STF_ULP_EQUAL(majority(bs::Inf<T>(), bs::Inf<T>(), bs::Inf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(majority(bs::Minf<T>(), bs::Minf<T>(), bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(majority(bs::Nan<T>(), bs::Nan<T>(), bs::Nan<T>()), r_t(true), 0.5);
 #endif
-  STF_EQUAL(majority(-bs::Zero<T>(), -bs::Zero<T>(), -bs::Zero<T>()), r_t(false));
-  STF_EQUAL(majority(bs::Half<T>(), bs::Half<T>(), bs::Half<T>()), r_t(true));
-  STF_EQUAL(majority(bs::Mone<T>(), bs::Mone<T>(), bs::Mone<T>()), r_t(true));
-  STF_EQUAL(majority(bs::One<T>(), bs::One<T>(), bs::One<T>()), r_t(true));
-  STF_EQUAL(majority(bs::Quarter<T>(), bs::Quarter<T>(), bs::Quarter<T>()), r_t(true));
-  STF_EQUAL(majority(bs::Two<T>(), bs::Two<T>(), bs::Two<T>()), r_t(true));
-  STF_EQUAL(majority(bs::Zero<T>(), bs::Zero<T>(), bs::Zero<T>()), r_t(false));
+  STF_ULP_EQUAL(majority(-bs::Zero<T>(), -bs::Zero<T>(), -bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(majority(bs::Half<T>(), bs::Half<T>(), bs::Half<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(majority(bs::Mone<T>(), bs::Mone<T>(), bs::Mone<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(majority(bs::One<T>(), bs::One<T>(), bs::One<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(majority(bs::Quarter<T>(), bs::Quarter<T>(), bs::Quarter<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(majority(bs::Two<T>(), bs::Two<T>(), bs::Two<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(majority(bs::Zero<T>(), bs::Zero<T>(), bs::Zero<T>()), r_t(false), 0.5);
 }
 
 STF_CASE_TPL (" majoritysigned_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/mantissa.cpp
+++ b/test/function/scalar/mantissa.cpp
@@ -31,14 +31,14 @@ STF_CASE_TPL (" mantissareal",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(mantissa(bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(mantissa(bs::Minf<T>()), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(mantissa(bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(mantissa(bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(mantissa(bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(mantissa(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(mantissa(bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(mantissa(bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(mantissa(bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(mantissa(bs::Two <T>()), bs::One<r_t>());
-  STF_EQUAL(mantissa(T(1.5)), T(1.5));
-  STF_EQUAL(mantissa(T(2.5)), T(1.25));
+  STF_ULP_EQUAL(mantissa(bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(mantissa(bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(mantissa(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(mantissa(bs::Two <T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(mantissa(T(1.5)), T(1.5), 0.5);
+  STF_ULP_EQUAL(mantissa(T(2.5)), T(1.25), 0.5);
 }

--- a/test/function/scalar/mask2logical.cpp
+++ b/test/function/scalar/mask2logical.cpp
@@ -32,8 +32,8 @@ STF_CASE_TPL (" mask2logical real",  STF_IEEE_TYPES)
   STF_EXPR_IS( mask2logical(T()), lT );
 
   // specific values tests
-  STF_EQUAL(mask2logical(T(0)), bs::False<lT>());
-  STF_EQUAL(mask2logical(bs::Nan<T>()) , bs::True<lT>());
+  STF_ULP_EQUAL(mask2logical(T(0)), bs::False<lT>(), 0.5);
+  STF_ULP_EQUAL(mask2logical(bs::Nan<T>()) , bs::True<lT>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" mask2logical signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/max.cpp
+++ b/test/function/scalar/max.cpp
@@ -28,17 +28,17 @@ STF_CASE_TPL (" max real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(max(bs::Inf<T>(),  bs::Inf<T>()),  bs::Inf<T>());
-  STF_EQUAL(max(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<T>());
-  STF_IEEE_EQUAL(max(bs::Nan<T>(),  bs::Nan<T>()),  bs::Nan<T>());
+  STF_ULP_EQUAL(max(bs::Inf<T>(),  bs::Inf<T>()),  bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(max(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<T>(), 0.5);
+  STF_ULP_EQUAL(max(bs::Nan<T>(),  bs::Nan<T>()),  bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(max(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<T>());
-  STF_EQUAL(max(bs::One<T>(),  bs::One<T>()),  bs::One<T>());
-  STF_EQUAL(max(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>());
-  STF_IEEE_EQUAL(max(bs::Nan<T>(),  bs::One<T>()),  bs::Nan<T>());
-  STF_IEEE_EQUAL(max(bs::One<T>(),  bs::Nan<T>()),  bs::One<T>());
-  STF_EQUAL(max(bs::One<T>(),  bs::Two<T>()),  bs::Two<T>());
-  STF_EQUAL(max(bs::Two<T>(),  bs::One<T>()),  bs::Two<T>());
+  STF_ULP_EQUAL(max(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(max(bs::One<T>(),  bs::One<T>()),  bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(max(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(max(bs::Nan<T>(),  bs::One<T>()),  bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(max(bs::One<T>(),  bs::Nan<T>()),  bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(max(bs::One<T>(),  bs::Two<T>()),  bs::Two<T>(), 0.5);
+  STF_ULP_EQUAL(max(bs::Two<T>(),  bs::One<T>()),  bs::Two<T>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" max unsigned int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/maxmag.cpp
+++ b/test/function/scalar/maxmag.cpp
@@ -28,18 +28,18 @@ STF_CASE_TPL (" maxmag real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(maxmag(bs::Inf<T>(),  bs::Inf<T>()),  bs::Inf<T>());
-  STF_EQUAL(maxmag(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<T>());
-  STF_IEEE_EQUAL(maxmag(bs::Nan<T>(),  bs::Nan<T>()),  bs::Nan<T>());
+  STF_ULP_EQUAL(maxmag(bs::Inf<T>(),  bs::Inf<T>()),  bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(maxmag(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<T>(), 0.5);
+  STF_ULP_EQUAL(maxmag(bs::Nan<T>(),  bs::Nan<T>()),  bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(maxmag(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<T>());
-  STF_EQUAL(maxmag(bs::One<T>(),  bs::One<T>()),  bs::One<T>());
-  STF_EQUAL(maxmag(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>());
-  STF_IEEE_EQUAL(maxmag(bs::Nan<T>(),  bs::One<T>()),  bs::Nan<T>());
-  STF_EQUAL(maxmag(bs::One<T>(),  bs::Nan<T>()),  bs::One<T>());
-  STF_EQUAL(maxmag(bs::One<T>(),  bs::Two<T>()),  bs::Two<T>());
-  STF_EQUAL(maxmag(bs::Two<T>(),  bs::One<T>()),  bs::Two<T>());
-  STF_EQUAL(maxmag(-bs::Two<T>(),  bs::One<T>()),  -bs::Two<T>());
+  STF_ULP_EQUAL(maxmag(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(maxmag(bs::One<T>(),  bs::One<T>()),  bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(maxmag(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(maxmag(bs::Nan<T>(),  bs::One<T>()),  bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(maxmag(bs::One<T>(),  bs::Nan<T>()),  bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(maxmag(bs::One<T>(),  bs::Two<T>()),  bs::Two<T>(), 0.5);
+  STF_ULP_EQUAL(maxmag(bs::Two<T>(),  bs::One<T>()),  bs::Two<T>(), 0.5);
+  STF_ULP_EQUAL(maxmag(-bs::Two<T>(),  bs::One<T>()),  -bs::Two<T>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" maxmag unsigned int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/maxnum.cpp
+++ b/test/function/scalar/maxnum.cpp
@@ -34,24 +34,24 @@ STF_CASE_TPL (" maxnum real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(maxnum(bs::Inf<T>(),  bs::Inf<T>()),  bs::Inf<r_t>());
-  STF_EQUAL(maxnum(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(maxnum(bs::Nan<T>(),  bs::Nan<T>()),  bs::Nan<r_t>());
-  STF_EQUAL(maxnum(bs::Nan<T>(),  bs::One<T>()),  bs::One<r_t>());
-  STF_EQUAL(maxnum(bs::One<T>(),  bs::Nan<T>()),  bs::One<r_t>());
-  STF_EQUAL(maxnum(bs::Nan<T>(),  bs::One <T>()), bs::One<r_t>());
+  STF_ULP_EQUAL(maxnum(bs::Inf<T>(),  bs::Inf<T>()),  bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnum(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnum(bs::Nan<T>(),  bs::Nan<T>()),  bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnum(bs::Nan<T>(),  bs::One<T>()),  bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnum(bs::One<T>(),  bs::Nan<T>()),  bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnum(bs::Nan<T>(),  bs::One <T>()), bs::One<r_t>(), 0.5);
 #endif
-  STF_EQUAL(maxnum(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(maxnum(bs::One<T>(),  bs::One<T>()),  bs::One<r_t>());
-  STF_EQUAL(maxnum(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(maxnum(bs::Mone<T>(), bs::One <T>()), bs::One<r_t>());
-  STF_EQUAL(maxnum(bs::One <T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(maxnum(bs::One <T>(), bs::Two <T>()), bs::Two<r_t>());
-  STF_EQUAL(maxnum(bs::Two <T>(), bs::One <T>()), bs::Two<r_t>());
-  STF_EQUAL(maxnum(bs::Mtwo<T>(), bs::One <T>()), bs::One<r_t>());
-  STF_EQUAL(maxnum(bs::One <T>(), bs::Mtwo<T>()), bs::One<r_t>());
-  STF_EQUAL(maxnum(bs::Two <T>(), bs::Mone<T>()), bs::Two<r_t>());
-  STF_EQUAL(maxnum(bs::Mone<T>(), bs::Two <T>()), bs::Two<r_t>());
+  STF_ULP_EQUAL(maxnum(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnum(bs::One<T>(),  bs::One<T>()),  bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnum(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnum(bs::Mone<T>(), bs::One <T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnum(bs::One <T>(), bs::Mone<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnum(bs::One <T>(), bs::Two <T>()), bs::Two<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnum(bs::Two <T>(), bs::One <T>()), bs::Two<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnum(bs::Mtwo<T>(), bs::One <T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnum(bs::One <T>(), bs::Mtwo<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnum(bs::Two <T>(), bs::Mone<T>()), bs::Two<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnum(bs::Mone<T>(), bs::Two <T>()), bs::Two<r_t>(), 0.5);
 }
 
 
@@ -103,22 +103,22 @@ STF_CASE_TPL (" maxnum real std (fmax)",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bs::std_(maxnum)(bs::Inf<T>(),  bs::Inf<T>()),  bs::Inf<r_t>());
-  STF_EQUAL(bs::std_(maxnum)(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(bs::std_(maxnum)(bs::Nan<T>(),  bs::Nan<T>()),  bs::Nan<r_t>());
-  STF_EQUAL(bs::std_(maxnum)(bs::Nan<T>(),  bs::One<T>()),  bs::One<r_t>());
-  STF_EQUAL(bs::std_(maxnum)(bs::One<T>(),  bs::Nan<T>()),  bs::One<r_t>());
-  STF_EQUAL(bs::std_(maxnum)(bs::Nan<T>(),  bs::One <T>()), bs::One<r_t>());
+  STF_ULP_EQUAL(bs::std_(maxnum)(bs::Inf<T>(),  bs::Inf<T>()),  bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(maxnum)(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(maxnum)(bs::Nan<T>(),  bs::Nan<T>()),  bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(maxnum)(bs::Nan<T>(),  bs::One<T>()),  bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(maxnum)(bs::One<T>(),  bs::Nan<T>()),  bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(maxnum)(bs::Nan<T>(),  bs::One <T>()), bs::One<r_t>(), 0.5);
 #endif
-  STF_EQUAL(bs::std_(maxnum)(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(bs::std_(maxnum)(bs::One<T>(),  bs::One<T>()),  bs::One<r_t>());
-  STF_EQUAL(bs::std_(maxnum)(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(bs::std_(maxnum)(bs::Mone<T>(), bs::One <T>()), bs::One<r_t>());
-  STF_EQUAL(bs::std_(maxnum)(bs::One <T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(bs::std_(maxnum)(bs::One <T>(), bs::Two <T>()), bs::Two<r_t>());
-  STF_EQUAL(bs::std_(maxnum)(bs::Two <T>(), bs::One <T>()), bs::Two<r_t>());
-  STF_EQUAL(bs::std_(maxnum)(bs::Mtwo<T>(), bs::One <T>()), bs::One<r_t>());
-  STF_EQUAL(bs::std_(maxnum)(bs::One <T>(), bs::Mtwo<T>()), bs::One<r_t>());
-  STF_EQUAL(bs::std_(maxnum)(bs::Two <T>(), bs::Mone<T>()), bs::Two<r_t>());
-  STF_EQUAL(bs::std_(maxnum)(bs::Mone<T>(), bs::Two <T>()), bs::Two<r_t>());
+  STF_ULP_EQUAL(bs::std_(maxnum)(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(maxnum)(bs::One<T>(),  bs::One<T>()),  bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(maxnum)(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(maxnum)(bs::Mone<T>(), bs::One <T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(maxnum)(bs::One <T>(), bs::Mone<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(maxnum)(bs::One <T>(), bs::Two <T>()), bs::Two<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(maxnum)(bs::Two <T>(), bs::One <T>()), bs::Two<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(maxnum)(bs::Mtwo<T>(), bs::One <T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(maxnum)(bs::One <T>(), bs::Mtwo<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(maxnum)(bs::Two <T>(), bs::Mone<T>()), bs::Two<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(maxnum)(bs::Mone<T>(), bs::Two <T>()), bs::Two<r_t>(), 0.5);
 }

--- a/test/function/scalar/maxnummag.cpp
+++ b/test/function/scalar/maxnummag.cpp
@@ -31,23 +31,23 @@ STF_CASE_TPL (" maxnummag real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(maxnummag(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(maxnummag(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(maxnummag(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
-  STF_EQUAL(maxnummag(bs::Nan<T>(),bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(maxnummag(bs::One<T>(),bs::Nan<T>()), bs::One<r_t>());
+  STF_ULP_EQUAL(maxnummag(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnummag(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnummag(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnummag(bs::Nan<T>(),bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnummag(bs::One<T>(),bs::Nan<T>()), bs::One<r_t>(), 0.5);
 #endif
-  STF_EQUAL(maxnummag(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(maxnummag(bs::One<T>(),  bs::One<T>()),  bs::One<r_t>());
-  STF_EQUAL(maxnummag(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(maxnummag(bs::Mone<T>(), bs::One <T>()), bs::One<r_t>());
-  STF_EQUAL(maxnummag(bs::One <T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(maxnummag(bs::One <T>(), bs::Two <T>()), bs::Two<r_t>());
-  STF_EQUAL(maxnummag(bs::Two <T>(), bs::One <T>()), bs::Two<r_t>());
-  STF_EQUAL(maxnummag(bs::Mtwo<T>(), bs::One <T>()), bs::Mtwo<r_t>());
-  STF_EQUAL(maxnummag(bs::One <T>(), bs::Mtwo<T>()), bs::Mtwo<r_t>());
-  STF_EQUAL(maxnummag(bs::Two <T>(), bs::Mone<T>()), bs::Two<r_t>());
-  STF_EQUAL(maxnummag(bs::Mone<T>(), bs::Two <T>()), bs::Two<r_t>());
+  STF_ULP_EQUAL(maxnummag(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnummag(bs::One<T>(),  bs::One<T>()),  bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnummag(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnummag(bs::Mone<T>(), bs::One <T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnummag(bs::One <T>(), bs::Mone<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnummag(bs::One <T>(), bs::Two <T>()), bs::Two<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnummag(bs::Two <T>(), bs::One <T>()), bs::Two<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnummag(bs::Mtwo<T>(), bs::One <T>()), bs::Mtwo<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnummag(bs::One <T>(), bs::Mtwo<T>()), bs::Mtwo<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnummag(bs::Two <T>(), bs::Mone<T>()), bs::Two<r_t>(), 0.5);
+  STF_ULP_EQUAL(maxnummag(bs::Mone<T>(), bs::Two <T>()), bs::Two<r_t>(), 0.5);
 }
 
 STF_CASE_TPL (" maxnummag unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/meanof.cpp
+++ b/test/function/scalar/meanof.cpp
@@ -32,20 +32,20 @@ STF_CASE_TPL (" meanof real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(meanof(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<T>());
-  STF_EQUAL(meanof(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<T>());
-  STF_IEEE_EQUAL(meanof(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(meanof(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(meanof(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<T>(), 0.5);
+  STF_ULP_EQUAL(meanof(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(meanof(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<T>());
-  STF_EQUAL(meanof(bs::One<T>(), bs::One<T>()), bs::One<T>());
-  STF_EQUAL(meanof(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>());
-  STF_IEEE_EQUAL(meanof(bs::Inf<T>(), bs::Minf<T>()), bs::Nan<T>());
-  STF_EQUAL(meanof(bs::Valmax<T>(), bs::Valmax<T>()), bs::Valmax<T>());
-  STF_EQUAL(meanof(bs::Valmin<T>(), bs::Valmin<T>()), bs::Valmin<T>());
-  STF_EQUAL(meanof(bs::Valmax<T>()/2, bs::Valmax<T>()), bs::Valmax<T>()*T(0.75));
-  STF_EQUAL(meanof(bs::Valmin<T>()/2, bs::Valmin<T>()), bs::Valmin<T>()*T(0.75));
-  STF_EQUAL(meanof(bs::Valmax<T>()/2, bs::Valmax<T>()), bs::Valmax<T>()*T(0.75));
-  STF_EQUAL(meanof(bs::Valmin<T>()/2, bs::Valmin<T>()), bs::Valmin<T>()*T(0.75));
+  STF_ULP_EQUAL(meanof(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(meanof(bs::One<T>(), bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(meanof(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(meanof(bs::Inf<T>(), bs::Minf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(meanof(bs::Valmax<T>(), bs::Valmax<T>()), bs::Valmax<T>(), 0.5);
+  STF_ULP_EQUAL(meanof(bs::Valmin<T>(), bs::Valmin<T>()), bs::Valmin<T>(), 0.5);
+  STF_ULP_EQUAL(meanof(bs::Valmax<T>()/2, bs::Valmax<T>()), bs::Valmax<T>()*T(0.75), 0.5);
+  STF_ULP_EQUAL(meanof(bs::Valmin<T>()/2, bs::Valmin<T>()), bs::Valmin<T>()*T(0.75), 0.5);
+  STF_ULP_EQUAL(meanof(bs::Valmax<T>()/2, bs::Valmax<T>()), bs::Valmax<T>()*T(0.75), 0.5);
+  STF_ULP_EQUAL(meanof(bs::Valmin<T>()/2, bs::Valmin<T>()), bs::Valmin<T>()*T(0.75), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" meanof signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/min.cpp
+++ b/test/function/scalar/min.cpp
@@ -28,17 +28,17 @@ STF_CASE_TPL (" min real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(min(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<T>());
-  STF_EQUAL(min(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<T>());
-  STF_IEEE_EQUAL(min(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(min(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(min(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<T>(), 0.5);
+  STF_ULP_EQUAL(min(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(min(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<T>());
-  STF_EQUAL(min(bs::One<T>(), bs::One<T>()), bs::One<T>());
-  STF_EQUAL(min(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>());
-  STF_IEEE_EQUAL(min(bs::Nan<T>(), bs::One<T>()), bs::Nan<T>());
-  STF_EQUAL(min(bs::One<T>(), bs::Nan<T>()), bs::One<T>());
-  STF_EQUAL(min(bs::One<T>(), bs::Two<T>()), bs::One<T>());
-  STF_EQUAL(min(bs::Two<T>(), bs::One<T>()), bs::One<T>());
+  STF_ULP_EQUAL(min(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(min(bs::One<T>(), bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(min(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(min(bs::Nan<T>(), bs::One<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(min(bs::One<T>(), bs::Nan<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(min(bs::One<T>(), bs::Two<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(min(bs::Two<T>(), bs::One<T>()), bs::One<T>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" minu nsigned int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/minmag.cpp
+++ b/test/function/scalar/minmag.cpp
@@ -32,23 +32,23 @@ STF_CASE_TPL (" minmag real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(minmag(bs::Inf<T>(), bs::Inf<T>()),   bs::Inf<r_t>());
-  STF_EQUAL(minmag(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(minmag(bs::Nan<T>(), bs::Nan<T>()),   bs::Nan<r_t>());
-  STF_EQUAL(minmag(bs::One<T>(), bs::Nan<T>()),   bs::One<r_t>());
-  STF_IEEE_EQUAL(minmag(bs::Nan<T>(), bs::One<T>()),   bs::Nan<r_t>());
+  STF_ULP_EQUAL(minmag(bs::Inf<T>(), bs::Inf<T>()),   bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(minmag(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(minmag(bs::Nan<T>(), bs::Nan<T>()),   bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(minmag(bs::One<T>(), bs::Nan<T>()),   bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(minmag(bs::Nan<T>(), bs::One<T>()),   bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(minmag(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(minmag(bs::One<T>(),  bs::One<T>()),  bs::One<r_t>());
-  STF_EQUAL(minmag(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(minmag(bs::Mone<T>(), bs::One <T>()), bs::Mone<r_t>());
-  STF_EQUAL(minmag(bs::One <T>(), bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(minmag(bs::One <T>(), bs::Two <T>()), bs::One<r_t>());
-  STF_EQUAL(minmag(bs::Two <T>(), bs::One <T>()), bs::One<r_t>());
-  STF_EQUAL(minmag(bs::Mtwo<T>(), bs::One <T>()), bs::One<r_t>());
-  STF_EQUAL(minmag(bs::One <T>(), bs::Mtwo<T>()), bs::One<r_t>());
-  STF_EQUAL(minmag(bs::Two <T>(), bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(minmag(bs::Mone<T>(), bs::Two <T>()), bs::Mone<r_t>());
+  STF_ULP_EQUAL(minmag(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(minmag(bs::One<T>(),  bs::One<T>()),  bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(minmag(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(minmag(bs::Mone<T>(), bs::One <T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(minmag(bs::One <T>(), bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(minmag(bs::One <T>(), bs::Two <T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(minmag(bs::Two <T>(), bs::One <T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(minmag(bs::Mtwo<T>(), bs::One <T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(minmag(bs::One <T>(), bs::Mtwo<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(minmag(bs::Two <T>(), bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(minmag(bs::Mone<T>(), bs::Two <T>()), bs::Mone<r_t>(), 0.5);
 }
 
 

--- a/test/function/scalar/minmod.cpp
+++ b/test/function/scalar/minmod.cpp
@@ -31,21 +31,21 @@ STF_CASE_TPL (" minmod real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(minmod(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<T>());
-  STF_EQUAL(minmod(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<T>());
-  STF_IEEE_EQUAL(minmod(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(minmod(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(minmod(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<T>(), 0.5);
+  STF_ULP_EQUAL(minmod(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(minmod(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<T>());
-  STF_EQUAL(minmod(bs::One<T>(), bs::One<T>()), bs::One<T>());
-  STF_EQUAL(minmod(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>());
-  STF_IEEE_EQUAL(minmod(bs::Nan<T>(), bs::One<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(minmod(bs::One<T>(), bs::Nan<T>()), bs::One<T>());
-  STF_IEEE_EQUAL(minmod(bs::Nan<T>(), bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(minmod(bs::Zero<T>(), bs::Nan<T>()), bs::Zero<T>());
-  STF_EQUAL(minmod(bs::One<T>(), bs::Two<T>()), bs::One<T>());
-  STF_EQUAL(minmod(bs::Two<T>(), bs::One<T>()), bs::One<T>());
-  STF_EQUAL(minmod(bs::One<T>(), bs::Mtwo<T>()), bs::Zero<T>());
-  STF_EQUAL(minmod(bs::Mtwo<T>(), bs::One<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(minmod(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(minmod(bs::One<T>(), bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(minmod(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(minmod(bs::Nan<T>(), bs::One<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(minmod(bs::One<T>(), bs::Nan<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(minmod(bs::Nan<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(minmod(bs::Zero<T>(), bs::Nan<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(minmod(bs::One<T>(), bs::Two<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(minmod(bs::Two<T>(), bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(minmod(bs::One<T>(), bs::Mtwo<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(minmod(bs::Mtwo<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" minmodunsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/minnum.cpp
+++ b/test/function/scalar/minnum.cpp
@@ -33,23 +33,23 @@ STF_CASE_TPL (" minnum real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(minnum(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(minnum(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(minnum(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
-  STF_EQUAL(minnum(bs::Nan<T>(),bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(minnum(bs::One<T>(),bs::Nan<T>()), bs::One<r_t>());
+  STF_ULP_EQUAL(minnum(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnum(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnum(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnum(bs::Nan<T>(),bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnum(bs::One<T>(),bs::Nan<T>()), bs::One<r_t>(), 0.5);
 #endif
-  STF_EQUAL(minnum(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(minnum(bs::One<T>(),  bs::One<T>()),  bs::One<r_t>());
-  STF_EQUAL(minnum(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(minnum(bs::Mone<T>(), bs::One <T>()), bs::Mone<r_t>());
-  STF_EQUAL(minnum(bs::One <T>(), bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(minnum(bs::One <T>(), bs::Two <T>()), bs::One<r_t>());
-  STF_EQUAL(minnum(bs::Two <T>(), bs::One <T>()), bs::One<r_t>());
-  STF_EQUAL(minnum(bs::Mtwo<T>(), bs::One <T>()), bs::Mtwo<r_t>());
-  STF_EQUAL(minnum(bs::One <T>(), bs::Mtwo<T>()), bs::Mtwo<r_t>());
-  STF_EQUAL(minnum(bs::Two <T>(), bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(minnum(bs::Mone<T>(), bs::Two <T>()), bs::Mone<r_t>());
+  STF_ULP_EQUAL(minnum(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnum(bs::One<T>(),  bs::One<T>()),  bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnum(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnum(bs::Mone<T>(), bs::One <T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnum(bs::One <T>(), bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnum(bs::One <T>(), bs::Two <T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnum(bs::Two <T>(), bs::One <T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnum(bs::Mtwo<T>(), bs::One <T>()), bs::Mtwo<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnum(bs::One <T>(), bs::Mtwo<T>()), bs::Mtwo<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnum(bs::Two <T>(), bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnum(bs::Mone<T>(), bs::Two <T>()), bs::Mone<r_t>(), 0.5);
 }
 
 STF_CASE_TPL (" minnum unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/minnummag.cpp
+++ b/test/function/scalar/minnummag.cpp
@@ -32,23 +32,23 @@ STF_CASE_TPL (" minnummag real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(minnummag(bs::Inf<T>(),  bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(minnummag(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(minnummag(bs::Nan<T>(),  bs::Nan<T>()), bs::Nan<r_t>());
-  STF_EQUAL(minnummag(bs::Nan<T>(),  bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(minnummag(bs::One<T>(),  bs::Nan<T>()), bs::One<r_t>());
+  STF_ULP_EQUAL(minnummag(bs::Inf<T>(),  bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnummag(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnummag(bs::Nan<T>(),  bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnummag(bs::Nan<T>(),  bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnummag(bs::One<T>(),  bs::Nan<T>()), bs::One<r_t>(), 0.5);
 #endif
-  STF_EQUAL(minnummag(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(minnummag(bs::One<T>(),  bs::One<T>()),  bs::One<r_t>());
-  STF_EQUAL(minnummag(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(minnummag(bs::Mone<T>(), bs::One <T>()), bs::Mone<r_t>());
-  STF_EQUAL(minnummag(bs::One <T>(), bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(minnummag(bs::One <T>(), bs::Two <T>()), bs::One<r_t>());
-  STF_EQUAL(minnummag(bs::Two <T>(), bs::One <T>()), bs::One<r_t>());
-  STF_EQUAL(minnummag(bs::Mtwo<T>(), bs::One <T>()), bs::One<r_t>());
-  STF_EQUAL(minnummag(bs::One <T>(), bs::Mtwo<T>()), bs::One<r_t>());
-  STF_EQUAL(minnummag(bs::Two <T>(), bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(minnummag(bs::Mone<T>(), bs::Two <T>()), bs::Mone<r_t>());
+  STF_ULP_EQUAL(minnummag(bs::Mone<T>(), bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnummag(bs::One<T>(),  bs::One<T>()),  bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnummag(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnummag(bs::Mone<T>(), bs::One <T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnummag(bs::One <T>(), bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnummag(bs::One <T>(), bs::Two <T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnummag(bs::Two <T>(), bs::One <T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnummag(bs::Mtwo<T>(), bs::One <T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnummag(bs::One <T>(), bs::Mtwo<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnummag(bs::Two <T>(), bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(minnummag(bs::Mone<T>(), bs::Two <T>()), bs::Mone<r_t>(), 0.5);
 }
 
 STF_CASE_TPL (" minnummag unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/minus.cpp
+++ b/test/function/scalar/minus.cpp
@@ -25,12 +25,12 @@ STF_CASE_TPL( "Check minus behavior with floating", STF_IEEE_TYPES )
   STF_TYPE_IS(r_t, T);
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(minus(bs::Inf<T>(),  bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(minus(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(minus(bs::Nan<T>(),  bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(minus(bs::Inf<T>(),  bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(minus(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(minus(bs::Nan<T>(),  bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(minus(bs::One<T>(),bs::Zero<T>()), bs::One<r_t>());
-  STF_EQUAL(minus(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(minus(bs::One<T>(),bs::Zero<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(minus(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 }
 
 

--- a/test/function/scalar/multiplies.cpp
+++ b/test/function/scalar/multiplies.cpp
@@ -24,13 +24,13 @@ STF_CASE_TPL( "Check multiplies behavior with floating", STF_IEEE_TYPES )
   STF_TYPE_IS(r_t, T);
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(multiplies(bs::Inf<T>(),  bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(multiplies(bs::Minf<T>(), bs::Minf<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(multiplies(bs::Nan<T>(),  bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(multiplies(bs::Inf<T>(),  bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(multiplies(bs::Minf<T>(), bs::Minf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(multiplies(bs::Nan<T>(),  bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(multiplies(bs::One<T>(),bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(multiplies(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(multiplies(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
+  STF_ULP_EQUAL(multiplies(bs::One<T>(),bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(multiplies(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(multiplies(bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
 }
 
 

--- a/test/function/scalar/nbtrue.cpp
+++ b/test/function/scalar/nbtrue.cpp
@@ -25,12 +25,12 @@ STF_CASE_TPL (" nbtrue real",  STF_IEEE_TYPES)
   using bs::nbtrue;
 
   // specific values tests
-  STF_EQUAL(nbtrue(bs::Inf<T>()) ,1u);
-  STF_EQUAL(nbtrue(bs::Minf<T>()),1u);
-  STF_EQUAL(nbtrue(bs::Mone<T>()),1u);
-  STF_EQUAL(nbtrue(bs::Nan<T>()) ,1u);
-  STF_EQUAL(nbtrue(bs::One<T>()) ,1u);
-  STF_EQUAL(nbtrue(bs::Zero<T>()), 0u);
+  STF_ULP_EQUAL(nbtrue(bs::Inf<T>()) ,1u, 0.5);
+  STF_ULP_EQUAL(nbtrue(bs::Minf<T>()),1u, 0.5);
+  STF_ULP_EQUAL(nbtrue(bs::Mone<T>()),1u, 0.5);
+  STF_ULP_EQUAL(nbtrue(bs::Nan<T>()) ,1u, 0.5);
+  STF_ULP_EQUAL(nbtrue(bs::One<T>()) ,1u, 0.5);
+  STF_ULP_EQUAL(nbtrue(bs::Zero<T>()), 0u, 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" nbtrue integer",  STF_INTEGRAL_TYPES)

--- a/test/function/scalar/nearbyint.cpp
+++ b/test/function/scalar/nearbyint.cpp
@@ -33,19 +33,19 @@ STF_CASE_TPL ( "nearbyint real",  STF_IEEE_TYPES)
   STF_TYPE_IS( r_t, T );
 
   // specific values tests
-  STF_IEEE_EQUAL(nearbyint(T(1.4)), 1);
-  STF_IEEE_EQUAL(nearbyint(T(1.5)), 2);
-  STF_IEEE_EQUAL(nearbyint(T(1.6)), 2);
-  STF_IEEE_EQUAL(nearbyint(T(2.5)), 2);
-  STF_IEEE_EQUAL(nearbyint(bs::Half<T>()), bs::Zero<r_t>());
-  STF_IEEE_EQUAL(nearbyint(bs::Inf<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(nearbyint(bs::Mhalf<T>()), bs::Zero<r_t>());
-  STF_IEEE_EQUAL(nearbyint(bs::Minf<T>()), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(nearbyint(bs::Mone<T>()), bs::Mone<r_t>());
-  STF_IEEE_EQUAL(nearbyint(bs::Nan<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(nearbyint(bs::One<T>()), bs::One<r_t>());
-  STF_IEEE_EQUAL(nearbyint(bs::Zero<T>()), bs::Zero<r_t>());
-  STF_IEEE_EQUAL(nearbyint(bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(nearbyint(T(1.4)), 1, 0.5);
+  STF_ULP_EQUAL(nearbyint(T(1.5)), 2, 0.5);
+  STF_ULP_EQUAL(nearbyint(T(1.6)), 2, 0.5);
+  STF_ULP_EQUAL(nearbyint(T(2.5)), 2, 0.5);
+  STF_ULP_EQUAL(nearbyint(bs::Half<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(nearbyint(bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(nearbyint(bs::Mhalf<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(nearbyint(bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(nearbyint(bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(nearbyint(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(nearbyint(bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(nearbyint(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(nearbyint(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
   STF_EXPECT(bs::is_negative(nearbyint(bs::Mzero<T>())));
   STF_EXPECT(bs::is_positive(nearbyint(bs::Zero<T>())));
 } // end of test for floating_
@@ -92,16 +92,16 @@ STF_CASE_TPL ( "nearbyint std",  STF_IEEE_TYPES)
   STF_TYPE_IS( r_t, T );
 
   // specific values tests
-  STF_IEEE_EQUAL(bs::std_(nearbyint)(T(1.4)), 1);
-  STF_IEEE_EQUAL(bs::std_(nearbyint)(T(1.5)), 2);
-  STF_IEEE_EQUAL(bs::std_(nearbyint)(T(1.6)), 2);
-  STF_IEEE_EQUAL(bs::std_(nearbyint)(T(2.5)), 2);
-  STF_IEEE_EQUAL(bs::std_(nearbyint)(bs::Half<T>()), bs::Zero<r_t>());
-  STF_IEEE_EQUAL(bs::std_(nearbyint)(bs::Inf<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(bs::std_(nearbyint)(bs::Mhalf<T>()), bs::Zero<r_t>());
-  STF_IEEE_EQUAL(bs::std_(nearbyint)(bs::Minf<T>()), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(bs::std_(nearbyint)(bs::Mone<T>()), bs::Mone<r_t>());
-  STF_IEEE_EQUAL(bs::std_(nearbyint)(bs::Nan<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(bs::std_(nearbyint)(bs::One<T>()), bs::One<r_t>());
-  STF_IEEE_EQUAL(bs::std_(nearbyint)(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(bs::std_(nearbyint)(T(1.4)), 1, 0.5);
+  STF_ULP_EQUAL(bs::std_(nearbyint)(T(1.5)), 2, 0.5);
+  STF_ULP_EQUAL(bs::std_(nearbyint)(T(1.6)), 2, 0.5);
+  STF_ULP_EQUAL(bs::std_(nearbyint)(T(2.5)), 2, 0.5);
+  STF_ULP_EQUAL(bs::std_(nearbyint)(bs::Half<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(nearbyint)(bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(nearbyint)(bs::Mhalf<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(nearbyint)(bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(nearbyint)(bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(nearbyint)(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(nearbyint)(bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(nearbyint)(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 } // end of test for floating_

--- a/test/function/scalar/negate.cpp
+++ b/test/function/scalar/negate.cpp
@@ -34,22 +34,22 @@ STF_CASE_TPL (" negate real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(negate(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(negate(bs::Minf<T>(), bs::Minf<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(negate(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(negate(bs::Nan<T>(), bs::Zero<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(negate(bs::Zero<T>(), bs::Nan<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(negate(bs::Nan<T>(), bs::Zero<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(negate(bs::One<T>(), bs::Nan<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(negate(bs::Nan<T>(), bs::One<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(negate(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(negate(bs::Minf<T>(), bs::Minf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(negate(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(negate(bs::Nan<T>(), bs::Zero<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(negate(bs::Zero<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(negate(bs::Nan<T>(), bs::Zero<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(negate(bs::One<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(negate(bs::Nan<T>(), bs::One<T>()), bs::Nan<r_t>(), 0.5);
 #endif
   STF_TYPE_IS(r_t, T);
-  STF_EQUAL(negate(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(negate(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(negate(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(negate(bs::One<T>(), bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(negate(bs::Two<T>(), bs::Mthree<T>()), bs::Mtwo<r_t>());
-  STF_EQUAL(negate(bs::Two<T>(), bs::Three<T>()), bs::Two<r_t>());
+  STF_ULP_EQUAL(negate(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(negate(bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(negate(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(negate(bs::One<T>(), bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(negate(bs::Two<T>(), bs::Mthree<T>()), bs::Mtwo<r_t>(), 0.5);
+  STF_ULP_EQUAL(negate(bs::Two<T>(), bs::Three<T>()), bs::Two<r_t>(), 0.5);
 }
 
 STF_CASE_TPL (" negate unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/negatenz.cpp
+++ b/test/function/scalar/negatenz.cpp
@@ -34,19 +34,19 @@ STF_CASE_TPL (" negatenz real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(negatenz(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(negatenz(bs::Minf<T>(), bs::Minf<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(negatenz(bs::Nan<T>(), bs::Zero<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(negatenz(bs::Nan<T>(), bs::Zero<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(negatenz(bs::Nan<T>(), bs::One<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(negatenz(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(negatenz(bs::Minf<T>(), bs::Minf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(negatenz(bs::Nan<T>(), bs::Zero<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(negatenz(bs::Nan<T>(), bs::Zero<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(negatenz(bs::Nan<T>(), bs::One<T>()), bs::Nan<r_t>(), 0.5);
 #endif
   STF_TYPE_IS(r_t, T);
-  STF_EQUAL(negatenz(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>());
-  STF_EQUAL(negatenz(bs::One<T>(), bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(negatenz(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(negatenz(bs::One<T>(), bs::Zero<T>()), bs::One<r_t>());
-  STF_EQUAL(negatenz(bs::Two<T>(), bs::Mthree<T>()), bs::Mtwo<r_t>());
-  STF_EQUAL(negatenz(bs::Two<T>(), bs::Three<T>()), bs::Two<r_t>());
+  STF_ULP_EQUAL(negatenz(bs::Mone<T>(), bs::Mone<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(negatenz(bs::One<T>(), bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(negatenz(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(negatenz(bs::One<T>(), bs::Zero<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(negatenz(bs::Two<T>(), bs::Mthree<T>()), bs::Mtwo<r_t>(), 0.5);
+  STF_ULP_EQUAL(negatenz(bs::Two<T>(), bs::Three<T>()), bs::Two<r_t>(), 0.5);
 }
 
 STF_CASE_TPL (" negatenz unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/negif.cpp
+++ b/test/function/scalar/negif.cpp
@@ -29,12 +29,12 @@ STF_CASE_TPL (" negif real",  STF_IEEE_TYPES)
   STF_TYPE_IS( r_t, T );
 
   // specific values tests
-  STF_EQUAL(negif(logical<T>(T(0)),T(1)), 1);
-  STF_EQUAL(negif(logical<T>(T(1)),T(1)), -1);
-  STF_EQUAL(negif(logical<T>(bs::Inf<T>()),T(1)), -1);
-  STF_EQUAL(negif(logical<T>(bs::Minf<T>()),T(1)), -1);
-  STF_EQUAL(negif(logical<T>(bs::Nan<T>()),T(1)), -1);
-  STF_EQUAL(negif(logical<T>(bs::Zero<T>()),T(1)), 1);
+  STF_ULP_EQUAL(negif(logical<T>(T(0)),T(1)), 1, 0.5);
+  STF_ULP_EQUAL(negif(logical<T>(T(1)),T(1)), -1, 0.5);
+  STF_ULP_EQUAL(negif(logical<T>(bs::Inf<T>()),T(1)), -1, 0.5);
+  STF_ULP_EQUAL(negif(logical<T>(bs::Minf<T>()),T(1)), -1, 0.5);
+  STF_ULP_EQUAL(negif(logical<T>(bs::Nan<T>()),T(1)), -1, 0.5);
+  STF_ULP_EQUAL(negif(logical<T>(bs::Zero<T>()),T(1)), 1, 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" negif signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/negifnot.cpp
+++ b/test/function/scalar/negifnot.cpp
@@ -29,12 +29,12 @@ STF_CASE_TPL (" negifnot real",  STF_IEEE_TYPES)
   STF_TYPE_IS( r_t, T );
 
   // specific values tests
-  STF_EQUAL(negifnot(logical<T>(T(0)),T(1)), -1);
-  STF_EQUAL(negifnot(logical<T>(T(1)),T(1)), 1);
-  STF_EQUAL(negifnot(logical<T>(bs::Inf<T>()),T(1)), 1);
-  STF_EQUAL(negifnot(logical<T>(bs::Minf<T>()),T(1)), 1);
-  STF_IEEE_EQUAL(negifnot(logical<T>(bs::Nan<T>()),T(1)), 1);
-  STF_EQUAL(negifnot(logical<T>(bs::Zero<T>()),T(1)), -1);
+  STF_ULP_EQUAL(negifnot(logical<T>(T(0)),T(1)), -1, 0.5);
+  STF_ULP_EQUAL(negifnot(logical<T>(T(1)),T(1)), 1, 0.5);
+  STF_ULP_EQUAL(negifnot(logical<T>(bs::Inf<T>()),T(1)), 1, 0.5);
+  STF_ULP_EQUAL(negifnot(logical<T>(bs::Minf<T>()),T(1)), 1, 0.5);
+  STF_ULP_EQUAL(negifnot(logical<T>(bs::Nan<T>()),T(1)), 1, 0.5);
+  STF_ULP_EQUAL(negifnot(logical<T>(bs::Zero<T>()),T(1)), -1, 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" negifnot signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/next.cpp
+++ b/test/function/scalar/next.cpp
@@ -34,14 +34,14 @@ STF_CASE_TPL (" next real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(next(bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(next(bs::Minf<T>()), bs::Valmin<r_t>());
-  STF_IEEE_EQUAL(next(bs::Nan<T>()), bs::Nan<r_t>());
-  STF_EQUAL(next(bs::Valmax<T>()), bs::Inf<r_t>());
+  STF_ULP_EQUAL(next(bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(next(bs::Minf<T>()), bs::Valmin<r_t>(), 0.5);
+  STF_ULP_EQUAL(next(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(next(bs::Valmax<T>()), bs::Inf<r_t>(), 0.5);
 #endif
-  STF_EQUAL(next(bs::Mone<T>()), bs::Mone<r_t>()+bs::Eps<r_t>()/2);
-  STF_EQUAL(next(bs::One<T>()), bs::One<r_t>()+bs::Eps<r_t>());
-  STF_EQUAL(next(bs::Zero<T>()), bs::Bitincrement<T>());
+  STF_ULP_EQUAL(next(bs::Mone<T>()), bs::Mone<r_t>()+bs::Eps<r_t>()/2, 0.5);
+  STF_ULP_EQUAL(next(bs::One<T>()), bs::One<r_t>()+bs::Eps<r_t>(), 0.5);
+  STF_ULP_EQUAL(next(bs::Zero<T>()), bs::Bitincrement<T>(), 0.5);
 }
 
 STF_CASE_TPL (" next unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/nextafter.cpp
+++ b/test/function/scalar/nextafter.cpp
@@ -31,12 +31,12 @@ STF_CASE_TPL (" nextafter real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, T);
 
   // specific values tests
-  STF_EQUAL(nextafter(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(nextafter(bs::Minf<T>(), bs::One<T>()), bs::Valmin<r_t>());
-  STF_IEEE_EQUAL(nextafter(bs::Nan<T>(), bs::One<T>()), bs::Nan<r_t>());
-  STF_EQUAL(nextafter(bs::One<T>(), bs::Inf<T>()), bs::One<r_t>()+bs::Eps<r_t>());
-  STF_EQUAL(nextafter(bs::Valmax<T>(), bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(nextafter(bs::Mone<T>(), bs::One<T>()), bs::Mone<r_t>()+bs::Eps<r_t>()/2);
-  STF_EQUAL(nextafter(bs::Zero<T>(), bs::One<T>()), bs::Bitincrement<T>());
+  STF_ULP_EQUAL(nextafter(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(nextafter(bs::Minf<T>(), bs::One<T>()), bs::Valmin<r_t>(), 0.5);
+  STF_ULP_EQUAL(nextafter(bs::Nan<T>(), bs::One<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(nextafter(bs::One<T>(), bs::Inf<T>()), bs::One<r_t>()+bs::Eps<r_t>(), 0.5);
+  STF_ULP_EQUAL(nextafter(bs::Valmax<T>(), bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(nextafter(bs::Mone<T>(), bs::One<T>()), bs::Mone<r_t>()+bs::Eps<r_t>()/2, 0.5);
+  STF_ULP_EQUAL(nextafter(bs::Zero<T>(), bs::One<T>()), bs::Bitincrement<T>(), 0.5);
 }
 

--- a/test/function/scalar/nextpow2.cpp
+++ b/test/function/scalar/nextpow2.cpp
@@ -36,12 +36,12 @@ STF_CASE_TPL (" nextpow2 real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(nextpow2(bs::Inf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(nextpow2(bs::Minf<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(nextpow2(bs::Inf<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(nextpow2(bs::Minf<T>()), bs::Zero<r_t>(), 0.5);
 #endif
-  STF_EQUAL(nextpow2(bs::Mone<T>()), bs::Zero<r_t>());
-  STF_EQUAL(nextpow2(bs::One<T>()), bs::Zero<r_t>());
-  STF_EQUAL(nextpow2(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(nextpow2(bs::Mone<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(nextpow2(bs::One<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(nextpow2(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 }
 
 STF_CASE_TPL (" nextpow2 unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/oneminus.cpp
+++ b/test/function/scalar/oneminus.cpp
@@ -64,12 +64,12 @@ STF_CASE_TPL(" oneminus floating", STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(oneminus(bs::Inf<T>()), bs::Minf<T>());
-  STF_IEEE_EQUAL(oneminus(bs::Nan<T>()), bs::Nan<T>());
-  STF_EQUAL(oneminus(bs::Minf<T>()), bs::Inf<T>());
+  STF_ULP_EQUAL(oneminus(bs::Inf<T>()), bs::Minf<T>(), 0.5);
+  STF_ULP_EQUAL(oneminus(bs::Nan<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(oneminus(bs::Minf<T>()), bs::Inf<T>(), 0.5);
 #endif
-  STF_EQUAL(oneminus(bs::One<T>()), bs::Zero<T>());
-  STF_EQUAL(oneminus(bs::Two<T>()), bs::Mone<T>());
-  STF_EQUAL(oneminus(bs::Zero<T>()), bs::One<T>());
+  STF_ULP_EQUAL(oneminus(bs::One<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(oneminus(bs::Two<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(oneminus(bs::Zero<T>()), bs::One<T>(), 0.5);
 }
 

--- a/test/function/scalar/oneminus.saturated.cpp
+++ b/test/function/scalar/oneminus.saturated.cpp
@@ -61,12 +61,12 @@ STF_CASE_TPL(" bs::saturated_(bs::oneminus) floating", STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bs::saturated_(bs::oneminus)(bs::Inf<T>()), bs::Minf<T>());
-  STF_IEEE_EQUAL(bs::saturated_(bs::oneminus)(bs::Nan<T>()), bs::Nan<T>());
-  STF_EQUAL(bs::saturated_(bs::oneminus)(bs::Minf<T>()), bs::Inf<T>());
+  STF_ULP_EQUAL(bs::saturated_(bs::oneminus)(bs::Inf<T>()), bs::Minf<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::oneminus)(bs::Nan<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::oneminus)(bs::Minf<T>()), bs::Inf<T>(), 0.5);
 #endif
-  STF_EQUAL(bs::saturated_(bs::oneminus)(bs::One<T>()), bs::Zero<T>());
-  STF_EQUAL(bs::saturated_(bs::oneminus)(bs::Two<T>()), bs::Mone<T>());
-  STF_EQUAL(bs::saturated_(bs::oneminus)(bs::Zero<T>()), bs::One<T>());
+  STF_ULP_EQUAL(bs::saturated_(bs::oneminus)(bs::One<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::oneminus)(bs::Two<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::oneminus)(bs::Zero<T>()), bs::One<T>(), 0.5);
 }
 

--- a/test/function/scalar/plus.cpp
+++ b/test/function/scalar/plus.cpp
@@ -24,12 +24,12 @@ STF_CASE_TPL( "Check plus behavior with floating", STF_IEEE_TYPES )
   using r_t = decltype(plus(T(), T()));
   STF_TYPE_IS(r_t, T);
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(plus(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(plus(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(plus(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(plus(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(plus(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(plus(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(plus(bs::One<T>(),bs::Zero<T>()), bs::One<r_t>());
-  STF_EQUAL(plus(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(plus(bs::One<T>(),bs::Zero<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(plus(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 }
 
 STF_CASE_TPL( "Check plus saturated behavior", STF_NUMERIC_TYPES )

--- a/test/function/scalar/plus.saturated.cpp
+++ b/test/function/scalar/plus.saturated.cpp
@@ -71,11 +71,11 @@ STF_CASE_TPL (" plus real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bs::saturated_(plus)(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<T>());
-  STF_EQUAL(bs::saturated_(plus)(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<T>());
-  STF_IEEE_EQUAL(bs::saturated_(plus)(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(bs::saturated_(plus)(bs::Inf<T>(), bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(plus)(bs::Minf<T>(), bs::Minf<T>()), bs::Minf<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(plus)(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(bs::saturated_(plus)(bs::Mone<T>(), bs::Mone<T>()), bs::Mtwo<T>());
-  STF_EQUAL(bs::saturated_(plus)(bs::One<T>(), bs::One<T>()), bs::Two<T>());
-  STF_EQUAL(bs::saturated_(plus)(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(bs::saturated_(plus)(bs::Mone<T>(), bs::Mone<T>()), bs::Mtwo<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(plus)(bs::One<T>(), bs::One<T>()), bs::Two<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(plus)(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>(), 0.5);
 } // end of test for floating_

--- a/test/function/scalar/popcnt.cpp
+++ b/test/function/scalar/popcnt.cpp
@@ -30,9 +30,9 @@ STF_CASE_TPL (" popcnt real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(popcnt(bs::Nan<T>()), sizeof(T)*8);
+  STF_ULP_EQUAL(popcnt(bs::Nan<T>()), sizeof(T)*8, 0.5);
 #endif
-  STF_EQUAL(popcnt(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(popcnt(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" popcnt integer",  STF_INTEGRAL_TYPES)

--- a/test/function/scalar/pow2.cpp
+++ b/test/function/scalar/pow2.cpp
@@ -31,16 +31,16 @@ STF_CASE_TPL (" pow2",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, T);
 
   // specific values tests
-  STF_EQUAL(pow2(bs::Inf<T>(),  2), bs::Inf<r_t>());
-  STF_EQUAL(pow2(bs::Minf<T>(), 2), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(pow2(bs::Nan<T>(),  2), bs::Nan<r_t>());
-  STF_EQUAL(pow2(bs::Inf<T>(),  T(2.5)), bs::Inf<r_t>());
-  STF_EQUAL(pow2(bs::Minf<T>(), T(2.5)), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(pow2(bs::Nan<T>(),  T(2.5)), bs::Nan<r_t>());
-  STF_EQUAL(pow2(bs::Mone<T>(), 2), -bs::Four<r_t>());
-  STF_EQUAL(pow2(bs::One<T>(),  2), bs::Four<r_t>());
-  STF_EQUAL(pow2(bs::Zero<T>(), 2), bs::Zero<r_t>());
-  STF_EQUAL(pow2(bs::Mone<T>(), T(2.5)), -bs::Four<r_t>());
-  STF_EQUAL(pow2(bs::One<T>(),  T(2.5)), bs::Four<r_t>());
-  STF_EQUAL(pow2(bs::Zero<T>(), T(2.5)), bs::Zero<r_t>());
+  STF_ULP_EQUAL(pow2(bs::Inf<T>(),  2), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(pow2(bs::Minf<T>(), 2), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(pow2(bs::Nan<T>(),  2), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(pow2(bs::Inf<T>(),  T(2.5)), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(pow2(bs::Minf<T>(), T(2.5)), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(pow2(bs::Nan<T>(),  T(2.5)), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(pow2(bs::Mone<T>(), 2), -bs::Four<r_t>(), 0.5);
+  STF_ULP_EQUAL(pow2(bs::One<T>(),  2), bs::Four<r_t>(), 0.5);
+  STF_ULP_EQUAL(pow2(bs::Zero<T>(), 2), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(pow2(bs::Mone<T>(), T(2.5)), -bs::Four<r_t>(), 0.5);
+  STF_ULP_EQUAL(pow2(bs::One<T>(),  T(2.5)), bs::Four<r_t>(), 0.5);
+  STF_ULP_EQUAL(pow2(bs::Zero<T>(), T(2.5)), bs::Zero<r_t>(), 0.5);
 }

--- a/test/function/scalar/predecessor.cpp
+++ b/test/function/scalar/predecessor.cpp
@@ -36,15 +36,15 @@ STF_CASE_TPL (" predecessor real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(predecessor(bs::Inf<T>()), bs::Valmax<r_t>());
-  STF_IEEE_EQUAL(predecessor(bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(predecessor(bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(predecessor(bs::Inf<T>()), bs::Valmax<r_t>(), 0.5);
+  STF_ULP_EQUAL(predecessor(bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(predecessor(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(predecessor(bs::Mone<T>()), bs::Mone<r_t>()-bs::Eps<r_t>());
-  STF_EQUAL(predecessor(bs::One<T>()), bs::One<r_t>()-bs::Halfeps<r_t>());
-  STF_EQUAL(predecessor(bs::Valmin<T>()), bs::Minf<r_t>());
+  STF_ULP_EQUAL(predecessor(bs::Mone<T>()), bs::Mone<r_t>()-bs::Eps<r_t>(), 0.5);
+  STF_ULP_EQUAL(predecessor(bs::One<T>()), bs::One<r_t>()-bs::Halfeps<r_t>(), 0.5);
+  STF_ULP_EQUAL(predecessor(bs::Valmin<T>()), bs::Minf<r_t>(), 0.5);
 #if !defined(BOOST_SIMD_NO_DENORMALS)
-  STF_EQUAL(predecessor(bs::Zero<T>()), -bs::Bitincrement<T>());
+  STF_ULP_EQUAL(predecessor(bs::Zero<T>()), -bs::Bitincrement<T>(), 0.5);
 #endif
 } // end of test for floating_
 
@@ -96,15 +96,15 @@ STF_CASE_TPL (" predecessor real 2",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, T);
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(predecessor(bs::Minf<T>(), bs::Two<iT>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(predecessor(bs::Nan<T>(), bs::Two<iT>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(predecessor(bs::Minf<T>(), bs::Two<iT>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(predecessor(bs::Nan<T>(), bs::Two<iT>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(predecessor(bs::Mone<T>(), bs::Two<iT>()), bs::Mone<r_t>()-bs::Eps<r_t>()-bs::Eps<r_t>());
-  STF_EQUAL(predecessor(bs::One<T>(), bs::Two<iT>()), bs::One<r_t>()-bs::Eps<r_t>());
-  STF_IEEE_EQUAL(predecessor(bs::Valmin<T>(), bs::Two<iT>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(predecessor(bs::Valmin<T>(), bs::Four<iT>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(predecessor(bs::Mone<T>(), bs::Two<iT>()), bs::Mone<r_t>()-bs::Eps<r_t>()-bs::Eps<r_t>(), 0.5);
+  STF_ULP_EQUAL(predecessor(bs::One<T>(), bs::Two<iT>()), bs::One<r_t>()-bs::Eps<r_t>(), 0.5);
+  STF_ULP_EQUAL(predecessor(bs::Valmin<T>(), bs::Two<iT>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(predecessor(bs::Valmin<T>(), bs::Four<iT>()), bs::Nan<r_t>(), 0.5);
 #if !defined(BOOST_SIMD_NO_DENORMALS)
-  STF_EQUAL(predecessor(bs::Zero<T>(), bs::Two<iT>()), -bs::Bitincrement<r_t>()-bs::Bitincrement<r_t>());
+  STF_ULP_EQUAL(predecessor(bs::Zero<T>(), bs::Two<iT>()), -bs::Bitincrement<r_t>()-bs::Bitincrement<r_t>(), 0.5);
 #endif
 }
 

--- a/test/function/scalar/prev.cpp
+++ b/test/function/scalar/prev.cpp
@@ -37,14 +37,14 @@ STF_CASE_TPL (" prev real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(prev(bs::Inf<T>()), bs::Valmax<r_t>());
-  STF_EQUAL(prev(bs::Minf<T>()), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(prev(bs::Nan<T>()), bs::Nan<r_t>());
-  STF_EQUAL(prev(bs::Valmin<T>()), bs::Minf<r_t>());
+  STF_ULP_EQUAL(prev(bs::Inf<T>()), bs::Valmax<r_t>(), 0.5);
+  STF_ULP_EQUAL(prev(bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(prev(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(prev(bs::Valmin<T>()), bs::Minf<r_t>(), 0.5);
 #endif
-  STF_EQUAL(prev(bs::Mone<T>()), bs::Mone<r_t>()-bs::Eps<r_t>());
-  STF_EQUAL(prev(bs::One<T>()), bs::One<r_t>()-bs::Eps<r_t>()/2);
-  STF_EQUAL(prev(bs::Zero<T>()), -bs::Bitincrement<T>());
+  STF_ULP_EQUAL(prev(bs::Mone<T>()), bs::Mone<r_t>()-bs::Eps<r_t>(), 0.5);
+  STF_ULP_EQUAL(prev(bs::One<T>()), bs::One<r_t>()-bs::Eps<r_t>()/2, 0.5);
+  STF_ULP_EQUAL(prev(bs::Zero<T>()), -bs::Bitincrement<T>(), 0.5);
 }
 
 STF_CASE_TPL (" prev unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/rec.cpp
+++ b/test/function/scalar/rec.cpp
@@ -28,13 +28,13 @@ STF_CASE_TPL("regular rec",  STF_IEEE_TYPES)
   STF_EXPR_IS( rec(T()) , T );
 
   // specific values tests
-  STF_EQUAL(rec(bs::Inf<T>()), bs::Zero<T>());
-  STF_EQUAL(rec(bs::Minf<T>()), bs::Zero<T>());
-  STF_EQUAL(rec(bs::Mone<T>()), bs::Mone<T>());
-  STF_EQUAL(rec(bs::Mzero<T>()), bs::Minf<T>());
-  STF_IEEE_EQUAL(rec(bs::Nan<T>()), bs::Nan<T>());
-  STF_EQUAL(rec(bs::One<T>()), bs::One<T>());
-  STF_EQUAL(rec(bs::Zero<T>()), bs::Inf<T>());
+  STF_ULP_EQUAL(rec(bs::Inf<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(rec(bs::Minf<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(rec(bs::Mone<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(rec(bs::Mzero<T>()), bs::Minf<T>(), 0.5);
+  STF_ULP_EQUAL(rec(bs::Nan<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rec(bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(rec(bs::Zero<T>()), bs::Inf<T>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL("fast rec",  STF_IEEE_TYPES)

--- a/test/function/scalar/rem/rem.ceil.cpp
+++ b/test/function/scalar/rem/rem.ceil.cpp
@@ -30,17 +30,17 @@ STF_CASE_TPL (" rem ceil real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(rem(bs::ceil, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::ceil, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::ceil, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::ceil, bs::Inf<T>(), bs::One<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::ceil, bs::One<T>(), bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::ceil, bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(rem(bs::ceil, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::ceil, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::ceil, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::ceil, bs::Inf<T>(), bs::One<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::ceil, bs::One<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::ceil, bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(rem(bs::ceil, bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>());
-  STF_EQUAL(rem(bs::ceil, bs::One<T>(), bs::One<T>()), bs::Zero<T>());
-  STF_IEEE_EQUAL(rem(bs::ceil, bs::One<T>(),bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::ceil, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(rem(bs::ceil, bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::ceil, bs::One<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::ceil, bs::One<T>(),bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::ceil, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<T>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" rem ceil signed_int",  STF_SIGNED_INTEGRAL_TYPES)
@@ -72,18 +72,18 @@ STF_CASE_TPL (" remp ceil fast",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::ceil, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::ceil, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::ceil, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::ceil, bs::Inf<T>(), bs::One<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::ceil, bs::Minf<T>(), bs::One<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::ceil, bs::One<T>(), bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::ceil, bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::ceil, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::ceil, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::ceil, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::ceil, bs::Inf<T>(), bs::One<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::ceil, bs::Minf<T>(), bs::One<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::ceil, bs::One<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::ceil, bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(bs::fast_(rem)(bs::ceil, bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>());
-  STF_EQUAL(bs::fast_(rem)(bs::ceil, bs::One<T>(), bs::One<T>()), bs::Zero<T>());
-  STF_EQUAL(bs::fast_(rem)(bs::ceil, bs::Two<T>(), bs::Three<T>()), bs::Mone<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::ceil, bs::Two<T>(), bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::ceil, bs::Two<T>(), bs::Mzero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::ceil, bs::Zero<T>(), bs::One<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::ceil, bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::ceil, bs::One<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::ceil, bs::Two<T>(), bs::Three<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::ceil, bs::Two<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::ceil, bs::Two<T>(), bs::Mzero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::ceil, bs::Zero<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
 } // end of test for signed_int_

--- a/test/function/scalar/rem/rem.cpp
+++ b/test/function/scalar/rem/rem.cpp
@@ -31,17 +31,17 @@ STF_CASE_TPL (" rem real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(rem(bs::Inf<T>(), bs::Inf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::Inf<T>(), bs::One<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::One<T>(), bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(rem(bs::Inf<T>(), bs::Inf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::Inf<T>(), bs::One<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::One<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(rem(bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>());
-  STF_EQUAL(rem(bs::One<T>(), bs::One<T>()), bs::Zero<T>());
-  STF_IEEE_EQUAL(rem(bs::One<T>(),bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(rem(bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::One<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::One<T>(),bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
   STF_EXPECT(bs::is_negative(rem(-T(0), T(1))));
   STF_EXPECT(bs::is_positive(rem(T(0), T(1))));
 } // end of test for floating_
@@ -104,9 +104,9 @@ STF_CASE_TPL (" rem std",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, T);
 
   // specific values tests
-  STF_EQUAL(bs::std_(rem)(bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>());
-  STF_EQUAL(bs::std_(rem)(bs::One<T>(), bs::One<T>()), bs::Zero<T>());
-  STF_EQUAL(bs::std_(rem)(T(3), T(2)), bs::One<T>());
+  STF_ULP_EQUAL(bs::std_(rem)(bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(rem)(bs::One<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(rem)(T(3), T(2)), bs::One<T>(), 0.5);
 } // end of test for signed_int_
 
 STF_CASE_TPL (" rem option fix",  STF_IEEE_TYPES)
@@ -120,9 +120,9 @@ STF_CASE_TPL (" rem option fix",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, T);
 
   // specific values tests
-  STF_EQUAL(rem(bs::fix, bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>());
-  STF_EQUAL(rem(bs::fix, bs::One<T>(), bs::One<T>()), bs::Zero<T>());
-  STF_EQUAL(rem(bs::fix, T(3), T(2)), bs::One<T>());
+  STF_ULP_EQUAL(rem(bs::fix, bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::fix, bs::One<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::fix, T(3), T(2)), bs::One<T>(), 0.5);
 } // end of test for signed_int_
 
   STF_CASE_TPL (" fast_ rem option fix",  STF_IEEE_TYPES)
@@ -137,18 +137,18 @@ STF_CASE_TPL (" rem option fix",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::fix, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::fix, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::fix, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::fix, bs::Inf<T>(), bs::One<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::fix, bs::Minf<T>(), bs::One<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::fix, bs::One<T>(), bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::fix, bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::fix, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::fix, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::fix, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::fix, bs::Inf<T>(), bs::One<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::fix, bs::Minf<T>(), bs::One<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::fix, bs::One<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::fix, bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(bs::fast_(rem)(bs::fix, bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>());
-  STF_EQUAL(bs::fast_(rem)(bs::fix, bs::One<T>(), bs::One<T>()), bs::Zero<T>());
-  STF_EQUAL(bs::fast_(rem)(bs::fix, T(3), T(2)), bs::One<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::fix, bs::Two<T>(), bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::fix, bs::Two<T>(), bs::Mzero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::fix, bs::Zero<T>(), bs::One<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::fix, bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::fix, bs::One<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::fix, T(3), T(2)), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::fix, bs::Two<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::fix, bs::Two<T>(), bs::Mzero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::fix, bs::Zero<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
 } // end of test for signed_int_

--- a/test/function/scalar/rem/rem.floor.cpp
+++ b/test/function/scalar/rem/rem.floor.cpp
@@ -32,17 +32,17 @@ STF_CASE_TPL (" remfloor real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(rem(bs::floor, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::floor, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::floor, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::floor, bs::Inf<T>(), bs::One<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::floor, bs::One<T>(), bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::floor, bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(rem(bs::floor, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::floor, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::floor, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::floor, bs::Inf<T>(), bs::One<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::floor, bs::One<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::floor, bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(rem(bs::floor, bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>());
-  STF_EQUAL(rem(bs::floor, bs::One<T>(), bs::One<T>()), bs::Zero<T>());
-  STF_IEEE_EQUAL(rem(bs::floor, bs::One<T>(),bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::floor, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(rem(bs::floor, bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::floor, bs::One<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::floor, bs::One<T>(),bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::floor, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<T>(), 0.5);
   STF_EXPECT(bs::is_negative(rem(bs::floor,-T(0), T(1))));
   STF_EXPECT(bs::is_positive(rem(bs::floor,T(0), T(1))));
 } // end of test for floating_
@@ -76,18 +76,18 @@ STF_CASE_TPL (" rem floor fast",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::floor, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::floor, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::floor, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::floor, bs::Inf<T>(), bs::One<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::floor, bs::Minf<T>(), bs::One<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::floor, bs::One<T>(), bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::floor, bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::floor, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::floor, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::floor, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::floor, bs::Inf<T>(), bs::One<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::floor, bs::Minf<T>(), bs::One<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::floor, bs::One<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::floor, bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(bs::fast_(rem)(bs::floor, bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>());
-  STF_EQUAL(bs::fast_(rem)(bs::floor, bs::One<T>(), bs::One<T>()), bs::Zero<T>());
-  STF_EQUAL(bs::fast_(rem)(bs::floor, bs::Two<T>(), bs::Three<T>()), bs::Two<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::floor, bs::Two<T>(), bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::floor, bs::Two<T>(), bs::Mzero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::floor, bs::Zero<T>(), bs::One<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::floor, bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::floor, bs::One<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::floor, bs::Two<T>(), bs::Three<T>()), bs::Two<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::floor, bs::Two<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::floor, bs::Two<T>(), bs::Mzero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::floor, bs::Zero<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
 } // end of test for signed_int_

--- a/test/function/scalar/rem/rem.nearbyint.cpp
+++ b/test/function/scalar/rem/rem.nearbyint.cpp
@@ -30,17 +30,17 @@ STF_CASE_TPL (" remainder real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(rem(bs::nearbyint, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::nearbyint, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::nearbyint, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::floor, bs::Inf<T>(), bs::One<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::floor, bs::One<T>(), bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::floor, bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(rem(bs::nearbyint, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::nearbyint, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::nearbyint, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::floor, bs::Inf<T>(), bs::One<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::floor, bs::One<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::floor, bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(rem(bs::nearbyint, bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>());
-  STF_EQUAL(rem(bs::nearbyint, bs::One<T>(), bs::One<T>()), bs::Zero<T>());
-  STF_IEEE_EQUAL(rem(bs::nearbyint, bs::One<T>(),bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::nearbyint, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(rem(bs::nearbyint, bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::nearbyint, bs::One<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::nearbyint, bs::One<T>(),bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::nearbyint, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<T>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" remainder signed_int",  STF_SIGNED_INTEGRAL_TYPES)
@@ -73,18 +73,18 @@ STF_CASE_TPL (" rem nearbyint fast",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Inf<T>(), bs::One<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Minf<T>(), bs::One<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::One<T>(), bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Inf<T>(), bs::One<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Minf<T>(), bs::One<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::One<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>());
-  STF_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::One<T>(), bs::One<T>()), bs::Zero<T>());
-  STF_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Two<T>(), bs::Three<T>()), bs::Mone<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Two<T>(), bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Two<T>(), bs::Mzero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Zero<T>(), bs::One<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::One<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Two<T>(), bs::Three<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Two<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Two<T>(), bs::Mzero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::nearbyint, bs::Zero<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
 } // end of test for signed_int_

--- a/test/function/scalar/rem/rem.round.cpp
+++ b/test/function/scalar/rem/rem.round.cpp
@@ -32,17 +32,17 @@ STF_CASE_TPL (" remainder real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(rem(bs::round, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::round, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::round, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::floor, bs::Inf<T>(), bs::One<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::floor, bs::One<T>(), bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::floor, bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(rem(bs::round, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::round, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::round, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::floor, bs::Inf<T>(), bs::One<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::floor, bs::One<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::floor, bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(rem(bs::round, bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>());
-  STF_EQUAL(rem(bs::round, bs::One<T>(), bs::One<T>()), bs::Zero<T>());
-  STF_IEEE_EQUAL(rem(bs::round, bs::One<T>(),bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(rem(bs::round, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(rem(bs::round, bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::round, bs::One<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::round, bs::One<T>(),bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(rem(bs::round, bs::Zero<T>(),bs::Zero<T>()), bs::Nan<T>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" remainder signed_int",  STF_SIGNED_INTEGRAL_TYPES)
@@ -74,18 +74,18 @@ STF_CASE_TPL (" rem round fast",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::round, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::round, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::round, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::round, bs::Inf<T>(), bs::One<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::round, bs::Minf<T>(), bs::One<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::round, bs::One<T>(), bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::round, bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::round, bs::Inf<T>(), bs::Inf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::round, bs::Minf<T>(), bs::Minf<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::round, bs::Nan<T>(), bs::Nan<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::round, bs::Inf<T>(), bs::One<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::round, bs::Minf<T>(), bs::One<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::round, bs::One<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::round, bs::Zero<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(bs::fast_(rem)(bs::round, bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>());
-  STF_EQUAL(bs::fast_(rem)(bs::round, bs::One<T>(), bs::One<T>()), bs::Zero<T>());
-  STF_EQUAL(bs::fast_(rem)(bs::round, bs::Two<T>(), bs::Three<T>()), bs::Two<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::round, bs::Two<T>(), bs::Zero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::round, bs::Two<T>(), bs::Mzero<T>()), bs::Nan<T>());
-  STF_IEEE_EQUAL(bs::fast_(rem)(bs::round, bs::Zero<T>(), bs::One<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::round, bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::round, bs::One<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::round, bs::Two<T>(), bs::Three<T>()), bs::Two<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::round, bs::Two<T>(), bs::Zero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::round, bs::Two<T>(), bs::Mzero<T>()), bs::Nan<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(rem)(bs::round, bs::Zero<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
 } // end of test for signed_int_

--- a/test/function/scalar/remquo.cpp
+++ b/test/function/scalar/remquo.cpp
@@ -41,28 +41,28 @@ STF_CASE_TPL(" remquo invalid", STF_IEEE_TYPES)
   std::pair<T,iT> p;
 
   p =  remquo(one_,nan_);
-  STF_IEEE_EQUAL(p.first, nan_);
+  STF_ULP_EQUAL(p.first, nan_, 0.5);
 
   p =  remquo(one_,inf_);
-  STF_IEEE_EQUAL(p.first, nan_);
+  STF_ULP_EQUAL(p.first, nan_, 0.5);
 
   p =  remquo(one_,zero_);
-  STF_IEEE_EQUAL(p.first, nan_);
+  STF_ULP_EQUAL(p.first, nan_, 0.5);
 
   p =  remquo(inf_,zero_);
-  STF_IEEE_EQUAL(p.first, nan_);
+  STF_ULP_EQUAL(p.first, nan_, 0.5);
 
   p =  remquo(nan_,zero_);
-  STF_IEEE_EQUAL(p.first, nan_);
+  STF_ULP_EQUAL(p.first, nan_, 0.5);
 
   p =  remquo(nan_,one_);
-  STF_IEEE_EQUAL(p.first, nan_);
+  STF_ULP_EQUAL(p.first, nan_, 0.5);
 
   p =  remquo(nan_,nan_);
-  STF_IEEE_EQUAL(p.first, nan_);
+  STF_ULP_EQUAL(p.first, nan_, 0.5);
 
   p =  remquo(nan_,inf_);
-  STF_IEEE_EQUAL(p.first, nan_);
+  STF_ULP_EQUAL(p.first, nan_, 0.5);
 }
 #endif
 
@@ -88,7 +88,7 @@ STF_CASE_TPL(" remquo valid", STF_IEEE_TYPES)
   for(std::size_t i=0;i<nb;++i)
   {
     p = remquo(a0[i],a1[i]);
-    STF_EQUAL(p.second, iT(a0[i] / a1[i]));
-    STF_EQUAL(p.first, a0[i] - p.second*a1[i]);
+    STF_ULP_EQUAL(p.second, iT(a0[i] / a1[i]), 0.5);
+    STF_ULP_EQUAL(p.first, a0[i] - p.second*a1[i], 0.5);
   }
 }

--- a/test/function/scalar/rol.cpp
+++ b/test/function/scalar/rol.cpp
@@ -45,9 +45,9 @@ STF_CASE_TPL (" rolreal", STF_IEEE_TYPES)
   iT w = sizeof(T)*CHAR_BIT;
 
   for(iT i=0;i<w;++i)
-    STF_EQUAL( rol(bitwise_cast<T>(iT(1)),iT(i))
+    STF_ULP_EQUAL( rol(bitwise_cast<T>(iT(1)),iT(i))
                   , bitwise_cast<T>(iT(1)<<i)
-                  );
+                  , 0.5);
 /*
   STF_ASSERT(rol(T(1),iT(-1)));
   STF_ASSERT(rol(T(1),iT(w+1)));

--- a/test/function/scalar/ror.cpp
+++ b/test/function/scalar/ror.cpp
@@ -47,9 +47,9 @@ STF_CASE_TPL (" rorreal", STF_IEEE_TYPES)
   iT w = sizeof(T)*CHAR_BIT;
 
   for(iT i=0;i<w;++i)
-    STF_EQUAL( ror(bitwise_cast<T>(iT(1)),i)
+    STF_ULP_EQUAL( ror(bitwise_cast<T>(iT(1)),i)
                   , bitwise_cast<T>(iT(1)<<((w-i) & (w-1)))
-                  );
+                 , 0.5);
 /*
   STF_ASSERT(ror(T(1),iT(-1)));
   STF_ASSERT(ror(T(1),iT(w+1)));

--- a/test/function/scalar/round.cpp
+++ b/test/function/scalar/round.cpp
@@ -36,31 +36,31 @@ STF_CASE_TPL (" round real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(round(bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(round(bs::Minf<T>()), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(round(bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(round(bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(round(bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(round(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(round(bs::Mhalf<T>()), bs::Mone<r_t>());
-  STF_EQUAL(round(bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(round(bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(round(bs::Zero<T>()), bs::Zero<r_t>());
-  STF_EQUAL(round(bs::Maxflint<T>()-bs::Half<T>()),bs::Maxflint<T>());
-  STF_EQUAL(round(bs::Maxflint<T>()),bs::Maxflint<T>());
-  STF_EQUAL(round(T(1.4)), T(1));
-  STF_EQUAL(round(T(1.5)), T(2));
-  STF_EQUAL(round(T(1.6)), T(2));
-  STF_EQUAL(round(T(2.5)), T(3));
-  STF_EQUAL(round(T(-1.4)), T(-1));
-  STF_EQUAL(round(T(-1.5)), T(-2));
-  STF_EQUAL(round(T(-1.6)), T(-2));
-  STF_EQUAL(round(T(-2.5)), T(-3));
-  STF_EQUAL(round(bs::Half<T>()), bs::One<r_t>());
-  STF_EQUAL(round(prev(prev(bs::Half<T>()))),  bs::Zero<T>());
-  STF_EQUAL(round(prev(bs::Half<T>())),  bs::Zero<T>());
-  STF_EQUAL(round(     bs::Half<T>()) ,  bs::One <T>());
-  STF_EQUAL(round(next(bs::Half<T>())),  bs::One <T>());
+  STF_ULP_EQUAL(round(bs::Mhalf<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(round(bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(round(bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(round(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(round(bs::Maxflint<T>()-bs::Half<T>()),bs::Maxflint<T>(), 0.5);
+  STF_ULP_EQUAL(round(bs::Maxflint<T>()),bs::Maxflint<T>(), 0.5);
+  STF_ULP_EQUAL(round(T(1.4)), T(1), 0.5);
+  STF_ULP_EQUAL(round(T(1.5)), T(2), 0.5);
+  STF_ULP_EQUAL(round(T(1.6)), T(2), 0.5);
+  STF_ULP_EQUAL(round(T(2.5)), T(3), 0.5);
+  STF_ULP_EQUAL(round(T(-1.4)), T(-1), 0.5);
+  STF_ULP_EQUAL(round(T(-1.5)), T(-2), 0.5);
+  STF_ULP_EQUAL(round(T(-1.6)), T(-2), 0.5);
+  STF_ULP_EQUAL(round(T(-2.5)), T(-3), 0.5);
+  STF_ULP_EQUAL(round(bs::Half<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(round(prev(prev(bs::Half<T>()))),  bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(round(prev(bs::Half<T>())),  bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(round(     bs::Half<T>()) ,  bs::One <T>(), 0.5);
+  STF_ULP_EQUAL(round(next(bs::Half<T>())),  bs::One <T>(), 0.5);
   T z = bs::Maxflint < T>()/T(2)+T(1);
-  STF_EQUAL(round(z), z);
+  STF_ULP_EQUAL(round(z), z, 0.5);
 
 } // end of test for floating_
 
@@ -78,24 +78,24 @@ STF_CASE_TPL (" round real2", STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(round(bs::Inf<T>(), 2), bs::Inf<r_t>());
-  STF_EQUAL(round(bs::Minf<T>(), 2), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(round(bs::Nan<T>(), 2), bs::Nan<r_t>());
+  STF_ULP_EQUAL(round(bs::Inf<T>(), 2), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(round(bs::Minf<T>(), 2), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(round(bs::Nan<T>(), 2), bs::Nan<r_t>(), 0.5);
 #endif
-   STF_EQUAL(round(bs::Mhalf<T>(), 2), bs::Mhalf<T>());
-  STF_EQUAL(round(bs::Mone<T>(), 2), bs::Mone<r_t>());
-  STF_EQUAL(round(bs::One<T>(), 2), bs::One<r_t>());
-  STF_EQUAL(round(bs::Zero<T>(), 2), bs::Zero<r_t>());
-  STF_EQUAL(round(bs::Maxflint<T>()-bs::Half<T>(), 2),bs::Maxflint<T>());
-  STF_EQUAL(round(bs::Maxflint<T>(), 2),bs::Maxflint<T>());
-  STF_EQUAL(round(T(1.44), 1), T(1.4));
-  STF_EQUAL(round(T(1.45), 1), T(1.5));
-  STF_EQUAL(round(T(1.46), 1), T(1.5));
-  STF_EQUAL(round(T(2.45), 1), T(2.5));
-  STF_EQUAL(round(T(-1.44), 1), T(-1.4));
-  STF_EQUAL(round(T(-1.45), 1), T(-1.5));
-  STF_EQUAL(round(T(-1.46), 1), T(-1.5));
-  STF_EQUAL(round(T(-2.45), 1), T(-2.5));
+   STF_ULP_EQUAL(round(bs::Mhalf<T>(), 2), bs::Mhalf<T>(), 0.5);
+  STF_ULP_EQUAL(round(bs::Mone<T>(), 2), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(round(bs::One<T>(), 2), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(round(bs::Zero<T>(), 2), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(round(bs::Maxflint<T>()-bs::Half<T>(), 2),bs::Maxflint<T>(), 0.5);
+  STF_ULP_EQUAL(round(bs::Maxflint<T>(), 2),bs::Maxflint<T>(), 0.5);
+  STF_ULP_EQUAL(round(T(1.44), 1), T(1.4), 0.5);
+  STF_ULP_EQUAL(round(T(1.45), 1), T(1.5), 0.5);
+  STF_ULP_EQUAL(round(T(1.46), 1), T(1.5), 0.5);
+  STF_ULP_EQUAL(round(T(2.45), 1), T(2.5), 0.5);
+  STF_ULP_EQUAL(round(T(-1.44), 1), T(-1.4), 0.5);
+  STF_ULP_EQUAL(round(T(-1.45), 1), T(-1.5), 0.5);
+  STF_ULP_EQUAL(round(T(-1.46), 1), T(-1.5), 0.5);
+  STF_ULP_EQUAL(round(T(-2.45), 1), T(-2.5), 0.5);
   STF_ULP_EQUAL(round(T(145), -2), T(100), 0.5);
   STF_ULP_EQUAL(round(T(150), -2), T(200), 0.5);
   STF_ULP_EQUAL(round(T(156), -2), T(200), 0.5);
@@ -121,24 +121,24 @@ STF_CASE_TPL (" round real2u", STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(round(bs::Inf<T>(), 2u), bs::Inf<r_t>());
-  STF_EQUAL(round(bs::Minf<T>(), 2u), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(round(bs::Nan<T>(), 2u), bs::Nan<r_t>());
+  STF_ULP_EQUAL(round(bs::Inf<T>(), 2u), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(round(bs::Minf<T>(), 2u), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(round(bs::Nan<T>(), 2u), bs::Nan<r_t>(), 0.5);
 #endif
-   STF_EQUAL(round(bs::Mhalf<T>(), 2u), bs::Mhalf<T>());
-  STF_EQUAL(round(bs::Mone<T>(), 2u), bs::Mone<r_t>());
-  STF_EQUAL(round(bs::One<T>(), 2u), bs::One<r_t>());
-  STF_EQUAL(round(bs::Zero<T>(), 2u), bs::Zero<r_t>());
-  STF_EQUAL(round(bs::Maxflint<T>()-bs::Half<T>(), 2u),bs::Maxflint<T>());
-  STF_EQUAL(round(bs::Maxflint<T>(), 2u),bs::Maxflint<T>());
-  STF_EQUAL(round(T(1.44), 1u), T(1.4));
-  STF_EQUAL(round(T(1.45), 1u), T(1.5));
-  STF_EQUAL(round(T(1.46), 1u), T(1.5));
-  STF_EQUAL(round(T(2.45), 1u), T(2.5));
-  STF_EQUAL(round(T(-1.44), 1u), T(-1.4));
-  STF_EQUAL(round(T(-1.45), 1u), T(-1.5));
-  STF_EQUAL(round(T(-1.46), 1u), T(-1.5));
-  STF_EQUAL(round(T(-2.45), 1u), T(-2.5));
+   STF_ULP_EQUAL(round(bs::Mhalf<T>(), 2u), bs::Mhalf<T>(), 0.5);
+  STF_ULP_EQUAL(round(bs::Mone<T>(), 2u), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(round(bs::One<T>(), 2u), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(round(bs::Zero<T>(), 2u), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(round(bs::Maxflint<T>()-bs::Half<T>(), 2u),bs::Maxflint<T>(), 0.5);
+  STF_ULP_EQUAL(round(bs::Maxflint<T>(), 2u),bs::Maxflint<T>(), 0.5);
+  STF_ULP_EQUAL(round(T(1.44), 1u), T(1.4), 0.5);
+  STF_ULP_EQUAL(round(T(1.45), 1u), T(1.5), 0.5);
+  STF_ULP_EQUAL(round(T(1.46), 1u), T(1.5), 0.5);
+  STF_ULP_EQUAL(round(T(2.45), 1u), T(2.5), 0.5);
+  STF_ULP_EQUAL(round(T(-1.44), 1u), T(-1.4), 0.5);
+  STF_ULP_EQUAL(round(T(-1.45), 1u), T(-1.5), 0.5);
+  STF_ULP_EQUAL(round(T(-1.46), 1u), T(-1.5), 0.5);
+  STF_ULP_EQUAL(round(T(-2.45), 1u), T(-2.5), 0.5);
  } // end of test for floating_
 
 STF_CASE_TPL (" roundunsigned_int__1_0",  STF_UNSIGNED_INTEGRAL_TYPES)
@@ -184,20 +184,20 @@ STF_CASE_TPL ( "round std",  STF_IEEE_TYPES)
   STF_TYPE_IS( r_t, T );
 
   // specific values tests
-  STF_IEEE_EQUAL(bs::std_(round)(T(-1.4)), -1);
-  STF_IEEE_EQUAL(bs::std_(round)(T(-1.5)), -2);
-  STF_IEEE_EQUAL(bs::std_(round)(T(-1.6)), -2);
-  STF_IEEE_EQUAL(bs::std_(round)(T(-2.5)), -3);
-   STF_IEEE_EQUAL(bs::std_(round)(T(1.4)), 1);
-  STF_IEEE_EQUAL(bs::std_(round)(T(1.5)), 2);
-  STF_IEEE_EQUAL(bs::std_(round)(T(1.6)), 2);
-  STF_IEEE_EQUAL(bs::std_(round)(T(2.5)), 3);
-  STF_IEEE_EQUAL(bs::std_(round)(bs::Half<T>()), bs::One<r_t>());
-  STF_IEEE_EQUAL(bs::std_(round)(bs::Inf<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(bs::std_(round)(bs::Mhalf<T>()), bs::Mone<r_t>());
-  STF_IEEE_EQUAL(bs::std_(round)(bs::Minf<T>()), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(bs::std_(round)(bs::Mone<T>()), bs::Mone<r_t>());
-  STF_IEEE_EQUAL(bs::std_(round)(bs::Nan<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(bs::std_(round)(bs::One<T>()), bs::One<r_t>());
-  STF_IEEE_EQUAL(bs::std_(round)(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(bs::std_(round)(T(-1.4)), -1, 0.5);
+  STF_ULP_EQUAL(bs::std_(round)(T(-1.5)), -2, 0.5);
+  STF_ULP_EQUAL(bs::std_(round)(T(-1.6)), -2, 0.5);
+  STF_ULP_EQUAL(bs::std_(round)(T(-2.5)), -3, 0.5);
+   STF_ULP_EQUAL(bs::std_(round)(T(1.4)), 1, 0.5);
+  STF_ULP_EQUAL(bs::std_(round)(T(1.5)), 2, 0.5);
+  STF_ULP_EQUAL(bs::std_(round)(T(1.6)), 2, 0.5);
+  STF_ULP_EQUAL(bs::std_(round)(T(2.5)), 3, 0.5);
+  STF_ULP_EQUAL(bs::std_(round)(bs::Half<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(round)(bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(round)(bs::Mhalf<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(round)(bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(round)(bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(round)(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(round)(bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::std_(round)(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 } // end of test for floating_

--- a/test/function/scalar/rsqrt.cpp
+++ b/test/function/scalar/rsqrt.cpp
@@ -33,14 +33,14 @@ STF_CASE_TPL (" rsqrtreal",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(rsqrt(bs::Inf<T>()), bs::Zero<r_t>());
-  STF_IEEE_EQUAL(rsqrt(bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(rsqrt(bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(rsqrt(bs::Inf<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(rsqrt(bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(rsqrt(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_IEEE_EQUAL(rsqrt(bs::Mone<T>()), bs::Nan<r_t>());
-  STF_EQUAL(rsqrt(bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(rsqrt(bs::Zero<T>()), bs::Inf<r_t>());
-  STF_EQUAL(rsqrt(bs::Four<T>()), bs::Half<r_t>());
+  STF_ULP_EQUAL(rsqrt(bs::Mone<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(rsqrt(bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(rsqrt(bs::Zero<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(rsqrt(bs::Four<T>()), bs::Half<r_t>(), 0.5);
   STF_ULP_EQUAL(rsqrt(T(0.5)), bs::Sqrt_2<T>(), 0.5);
   STF_ULP_EQUAL(rsqrt(T(0.01)), T(10), 0.5);
   STF_ULP_EQUAL(rsqrt(T(0.0001)), T(100), 0.5);

--- a/test/function/scalar/safe_max.cpp
+++ b/test/function/scalar/safe_max.cpp
@@ -31,13 +31,13 @@ STF_CASE_TPL (" safe_max real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(safe_max(bs::Zero<T>()), bs::Inf<r_t>());
-  STF_EQUAL(safe_max(bs::Inf<T>()), bs::Zero<r_t>());
-  STF_EQUAL(safe_max(bs::Minf<T>()), bs::Zero<r_t>());
-  STF_IEEE_EQUAL(safe_max(bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(safe_max(bs::Zero<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(safe_max(bs::Inf<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(safe_max(bs::Minf<T>()), bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(safe_max(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(safe_max(bs::Mone<T>()), bs::Sqrtvalmax<r_t>());
-  STF_EQUAL(safe_max(bs::One<T>()), bs::Sqrtvalmax<r_t>());
+  STF_ULP_EQUAL(safe_max(bs::Mone<T>()), bs::Sqrtvalmax<r_t>(), 0.5);
+  STF_ULP_EQUAL(safe_max(bs::One<T>()), bs::Sqrtvalmax<r_t>(), 0.5);
 }
 
 

--- a/test/function/scalar/safe_min.cpp
+++ b/test/function/scalar/safe_min.cpp
@@ -31,12 +31,12 @@ STF_CASE_TPL (" safe_minreal",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(safe_min(bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(safe_min(bs::Minf<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(safe_min(bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(safe_min(bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(safe_min(bs::Minf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(safe_min(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(safe_min(bs::Mone<T>()), bs::Sqrtsmallestposval<r_t>());
-  STF_EQUAL(safe_min(bs::One<T>()), bs::Sqrtsmallestposval<r_t>());
-  STF_EQUAL(safe_min(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(safe_min(bs::Mone<T>()), bs::Sqrtsmallestposval<r_t>(), 0.5);
+  STF_ULP_EQUAL(safe_min(bs::One<T>()), bs::Sqrtsmallestposval<r_t>(), 0.5);
+  STF_ULP_EQUAL(safe_min(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 }
 

--- a/test/function/scalar/saturate.cpp
+++ b/test/function/scalar/saturate.cpp
@@ -52,14 +52,14 @@ STF_CASE_TPL (" saturate floating with floating",  STF_IEEE_TYPES)
   using bs::Inf;
   using bs::Minf;
 
-  STF_EQUAL( saturate<T>(Valmax<float>()), Valmax<float>());
-  STF_EQUAL( saturate<T>(Valmax<double>()), double(Valmax<T>()));
-  STF_EQUAL( saturate<T>(Valmin<float>()), Valmin<float>());
-  STF_EQUAL( saturate<T>(Valmin<double>()), double(Valmin<T>()));
-  STF_EQUAL( saturate<T>(Inf<float>()), Inf<float>());
-  STF_EQUAL( saturate<T>(Inf<double>()), double(Inf<T>()));
-  STF_EQUAL( saturate<T>(Minf<float>()), Minf<float>());
-  STF_EQUAL( saturate<T>(Minf<double>()), double(Minf<T>()));
+  STF_ULP_EQUAL( saturate<T>(Valmax<float>()), Valmax<float>(), 0.5);
+  STF_ULP_EQUAL( saturate<T>(Valmax<double>()), double(Valmax<T>()), 0.5);
+  STF_ULP_EQUAL( saturate<T>(Valmin<float>()), Valmin<float>(), 0.5);
+  STF_ULP_EQUAL( saturate<T>(Valmin<double>()), double(Valmin<T>()), 0.5);
+  STF_ULP_EQUAL( saturate<T>(Inf<float>()), Inf<float>(), 0.5);
+  STF_ULP_EQUAL( saturate<T>(Inf<double>()), double(Inf<T>()), 0.5);
+  STF_ULP_EQUAL( saturate<T>(Minf<float>()), Minf<float>(), 0.5);
+  STF_ULP_EQUAL( saturate<T>(Minf<double>()), double(Minf<T>()), 0.5);
 
 }
 

--- a/test/function/scalar/sbits.cpp
+++ b/test/function/scalar/sbits.cpp
@@ -30,9 +30,9 @@ STF_CASE_TPL (" sbits real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(sbits(bs::Nan<T>()), bs::Mone<r_t>());
+  STF_ULP_EQUAL(sbits(bs::Nan<T>()), bs::Mone<r_t>(), 0.5);
 #endif
-  STF_EQUAL(sbits(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(sbits(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 }
 
 STF_CASE_TPL (" sbits unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/shift_left.cpp
+++ b/test/function/scalar/shift_left.cpp
@@ -50,6 +50,6 @@ STF_CASE_TPL (" shift_left_real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, wished_r_t);
 
   // specific values tests
-  STF_EQUAL(shift_left(bs::One<T>(),bs::Zero<iT>()), bs::One<r_t>());
-  STF_EQUAL(shift_left(bs::Zero<T>(),bs::One<iT>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(shift_left(bs::One<T>(),bs::Zero<iT>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(shift_left(bs::Zero<T>(),bs::One<iT>()), bs::Zero<r_t>(), 0.5);
 } // end of test for floating_

--- a/test/function/scalar/shift_right.cpp
+++ b/test/function/scalar/shift_right.cpp
@@ -46,6 +46,6 @@ STF_CASE_TPL (" shift_right real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, T);
 
   // specific values tests
-  STF_EQUAL(shift_right(bs::One<T>(),bs::Zero<iT>()), bs::One<r_t>());
-  STF_EQUAL(shift_right(bs::Zero<T>(),bs::One<iT>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(shift_right(bs::One<T>(),bs::Zero<iT>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(shift_right(bs::Zero<T>(),bs::One<iT>()), bs::Zero<r_t>(), 0.5);
 } // end of test for floating_

--- a/test/function/scalar/sign.cpp
+++ b/test/function/scalar/sign.cpp
@@ -29,13 +29,13 @@ STF_CASE_TPL (" sign real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(sign(bs::Inf<T>()), bs::One<r_t>());
-  STF_EQUAL(sign(bs::Minf<T>()), bs::Mone<r_t>());
-  STF_IEEE_EQUAL(sign(bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(sign(bs::Inf<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(sign(bs::Minf<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(sign(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(sign(bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(sign(bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(sign(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(sign(bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(sign(bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(sign(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 }
 
 STF_CASE_TPL (" sign unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/signbit.cpp
+++ b/test/function/scalar/signbit.cpp
@@ -34,18 +34,18 @@ STF_CASE_TPL (" signbit  _real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(signbit(bs::Inf<T>()), r_t(false));
-  STF_EQUAL(signbit(bs::Minf<T>()), r_t(true));
-  STF_EQUAL(signbit(bs::Nan<T>()), r_t(true));
+  STF_ULP_EQUAL(signbit(bs::Inf<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(signbit(bs::Minf<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(signbit(bs::Nan<T>()), r_t(true), 0.5);
 #endif
-  STF_EQUAL(signbit(-bs::Zero<T>()), r_t(true));
-  STF_EQUAL(signbit(bs::Half<T>()), r_t(false));
-  STF_EQUAL(signbit(bs::Mone<T>()), r_t(true));
-  STF_EQUAL(signbit(bs::One<T>()), r_t(false));
-  STF_EQUAL(signbit(bs::Quarter<T>()), r_t(false));
-  STF_EQUAL(signbit(bs::Two<T>()), r_t(false));
-  STF_EQUAL(signbit(bs::Zero<T>()), r_t(false));
-  STF_EQUAL(signbit(bs::Mzero<T>()), r_t(true));
+  STF_ULP_EQUAL(signbit(-bs::Zero<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(signbit(bs::Half<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(signbit(bs::Mone<T>()), r_t(true), 0.5);
+  STF_ULP_EQUAL(signbit(bs::One<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(signbit(bs::Quarter<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(signbit(bs::Two<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(signbit(bs::Zero<T>()), r_t(false), 0.5);
+  STF_ULP_EQUAL(signbit(bs::Mzero<T>()), r_t(true), 0.5);
 }
 
 STF_CASE_TPL (" signbit _signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/signnz.cpp
+++ b/test/function/scalar/signnz.cpp
@@ -29,14 +29,14 @@ STF_CASE_TPL (" signnz real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(signnz(bs::Inf<T>()), bs::One<r_t>());
-  STF_EQUAL(signnz(bs::Minf<T>()), bs::Mone<r_t>());
-  STF_IEEE_EQUAL(signnz(bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(signnz(bs::Inf<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(signnz(bs::Minf<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(signnz(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(signnz(bs::Mzero<T>()), bs::Mone<r_t>());
-  STF_EQUAL(signnz(bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(signnz(bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(signnz(bs::Zero<T>()), bs::One<r_t>());
+  STF_ULP_EQUAL(signnz(bs::Mzero<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(signnz(bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(signnz(bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(signnz(bs::Zero<T>()), bs::One<r_t>(), 0.5);
 }
 
 STF_CASE_TPL (" signnz unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/sqr.cpp
+++ b/test/function/scalar/sqr.cpp
@@ -30,13 +30,13 @@ STF_CASE_TPL (" sqr real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(sqr(bs::Inf<T>()), bs::Inf<T>());
-  STF_EQUAL(sqr(bs::Minf<T>()), bs::Inf<T>());
-  STF_IEEE_EQUAL(sqr(bs::Nan<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(sqr(bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(sqr(bs::Minf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(sqr(bs::Nan<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(sqr(bs::Mone<T>()), bs::One<T>());
-  STF_EQUAL(sqr(bs::One<T>()), bs::One<T>());
-  STF_EQUAL(sqr(bs::Zero<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(sqr(bs::Mone<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(sqr(bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(sqr(bs::Zero<T>()), bs::Zero<T>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" sqr unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/sqr.saturated.cpp
+++ b/test/function/scalar/sqr.saturated.cpp
@@ -31,16 +31,16 @@ STF_CASE_TPL (" bs::saturated_(sqr_s) real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bs::saturated_(sqr)(bs::Inf<T>()), bs::Inf<T>());
-  STF_EQUAL(bs::saturated_(sqr)(bs::Minf<T>()), bs::Inf<T>());
-  STF_IEEE_EQUAL(bs::saturated_(sqr)(bs::Nan<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(bs::saturated_(sqr)(bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(sqr)(bs::Minf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(sqr)(bs::Nan<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(bs::saturated_(sqr)(bs::One<T>()), bs::One<T>());
-  STF_EQUAL(bs::saturated_(sqr)(bs::Mone<T>()), bs::One<T>());
-  STF_EQUAL(bs::saturated_(sqr)(bs::Valmax<T>()), bs::Inf<T>());
-  STF_EQUAL(bs::saturated_(sqr)(bs::Valmin<T>()), bs::Inf<T>());
-  STF_EQUAL(bs::saturated_(sqr)(bs::Zero<T>()), bs::Zero<T>());
-  STF_EQUAL(bs::saturated_(sqr)(T(1)), T(1));
+  STF_ULP_EQUAL(bs::saturated_(sqr)(bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(sqr)(bs::Mone<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(sqr)(bs::Valmax<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(sqr)(bs::Valmin<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(sqr)(bs::Zero<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(sqr)(T(1)), T(1), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" bs::saturated_(sqr) unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/sqr_abs.cpp
+++ b/test/function/scalar/sqr_abs.cpp
@@ -30,16 +30,16 @@ STF_CASE_TPL (" sqr_abs real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(sqr_abs(bs::Inf<T>()), bs::Inf<T>());
-  STF_EQUAL(sqr_abs(bs::Minf<T>()), bs::Inf<T>());
-  STF_IEEE_EQUAL(sqr_abs(bs::Nan<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(sqr_abs(bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(sqr_abs(bs::Minf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(sqr_abs(bs::Nan<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(sqr_abs(bs::One<T>()), bs::One<T>());
-  STF_EQUAL(sqr_abs(bs::Mone<T>()), bs::One<T>());
-  STF_EQUAL(sqr_abs(bs::Valmax<T>()), bs::Inf<T>());
-  STF_EQUAL(sqr_abs(bs::Valmin<T>()), bs::Inf<T>());
-  STF_EQUAL(sqr_abs(bs::Zero<T>()), bs::Zero<T>());
-  STF_EQUAL(sqr_abs(T(1)), T(1));
+  STF_ULP_EQUAL(sqr_abs(bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(sqr_abs(bs::Mone<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(sqr_abs(bs::Valmax<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(sqr_abs(bs::Valmin<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(sqr_abs(bs::Zero<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(sqr_abs(T(1)), T(1), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" sqr_absunsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/successor.cpp
+++ b/test/function/scalar/successor.cpp
@@ -28,13 +28,13 @@ STF_CASE_TPL (" successor real",  STF_IEEE_TYPES)
   using r_t = decltype(successor(T()));
 
   // specific values tests
-  STF_IEEE_EQUAL(successor(bs::Inf<T>()), bs::Nan<r_t>());
-  STF_EQUAL(successor(bs::Minf<T>()), bs::Valmin<r_t>());
-  STF_EQUAL(successor(bs::Mone<T>()), bs::Mone<r_t>()+bs::Eps<r_t>()/2);
-  STF_IEEE_EQUAL(successor(bs::Nan<T>()), bs::Nan<r_t>());
-  STF_EQUAL(successor(bs::One<T>()), bs::One<r_t>()+bs::Eps<r_t>());
-  STF_EQUAL(successor(bs::Valmax<T>()), bs::Inf<r_t>());
-  STF_EQUAL(successor(bs::Zero<T>()), bs::Bitincrement<T>());
+  STF_ULP_EQUAL(successor(bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(successor(bs::Minf<T>()), bs::Valmin<r_t>(), 0.5);
+  STF_ULP_EQUAL(successor(bs::Mone<T>()), bs::Mone<r_t>()+bs::Eps<r_t>()/2, 0.5);
+  STF_ULP_EQUAL(successor(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(successor(bs::One<T>()), bs::One<r_t>()+bs::Eps<r_t>(), 0.5);
+  STF_ULP_EQUAL(successor(bs::Valmax<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(successor(bs::Zero<T>()), bs::Bitincrement<T>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" successor unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/tofloat.cpp
+++ b/test/function/scalar/tofloat.cpp
@@ -37,13 +37,13 @@ STF_CASE_TPL (" tofloat real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(tofloat(bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(tofloat(bs::Minf<T>()), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(tofloat(bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(tofloat(bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(tofloat(bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(tofloat(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(tofloat(bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(tofloat(bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(tofloat(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(tofloat(bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(tofloat(bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(tofloat(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" tofloat unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/toint.cpp
+++ b/test/function/scalar/toint.cpp
@@ -29,9 +29,9 @@ STF_CASE_TPL (" toint real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, (bd::as_integer_t<T, signed>));
 
   // specific values tests
-  STF_EQUAL(toint(bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(toint(bs::One<T>()),  bs::One<r_t>());
-  STF_EQUAL(toint(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(toint(bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(toint(bs::One<T>()),  bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(toint(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 
 } // end of test for floating_
 

--- a/test/function/scalar/toint.saturated.cpp
+++ b/test/function/scalar/toint.saturated.cpp
@@ -28,18 +28,18 @@ STF_CASE_TPL (" bs::saturated_(bs::toint) real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, (bd::as_integer_t<T, signed>));
 
   // specific values tests
-  STF_EQUAL(bs::saturated_(bs::toint)(T(2)*bs::Valmax<r_t>()),  bs::Valmax<r_t>());
-  STF_EQUAL(bs::saturated_(bs::toint)(T(2)*bs::Valmin<r_t>()),  bs::Valmin<r_t>());
-  STF_EQUAL(bs::saturated_(bs::toint)(T(1.5)*bs::Valmax<r_t>()),  bs::Valmax<r_t>());
-  STF_EQUAL(bs::saturated_(bs::toint)(T(1.5)*bs::Valmin<r_t>()),  bs::Valmin<r_t>());
+  STF_ULP_EQUAL(bs::saturated_(bs::toint)(T(2)*bs::Valmax<r_t>()),  bs::Valmax<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::toint)(T(2)*bs::Valmin<r_t>()),  bs::Valmin<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::toint)(T(1.5)*bs::Valmax<r_t>()),  bs::Valmax<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::toint)(T(1.5)*bs::Valmin<r_t>()),  bs::Valmin<r_t>(), 0.5);
 
 
-  STF_EQUAL(bs::saturated_(bs::toint)(bs::Inf<T>()),  bs::Inf<r_t>());
-  STF_EQUAL(bs::saturated_(bs::toint)(bs::Minf<T>()), bs::Minf<r_t>());
-  STF_EQUAL(bs::saturated_(bs::toint)(bs::Mone<T>()), bs::Mone<r_t>());
-  STF_EQUAL(bs::saturated_(bs::toint)(bs::Nan<T>()),  bs::Zero<r_t>());
-  STF_EQUAL(bs::saturated_(bs::toint)(bs::One<T>()),  bs::One<r_t>());
-  STF_EQUAL(bs::saturated_(bs::toint)(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(bs::saturated_(bs::toint)(bs::Inf<T>()),  bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::toint)(bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::toint)(bs::Mone<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::toint)(bs::Nan<T>()),  bs::Zero<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::toint)(bs::One<T>()),  bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::toint)(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 
   T v = T(1);
   r_t iv = 1;
@@ -48,13 +48,13 @@ STF_CASE_TPL (" bs::saturated_(bs::toint) real",  STF_IEEE_TYPES)
   {
   namespace bs = boost::simd;
   namespace bd = boost::dispatch;
-    STF_EQUAL(bs::saturated_(bs::toint)(v), iv);
-    STF_EQUAL(bs::saturated_(bs::toint)(-v), -iv);
+    STF_ULP_EQUAL(bs::saturated_(bs::toint)(v), iv, 0.5);
+    STF_ULP_EQUAL(bs::saturated_(bs::toint)(-v), -iv, 0.5);
   }
-  STF_EQUAL(bs::saturated_(bs::toint)(bs::ldexp(bs::One<T>(), N)), bs::Valmax<r_t>());
-  STF_EQUAL(bs::saturated_(bs::toint)(bs::ldexp(bs::One<T>(), N+1)), bs::Valmax<r_t>());
-  STF_EQUAL(bs::saturated_(bs::toint)(-bs::ldexp(bs::One<T>(), N+1)), bs::Valmin<r_t>());
-  STF_EQUAL(bs::saturated_(bs::toint)(-bs::ldexp(bs::One<T>(), N+1)), bs::Valmin<r_t>());
+  STF_ULP_EQUAL(bs::saturated_(bs::toint)(bs::ldexp(bs::One<T>(), N)), bs::Valmax<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::toint)(bs::ldexp(bs::One<T>(), N+1)), bs::Valmax<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::toint)(-bs::ldexp(bs::One<T>(), N+1)), bs::Valmin<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::toint)(-bs::ldexp(bs::One<T>(), N+1)), bs::Valmin<r_t>(), 0.5);
 
 } // end of test for floating_
 

--- a/test/function/scalar/touint.cpp
+++ b/test/function/scalar/touint.cpp
@@ -26,6 +26,6 @@ STF_CASE_TPL (" touint real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, (bd::as_integer_t<T, unsigned>));
 
   // specific values tests
-  STF_EQUAL(touint(bs::One<T>()) , bs::One<r_t>());
-  STF_EQUAL(touint(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(touint(bs::One<T>()) , bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(touint(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
  } // end of test for floating_

--- a/test/function/scalar/trunc.cpp
+++ b/test/function/scalar/trunc.cpp
@@ -31,22 +31,22 @@ STF_CASE_TPL (" trunc real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(trunc(bs::Inf<T>()), bs::Inf<T>());
-  STF_EQUAL(trunc(bs::Minf<T>()), bs::Minf<T>());
-  STF_IEEE_EQUAL(trunc(bs::Nan<T>()), bs::Nan<T>());
+  STF_ULP_EQUAL(trunc(bs::Inf<T>()), bs::Inf<T>(), 0.5);
+  STF_ULP_EQUAL(trunc(bs::Minf<T>()), bs::Minf<T>(), 0.5);
+  STF_ULP_EQUAL(trunc(bs::Nan<T>()), bs::Nan<T>(), 0.5);
 #endif
-  STF_EQUAL(trunc(bs::One<T>()), bs::One<T>());
-  STF_EQUAL(trunc(bs::Mone<T>()), bs::Mone<T>());
-  STF_EQUAL(trunc(bs::Zero<T>()), bs::Zero<T>());
-  STF_EQUAL(trunc(bs::Pi<T>()), bs::Three<T>());
-  STF_EQUAL(trunc(T(1.4)), T(1));
-  STF_EQUAL(trunc(T(1.5)), T(1));
-  STF_EQUAL(trunc(T(1.6)), T(1));
-  STF_EQUAL(trunc(T(2.5)), T(2));
-  STF_EQUAL(trunc(T(-1.4)), T(-1));
-  STF_EQUAL(trunc(T(-1.5)), T(-1));
-  STF_EQUAL(trunc(T(-1.6)), T(-1));
-  STF_EQUAL(trunc(T(-2.5)), T(-2));
+  STF_ULP_EQUAL(trunc(bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(trunc(bs::Mone<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(trunc(bs::Zero<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(trunc(bs::Pi<T>()), bs::Three<T>(), 0.5);
+  STF_ULP_EQUAL(trunc(T(1.4)), T(1), 0.5);
+  STF_ULP_EQUAL(trunc(T(1.5)), T(1), 0.5);
+  STF_ULP_EQUAL(trunc(T(1.6)), T(1), 0.5);
+  STF_ULP_EQUAL(trunc(T(2.5)), T(2), 0.5);
+  STF_ULP_EQUAL(trunc(T(-1.4)), T(-1), 0.5);
+  STF_ULP_EQUAL(trunc(T(-1.5)), T(-1), 0.5);
+  STF_ULP_EQUAL(trunc(T(-1.6)), T(-1), 0.5);
+  STF_ULP_EQUAL(trunc(T(-2.5)), T(-2), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" trunc unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
@@ -92,17 +92,17 @@ STF_CASE_TPL ( "fast trunc real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, T);
 
   // specific values tests
-  STF_EQUAL(bs::fast_(trunc)(bs::One<T>()), bs::One<T>());
-  STF_EQUAL(bs::fast_(trunc)(bs::Mone<T>()), bs::Mone<T>());
-  STF_EQUAL(bs::fast_(trunc)(bs::Zero<T>()), bs::Zero<T>());
-  STF_EQUAL(bs::fast_(trunc)(bs::Pi<T>()), bs::Three<T>());
-  STF_EQUAL(bs::fast_(trunc)(T(1.4)), T(1));
-  STF_EQUAL(bs::fast_(trunc)(T(1.5)), T(1));
-  STF_EQUAL(bs::fast_(trunc)(T(1.6)), T(1));
-  STF_EQUAL(bs::fast_(trunc)(T(2.5)), T(2));
-  STF_EQUAL(bs::fast_(trunc)(T(-1.4)), T(-1));
-  STF_EQUAL(bs::fast_(trunc)(T(-1.5)), T(-1));
-  STF_EQUAL(bs::fast_(trunc)(T(-1.6)), T(-1));
-  STF_EQUAL(bs::fast_(trunc)(T(-2.5)), T(-2));
+  STF_ULP_EQUAL(bs::fast_(trunc)(bs::One<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(trunc)(bs::Mone<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(trunc)(bs::Zero<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(trunc)(bs::Pi<T>()), bs::Three<T>(), 0.5);
+  STF_ULP_EQUAL(bs::fast_(trunc)(T(1.4)), T(1), 0.5);
+  STF_ULP_EQUAL(bs::fast_(trunc)(T(1.5)), T(1), 0.5);
+  STF_ULP_EQUAL(bs::fast_(trunc)(T(1.6)), T(1), 0.5);
+  STF_ULP_EQUAL(bs::fast_(trunc)(T(2.5)), T(2), 0.5);
+  STF_ULP_EQUAL(bs::fast_(trunc)(T(-1.4)), T(-1), 0.5);
+  STF_ULP_EQUAL(bs::fast_(trunc)(T(-1.5)), T(-1), 0.5);
+  STF_ULP_EQUAL(bs::fast_(trunc)(T(-1.6)), T(-1), 0.5);
+  STF_ULP_EQUAL(bs::fast_(trunc)(T(-2.5)), T(-2), 0.5);
 } // end of test for floating_
 

--- a/test/function/scalar/two_add.cpp
+++ b/test/function/scalar/two_add.cpp
@@ -41,18 +41,18 @@ STF_CASE_TPL(" two_add", STF_IEEE_TYPES)
   std::pair<T,T> p;
 
   p = two_add(inf_,zero_);
-  STF_EQUAL(p.first, inf_);
-  STF_EQUAL(p.second, zero_);
+  STF_ULP_EQUAL(p.first, inf_, 0.5);
+  STF_ULP_EQUAL(p.second, zero_, 0.5);
 
   p = two_add(zero_, inf_);
-  STF_EQUAL(p.first, inf_);
-  STF_EQUAL(p.second, zero_);
+  STF_ULP_EQUAL(p.first, inf_, 0.5);
+  STF_ULP_EQUAL(p.second, zero_, 0.5);
 
   p = two_add(half_+ eps_2_, half_);
-  STF_EQUAL(p.first, one_);
-  STF_EQUAL(p.second, eps_2_);
+  STF_ULP_EQUAL(p.first, one_, 0.5);
+  STF_ULP_EQUAL(p.second, eps_2_, 0.5);
 
   p = two_add(half_, half_+ eps_2_);
-  STF_EQUAL(p.first, one_);
-  STF_EQUAL(p.second, eps_2_);
+  STF_ULP_EQUAL(p.first, one_, 0.5);
+  STF_ULP_EQUAL(p.second, eps_2_, 0.5);
 }

--- a/test/function/scalar/two_prod.cpp
+++ b/test/function/scalar/two_prod.cpp
@@ -40,18 +40,18 @@ STF_CASE_TPL(" two_prod", STF_IEEE_TYPES)
   std::pair<T,T> p;
 
   p = two_prod(inf_,one_);
-  STF_EQUAL(p.first, inf_);
-  STF_EQUAL(p.second, zero_);
+  STF_ULP_EQUAL(p.first, inf_, 0.5);
+  STF_ULP_EQUAL(p.second, zero_, 0.5);
 
   p = two_prod(one_, inf_);
-  STF_EQUAL(p.first, inf_);
-  STF_EQUAL(p.second, zero_);
+  STF_ULP_EQUAL(p.first, inf_, 0.5);
+  STF_ULP_EQUAL(p.second, zero_, 0.5);
 
   p = two_prod(one_ + eps_, one_ - eps_);
-  STF_EQUAL(p.first, one_);
-  STF_EQUAL(p.second, meps2_);
+  STF_ULP_EQUAL(p.first, one_, 0.5);
+  STF_ULP_EQUAL(p.second, meps2_, 0.5);
 
   p = two_prod(one_ - eps_,one_ + eps_);
-  STF_EQUAL(p.first, one_);
-  STF_EQUAL(p.second, meps2_);
+  STF_ULP_EQUAL(p.first, one_, 0.5);
+  STF_ULP_EQUAL(p.second, meps2_, 0.5);
 }

--- a/test/function/scalar/two_split.cpp
+++ b/test/function/scalar/two_split.cpp
@@ -37,7 +37,7 @@ STF_CASE_TPL(" two_split", STF_IEEE_TYPES)
   std::pair<T,T> p;
 
   p = two_split(one_-eps_);
-  STF_EQUAL(p.first, one_);
-  STF_EQUAL(p.second, -eps_);
+  STF_ULP_EQUAL(p.first, one_, 0.5);
+  STF_ULP_EQUAL(p.second, -eps_, 0.5);
 }
 

--- a/test/function/scalar/ulp.cpp
+++ b/test/function/scalar/ulp.cpp
@@ -31,13 +31,13 @@ STF_CASE_TPL (" ulp real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_IEEE_EQUAL(ulp(bs::Inf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(ulp(bs::Minf<T>()), bs::Nan<r_t>());
-  STF_IEEE_EQUAL(ulp(bs::Nan<T>()), bs::Nan<r_t>());
+  STF_ULP_EQUAL(ulp(bs::Inf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(ulp(bs::Minf<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(ulp(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(ulp(bs::Mone<T>()), bs::Eps<r_t>()/2);
-  STF_EQUAL(ulp(bs::One<T>()), bs::Eps<r_t>()/2);
-  STF_EQUAL(ulp(bs::Zero<T>()), bs::Mindenormal<r_t>());
+  STF_ULP_EQUAL(ulp(bs::Mone<T>()), bs::Eps<r_t>()/2, 0.5);
+  STF_ULP_EQUAL(ulp(bs::One<T>()), bs::Eps<r_t>()/2, 0.5);
+  STF_ULP_EQUAL(ulp(bs::Zero<T>()), bs::Mindenormal<r_t>(), 0.5);
 }
 
 STF_CASE_TPL (" ulp unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/ulpdist.cpp
+++ b/test/function/scalar/ulpdist.cpp
@@ -27,26 +27,26 @@ STF_CASE_TPL (" ulpdist real",  STF_IEEE_TYPES)
   STF_EXPR_IS( ulpdist(T(), T()), T);
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(ulpdist(bs::Inf<T>(), bs::Inf<T>()), bs::Zero<T>());
-  STF_EQUAL(ulpdist(bs::Minf<T>(), bs::Minf<T>()), bs::Zero<T>());
-  STF_EQUAL(ulpdist(bs::Nan<T>(), bs::Nan<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(ulpdist(bs::Inf<T>(), bs::Inf<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(ulpdist(bs::Minf<T>(), bs::Minf<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(ulpdist(bs::Nan<T>(), bs::Nan<T>()), bs::Zero<T>(), 0.5);
 #endif
 
-  STF_EQUAL(ulpdist(bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>());
-  STF_EQUAL(ulpdist(bs::One<T>(), bs::One<T>()), bs::Zero<T>());
-  STF_EQUAL(ulpdist(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(ulpdist(bs::Mone<T>(), bs::Mone<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(ulpdist(bs::One<T>(), bs::One<T>()), bs::Zero<T>(), 0.5);
+  STF_ULP_EQUAL(ulpdist(bs::Zero<T>(), bs::Zero<T>()), bs::Zero<T>(), 0.5);
 
-  STF_EQUAL( ulpdist(bs::One<T>(), bs::One<T>()+bs::Eps<T>())
+  STF_ULP_EQUAL( ulpdist(bs::One<T>(), bs::One<T>()+bs::Eps<T>())
                 , T(0.5)
-                );
+               , 0.5);
 
-  STF_EQUAL( ulpdist(bs::One<T>(), bs::One<T>()-bs::Eps<T>())
+  STF_ULP_EQUAL( ulpdist(bs::One<T>(), bs::One<T>()-bs::Eps<T>())
                 , T(0.5)
-                );
+                , 0.5);
 
-  STF_EQUAL( ulpdist(bs::One<T>(), bs::One<T>()-bs::Eps<T>()/2)
+  STF_ULP_EQUAL( ulpdist(bs::One<T>(), bs::One<T>()-bs::Eps<T>()/2)
                 , T(0.25)
-                );
+                , 0.5);
 }
 
 STF_CASE_TPL (" ulpdist signed_integral",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/unary_minus.cpp
+++ b/test/function/scalar/unary_minus.cpp
@@ -32,11 +32,11 @@ STF_CASE_TPL (" unary_minus real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, T);
 
   // specific values tests
-  STF_EQUAL(unary_minus(bs::Inf<T>()), bs::Minf<r_t>());
-  STF_EQUAL(unary_minus(bs::Minf<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(unary_minus(bs::Nan<T>()), bs::Nan<r_t>());
-  STF_EQUAL(unary_minus(bs::One<T>()), bs::Mone<r_t>());
-  STF_EQUAL(unary_minus(bs::Zero<T>()), bs::Mzero<r_t>());
+  STF_ULP_EQUAL(unary_minus(bs::Inf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(unary_minus(bs::Minf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(unary_minus(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(unary_minus(bs::One<T>()), bs::Mone<r_t>(), 0.5);
+  STF_ULP_EQUAL(unary_minus(bs::Zero<T>()), bs::Mzero<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" unary_minus signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/scalar/unary_minus.saturated.cpp
+++ b/test/function/scalar/unary_minus.saturated.cpp
@@ -26,15 +26,15 @@ STF_CASE_TPL( "Check bs::saturated_(bs::unary_minus_s) behavior with floating", 
   STF_TYPE_IS(r_t, T);
 
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(bs::saturated_(bs::unary_minus)(bs::Inf<T>()),  bs::Minf<r_t>());
-  STF_EQUAL(bs::saturated_(bs::unary_minus)(bs::Minf<T>()), bs::Inf<r_t>());
-  STF_IEEE_EQUAL(bs::saturated_(bs::unary_minus)(bs::Nan<T>()),  bs::Nan<r_t>());
+  STF_ULP_EQUAL(bs::saturated_(bs::unary_minus)(bs::Inf<T>()),  bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::unary_minus)(bs::Minf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::unary_minus)(bs::Nan<T>()),  bs::Nan<r_t>(), 0.5);
 #endif
-  STF_EQUAL(bs::saturated_(bs::unary_minus)(bs::Mone<T>()), bs::One<T>());
-  STF_EQUAL(bs::saturated_(bs::unary_minus)(bs::One<T>()), bs::Mone<T>());
-  STF_EQUAL(bs::saturated_(bs::unary_minus)(bs::Valmax<T>()), bs::Valmin<T>());
-  STF_EQUAL(bs::saturated_(bs::unary_minus)(bs::Valmin<T>()), bs::Valmax<T>());
-  STF_EQUAL(bs::saturated_(bs::unary_minus)(bs::Zero<T>()), bs::Zero<T>());
+  STF_ULP_EQUAL(bs::saturated_(bs::unary_minus)(bs::Mone<T>()), bs::One<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::unary_minus)(bs::One<T>()), bs::Mone<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::unary_minus)(bs::Valmax<T>()), bs::Valmin<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::unary_minus)(bs::Valmin<T>()), bs::Valmax<T>(), 0.5);
+  STF_ULP_EQUAL(bs::saturated_(bs::unary_minus)(bs::Zero<T>()), bs::Zero<T>(), 0.5);
 }
 
 

--- a/test/function/scalar/unary_plus.cpp
+++ b/test/function/scalar/unary_plus.cpp
@@ -30,11 +30,11 @@ STF_CASE_TPL (" unary_plus real",  STF_IEEE_TYPES)
   STF_TYPE_IS(r_t, T);
 
   // specific values tests
-  STF_EQUAL(unary_plus(bs::Inf<T>()), bs::Inf<r_t>());
-  STF_EQUAL(unary_plus(bs::Minf<T>()), bs::Minf<r_t>());
-  STF_IEEE_EQUAL(unary_plus(bs::Nan<T>()), bs::Nan<r_t>());
-  STF_EQUAL(unary_plus(bs::One<T>()), bs::One<r_t>());
-  STF_EQUAL(unary_plus(bs::Zero<T>()), bs::Zero<r_t>());
+  STF_ULP_EQUAL(unary_plus(bs::Inf<T>()), bs::Inf<r_t>(), 0.5);
+  STF_ULP_EQUAL(unary_plus(bs::Minf<T>()), bs::Minf<r_t>(), 0.5);
+  STF_ULP_EQUAL(unary_plus(bs::Nan<T>()), bs::Nan<r_t>(), 0.5);
+  STF_ULP_EQUAL(unary_plus(bs::One<T>()), bs::One<r_t>(), 0.5);
+  STF_ULP_EQUAL(unary_plus(bs::Zero<T>()), bs::Zero<r_t>(), 0.5);
 } // end of test for floating_
 
 STF_CASE_TPL (" unary_plus signed_int",  STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/simd/abs.cpp
+++ b/test/function/simd/abs.cpp
@@ -31,8 +31,8 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
   p_t cc (&c[0], &c[0]+N);
-  STF_EQUAL(bs::abs(aa1), bb);
-  STF_EQUAL(bs::std_(bs::abs)(aa1), cc);
+  STF_ULP_EQUAL(bs::abs(aa1), bb, 0.5);
+  STF_ULP_EQUAL(bs::std_(bs::abs)(aa1), cc, 0.5);
 }
 
 STF_CASE_TPL("Check abs saturated on pack" , STF_NUMERIC_TYPES)
@@ -59,7 +59,7 @@ void tests(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::saturated_(bs::abs)(aa1), bb);
+  STF_ULP_EQUAL(bs::saturated_(bs::abs)(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check abs on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/acosh.cpp
+++ b/test/function/simd/acosh.cpp
@@ -26,7 +26,7 @@ void test(Env& $)
 
   p_t aa1(&a1[0], &a1[N]);
   p_t bb (&b[0], &b[N]);
-  STF_EQUAL(bs::acosh(aa1), bb);
+  STF_ULP_EQUAL(bs::acosh(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check acosh on pack" , STF_IEEE_TYPES)

--- a/test/function/simd/acotpi.cpp
+++ b/test/function/simd/acotpi.cpp
@@ -28,7 +28,7 @@ void test(Env& $)
 
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
-  STF_EQUAL(bs::acotpi(aa1), bb);
+  STF_ULP_EQUAL(bs::acotpi(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check acotpi on pack" , STF_IEEE_TYPES)

--- a/test/function/simd/all.cpp
+++ b/test/function/simd/all.cpp
@@ -34,8 +34,8 @@ void test(Env& $)
   STF_EQUAL(bs::all(aa1), b);
   STF_EQUAL(bs::all(aa2), c);
 
-  STF_EQUAL(bs::splatted_(bs::all)(aa1), (bs::pack<bs::logical<T>,N>(b)) );
-  STF_EQUAL(bs::splatted_(bs::all)(aa2), (bs::pack<bs::logical<T>,N>(c)) );
+  STF_EQUAL(bs::splatted_(bs::all)(aa1), (bs::pack<bs::logical<T>,N>(b)));
+  STF_EQUAL(bs::splatted_(bs::all)(aa2), (bs::pack<bs::logical<T>,N>(c)));
 }
 
 STF_CASE_TPL("Check all on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/any.cpp
+++ b/test/function/simd/any.cpp
@@ -36,8 +36,8 @@ void test(Env& $)
   STF_EQUAL(bs::any(aa1), b);
   STF_EQUAL(bs::any(aa2), c);
 
-  STF_EQUAL(bs::splatted_(bs::any)(aa1), (bs::pack<bs::logical<T>,N>(b)) );
-  STF_EQUAL(bs::splatted_(bs::any)(aa2), (bs::pack<bs::logical<T>,N>(c)) );
+  STF_EQUAL(bs::splatted_(bs::any)(aa1), (bs::pack<bs::logical<T>,N>(b)));
+  STF_EQUAL(bs::splatted_(bs::any)(aa2), (bs::pack<bs::logical<T>,N>(c)));
 }
 
 STF_CASE_TPL("Check any on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/autofold.cpp
+++ b/test/function/simd/autofold.cpp
@@ -51,8 +51,8 @@ template <typename T, std::size_t N, typename Env> void test(Env& $)
 
   for(std::size_t i=0;i<N;i++) p[i] = k++;
 
-  STF_EQUAL( bs::fake_sum(p), T( (N*(N+1))/2 ) );
-  STF_EQUAL( bs::splatted_(bs::fake_sum)(p), p_t(T( (N*(N+1))/2 )) );
+  STF_ULP_EQUAL( bs::fake_sum(p), T( (N*(N+1))/2 ) , 0.5);
+  STF_ULP_EQUAL( bs::splatted_(bs::fake_sum)(p), p_t(T( (N*(N+1))/2 )) , 0.5);
 }
 
 STF_CASE_TPL("Check autofold behaviour on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/bitget.cpp
+++ b/test/function/simd/bitget.cpp
@@ -37,7 +37,7 @@ void test(Env& $)
   std::cout << aa1 << std::endl;
   std::cout << bb << std::endl;
   std::cout <<bs::bitget(aa1, aa2)<< std::endl;
-  STF_EQUAL(bs::bitget(aa1, aa2), bb);
+  STF_ULP_EQUAL(bs::bitget(aa1, aa2), bb, 0.5);
 }
 
 STF_CASE_TPL("Check bitget on pack" ,  STF_NUMERIC_TYPES)

--- a/test/function/simd/bitinteger.cpp
+++ b/test/function/simd/bitinteger.cpp
@@ -33,7 +33,7 @@ void test(Env& $)
   }
   p_t aa1(&a1[0], &a1[0]+N);
   i_t bb (&b[0], &b[0]+N);
-  STF_EQUAL(bs::bitinteger(aa1), bb);
+  STF_ULP_EQUAL(bs::bitinteger(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check bitinteger on pack" , STF_IEEE_TYPES)

--- a/test/function/simd/bitwise_cast.cpp
+++ b/test/function/simd/bitwise_cast.cpp
@@ -22,24 +22,24 @@ STF_CASE( "Check bitwise_cast between integer types" )
     using ps_t = bs::pack<std::uint16_t,N>;
     using pc_t = bs::pack<std::uint8_t,2*N>;
 
-    STF_EQUAL ( bs::bitwise_cast<ps_t>( pc_t(0x01) )  , ps_t(0x0101)  );
-    STF_EQUAL ( bs::bitwise_cast<pc_t>( ps_t(0x0101) ), pc_t(0x01)     );
+    STF_ULP_EQUAL ( bs::bitwise_cast<ps_t>( pc_t(0x01) )  , ps_t(0x0101)  , 0.5);
+    STF_ULP_EQUAL ( bs::bitwise_cast<pc_t>( ps_t(0x0101) ), pc_t(0x01)     , 0.5);
   }
 
   {
     using ps_t = bs::pack<std::uint16_t,N/2>;
     using pc_t = bs::pack<std::uint8_t,N>;
 
-    STF_EQUAL ( bs::bitwise_cast<ps_t>( pc_t(0x01) )  , ps_t(0x0101)  );
-    STF_EQUAL ( bs::bitwise_cast<pc_t>( ps_t(0x0101) ), pc_t(0x01)     );
+    STF_ULP_EQUAL ( bs::bitwise_cast<ps_t>( pc_t(0x01) )  , ps_t(0x0101)  , 0.5);
+    STF_ULP_EQUAL ( bs::bitwise_cast<pc_t>( ps_t(0x0101) ), pc_t(0x01)     , 0.5);
   }
 
   {
     using ps_t = bs::pack<std::uint16_t,2*N>;
     using pc_t = bs::pack<std::uint8_t,4*N>;
 
-    STF_EQUAL ( bs::bitwise_cast<ps_t>( pc_t(0x01) )  , ps_t(0x0101)  );
-    STF_EQUAL ( bs::bitwise_cast<pc_t>( ps_t(0x0101) ), pc_t(0x01)     );
+    STF_ULP_EQUAL ( bs::bitwise_cast<ps_t>( pc_t(0x01) )  , ps_t(0x0101)  , 0.5);
+    STF_ULP_EQUAL ( bs::bitwise_cast<pc_t>( ps_t(0x0101) ), pc_t(0x01)     , 0.5);
   }
 }
 
@@ -51,22 +51,22 @@ STF_CASE( "Check bitwise_cast between integer & real types" )
   {
     using pf_t = bs::pack<float,N>;
     using pi_t = bs::pack<std::uint32_t,N>;
-    STF_EQUAL ( bs::bitwise_cast<pi_t>( pf_t(1.f) )         , pi_t(0x3F800000UL)  );
-    STF_EQUAL ( bs::bitwise_cast<pf_t>( pi_t(0x3F800000UL) ), pf_t(1.f)           );
+    STF_ULP_EQUAL ( bs::bitwise_cast<pi_t>( pf_t(1.f) )         , pi_t(0x3F800000UL)  , 0.5);
+    STF_ULP_EQUAL ( bs::bitwise_cast<pf_t>( pi_t(0x3F800000UL) ), pf_t(1.f)           , 0.5);
   }
 
   {
     using pf_t = bs::pack<float,N/2>;
     using pi_t = bs::pack<std::uint32_t,N/2>;
-    STF_EQUAL ( bs::bitwise_cast<pi_t>( pf_t(1.f) )         , pi_t(0x3F800000UL)  );
-    STF_EQUAL ( bs::bitwise_cast<pf_t>( pi_t(0x3F800000UL) ), pf_t(1.f)           );
+    STF_ULP_EQUAL ( bs::bitwise_cast<pi_t>( pf_t(1.f) )         , pi_t(0x3F800000UL)  , 0.5);
+    STF_ULP_EQUAL ( bs::bitwise_cast<pf_t>( pi_t(0x3F800000UL) ), pf_t(1.f)           , 0.5);
   }
 
   {
     using pf_t = bs::pack<float,N*2>;
     using pi_t = bs::pack<std::uint32_t,N*2>;
-    STF_EQUAL ( bs::bitwise_cast<pi_t>( pf_t(1.f) )         , pi_t(0x3F800000UL)  );
-    STF_EQUAL ( bs::bitwise_cast<pf_t>( pi_t(0x3F800000UL) ), pf_t(1.f)           );
+    STF_ULP_EQUAL ( bs::bitwise_cast<pi_t>( pf_t(1.f) )         , pi_t(0x3F800000UL)  , 0.5);
+    STF_ULP_EQUAL ( bs::bitwise_cast<pf_t>( pi_t(0x3F800000UL) ), pf_t(1.f)           , 0.5);
   }
 }
 
@@ -78,21 +78,21 @@ STF_CASE_TPL( "Check bitwise_cast between arithmetic & logical types", STF_NUMER
   {
     using pa_t = bs::pack<T,N>;
     using pl_t = bs::pack<bs::logical<T>,N>;
-    STF_IEEE_EQUAL ( bs::bitwise_cast<pa_t>( pl_t(true) )         , bs::Allbits<pa_t>() );
-    STF_IEEE_EQUAL ( bs::bitwise_cast<pl_t>( bs::Allbits<pa_t>() ), pl_t(true)          );
+    STF_ULP_EQUAL ( bs::bitwise_cast<pa_t>( pl_t(true) )         , bs::Allbits<pa_t>() , 0.5);
+    STF_ULP_EQUAL ( bs::bitwise_cast<pl_t>( bs::Allbits<pa_t>() ), pl_t(true)          , 0.5);
   }
 
   {
     using pa_t = bs::pack<T,N/2>;
     using pl_t = bs::pack<bs::logical<T>,N/2>;
-    STF_IEEE_EQUAL ( bs::bitwise_cast<pa_t>( pl_t(true) )         , bs::Allbits<pa_t>() );
-    STF_IEEE_EQUAL ( bs::bitwise_cast<pl_t>( bs::Allbits<pa_t>() ), pl_t(true)          );
+    STF_ULP_EQUAL ( bs::bitwise_cast<pa_t>( pl_t(true) )         , bs::Allbits<pa_t>() , 0.5);
+    STF_ULP_EQUAL ( bs::bitwise_cast<pl_t>( bs::Allbits<pa_t>() ), pl_t(true)          , 0.5);
   }
 
   {
     using pa_t = bs::pack<T,N*2>;
     using pl_t = bs::pack<bs::logical<T>,N*2>;
-    STF_IEEE_EQUAL ( bs::bitwise_cast<pa_t>( pl_t(true) )         , bs::Allbits<pa_t>() );
-    STF_IEEE_EQUAL ( bs::bitwise_cast<pl_t>( bs::Allbits<pa_t>() ), pl_t(true)          );
+    STF_ULP_EQUAL ( bs::bitwise_cast<pa_t>( pl_t(true) )         , bs::Allbits<pa_t>() , 0.5);
+    STF_ULP_EQUAL ( bs::bitwise_cast<pl_t>( bs::Allbits<pa_t>() ), pl_t(true)          , 0.5);
   }
 }

--- a/test/function/simd/bitwise_select.cpp
+++ b/test/function/simd/bitwise_select.cpp
@@ -37,7 +37,7 @@ void test(Env& $)
   p_t aa2(&a2[0], &a2[0]+N);
   p_t aa3(&a3[0], &a3[0]+N);
   p_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::bitwise_select(aa1, aa2, aa3), bb);
+  STF_ULP_EQUAL(bs::bitwise_select(aa1, aa2, aa3), bb, 0.5);
 }
 
 STF_CASE_TPL("Check bitwise_select on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/broadcast.cpp
+++ b/test/function/simd/broadcast.cpp
@@ -22,10 +22,10 @@ void test(Env& $, brigand::list<N...> const&)
 
   p_t p( (T(1+N::value))... );
 
-  STF_EQUAL( bs::broadcast< -1>(p), bs::Zero<p_t>() );
-  STF_EQUAL( bs::broadcast<  0>(p), p_t(T(1))       );
-  STF_EQUAL( bs::broadcast<C-1>(p), p_t(T(C))       );
-  STF_EQUAL( bs::broadcast<C*2>(p), bs::Zero<p_t>() );
+  STF_ULP_EQUAL( bs::broadcast< -1>(p), bs::Zero<p_t>() , 0.5);
+  STF_ULP_EQUAL( bs::broadcast<  0>(p), p_t(T(1))       , 0.5);
+  STF_ULP_EQUAL( bs::broadcast<C-1>(p), p_t(T(C))       , 0.5);
+  STF_ULP_EQUAL( bs::broadcast<C*2>(p), bs::Zero<p_t>() , 0.5);
 }
 
 STF_CASE_TPL( "Check broadcast<N>() behavior", STF_NUMERIC_TYPES )

--- a/test/function/simd/ceil.cpp
+++ b/test/function/simd/ceil.cpp
@@ -29,8 +29,8 @@ void test(Env& $)
   }
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
-  STF_IEEE_EQUAL(bs::ceil(aa1), bb);
-  STF_EQUAL(bs::std_(bs::ceil)(aa1), bb);
+  STF_ULP_EQUAL(bs::ceil(aa1), bb, 0.5);
+  STF_ULP_EQUAL(bs::std_(bs::ceil)(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check ceil on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/clz.cpp
+++ b/test/function/simd/clz.cpp
@@ -32,7 +32,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   i_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::clz(aa1), bb);
+  STF_ULP_EQUAL(bs::clz(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check clz on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/combine/arithmetic.cpp
+++ b/test/function/simd/combine/arithmetic.cpp
@@ -16,8 +16,8 @@ namespace bs = boost::simd;
 STF_CASE_TPL("combine scalar into a pack<T,2>", STF_NUMERIC_TYPES)
 {
   bs::pack<T,2> res = bs::combine(T(13), T(37));
-  STF_EQUAL(res[0], T(13));
-  STF_EQUAL(res[1], T(37));
+  STF_ULP_EQUAL(res[0], T(13), 0.5);
+  STF_ULP_EQUAL(res[1], T(37), 0.5);
 }
 
 template<typename T, std::size_t N, typename Env>

--- a/test/function/simd/combine/logical.cpp
+++ b/test/function/simd/combine/logical.cpp
@@ -17,8 +17,8 @@ namespace bs = boost::simd;
 STF_CASE_TPL("combine scalar into a pack<T,2>", STF_NUMERIC_TYPES)
 {
   bs::pack<bs::logical<T>,2> res = bs::combine(bs::logical<T>(false), bs::logical<T>(true));
-  STF_EQUAL(res[0], bs::logical<T>(false));
-  STF_EQUAL(res[1], bs::logical<T>(true));
+  STF_ULP_EQUAL(res[0], bs::logical<T>(false), 0.5);
+  STF_ULP_EQUAL(res[1], bs::logical<T>(true), 0.5);
 }
 
 template<typename T, std::size_t N, typename Env>

--- a/test/function/simd/cosd.cpp
+++ b/test/function/simd/cosd.cpp
@@ -28,7 +28,7 @@ void test(Env& $)
 
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
-  STF_EQUAL(bs::cosd(aa1), bb);
+  STF_ULP_EQUAL(bs::cosd(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check cosd on pack" , STF_IEEE_TYPES)

--- a/test/function/simd/coth.cpp
+++ b/test/function/simd/coth.cpp
@@ -28,7 +28,7 @@ void test(Env& $)
 
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
-  STF_EQUAL(bs::coth(aa1), bb);
+  STF_ULP_EQUAL(bs::coth(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check coth saturated on pack" , STF_IEEE_TYPES)

--- a/test/function/simd/ctz.cpp
+++ b/test/function/simd/ctz.cpp
@@ -37,7 +37,7 @@ void test(Env& $)
 
   p_t aa1(&a1[0], &a1[0]+N);
   i_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::ctz(aa1), bb);
+  STF_ULP_EQUAL(bs::ctz(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check ctz on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/dec.cpp
+++ b/test/function/simd/dec.cpp
@@ -30,8 +30,8 @@ void pre_test(Env& $)
   p_t bb(&b[0], &b[0]+N);
 
   aa2 = --aa1;
-  STF_EQUAL(aa2, bb);
-  STF_EQUAL(aa1, bb);
+  STF_ULP_EQUAL(aa2, bb, 0.5);
+  STF_ULP_EQUAL(aa1, bb, 0.5);
 }
 
 STF_CASE_TPL("Check pre-decrement on pack" , STF_NUMERIC_TYPES)
@@ -61,7 +61,7 @@ void post_test(Env& $)
   p_t bb(&b[0], &b[0]+N);
 
   aa2 = aa1--;
-  STF_EQUAL(aa2, prev);
-  STF_EQUAL(aa1, bb);
+  STF_ULP_EQUAL(aa2, prev, 0.5);
+  STF_ULP_EQUAL(aa1, bb, 0.5);
 }
 

--- a/test/function/simd/deinterleave.cpp
+++ b/test/function/simd/deinterleave.cpp
@@ -32,8 +32,8 @@ void test(Env& $, std::true_type const& = {})
   p_t aa2(&a2[0], &a2[0]+N);
 
   std::array<p_t,2> out = bs::deinterleave(aa1, aa2);
-  STF_EQUAL( out[0], bs::deinterleave_first(aa1,aa2)  );
-  STF_EQUAL( out[1], bs::deinterleave_second(aa1,aa2) );
+  STF_ULP_EQUAL( out[0], bs::deinterleave_first(aa1,aa2)  , 0.5);
+  STF_ULP_EQUAL( out[1], bs::deinterleave_second(aa1,aa2) , 0.5);
 }
 
 STF_CASE_TPL("Check deinterleave on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/deinterleave_first.cpp
+++ b/test/function/simd/deinterleave_first.cpp
@@ -37,7 +37,7 @@ void test(Env& $, std::true_type const& = {})
   p_t aa2(&a2[0], &a2[0]+N);
   p_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::deinterleave_first(aa1, aa2), bb);
+  STF_ULP_EQUAL(bs::deinterleave_first(aa1, aa2), bb, 0.5);
 }
 
 STF_CASE_TPL("Check deinterleave_first on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/deinterleave_second.cpp
+++ b/test/function/simd/deinterleave_second.cpp
@@ -37,7 +37,7 @@ void test(Env& $, std::true_type const& = {})
   p_t aa2(&a2[0], &a2[0]+N);
   p_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::deinterleave_second(aa1, aa2), bb);
+  STF_ULP_EQUAL(bs::deinterleave_second(aa1, aa2), bb, 0.5);
 }
 
 STF_CASE_TPL("Check deinterleave_second on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/extract/dynamic.arithmetic.cpp
+++ b/test/function/simd/extract/dynamic.arithmetic.cpp
@@ -25,7 +25,7 @@ void test(Env& $)
   for(std::size_t i = 0; i < N; ++i) ref[i] = T(i*2);
 
   bs::pack<T,N> p(&ref[0], &ref[0]+N);
-  for(std::size_t i = 0; i < N; ++i) STF_EQUAL(bs::extract(p, i), ref[i]);
+  for(std::size_t i = 0; i < N; ++i) STF_ULP_EQUAL(bs::extract(p, i), ref[i], 0.5);
 }
 
 STF_CASE_TPL("Check dynamic extract on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/extract/dynamic.logical.cpp
+++ b/test/function/simd/extract/dynamic.logical.cpp
@@ -26,7 +26,7 @@ void test(Env& $)
   for(std::size_t i = 0; i < N; ++i) ref[i] = T(i*2);
 
   bs::pack<T,N> p(&ref[0], &ref[0]+N);
-  for(std::size_t i = 0; i < N; ++i) STF_EQUAL(bs::extract(p, i), ref[i]);
+  for(std::size_t i = 0; i < N; ++i) STF_ULP_EQUAL(bs::extract(p, i), ref[i], 0.5);
 }
 
 STF_CASE_TPL("Check dynamic extract on logical pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/extract/static.arithmetic.cpp
+++ b/test/function/simd/extract/static.arithmetic.cpp
@@ -20,7 +20,7 @@ namespace bd = boost::dispatch;
 template <typename T, std::size_t N, typename Env, typename Idx>
 void unroll_step ( bs::pack<T,N> const& p, std::array<T,N> const& ref, Idx const&, Env& $)
 {
-  STF_EQUAL(bs::extract<Idx::value>(p), ref[Idx::value]);
+  STF_ULP_EQUAL(bs::extract<Idx::value>(p), ref[Idx::value], 0.5);
 }
 
 template <typename T, std::size_t N, typename Env, typename... Idx>

--- a/test/function/simd/extract/static.logical.cpp
+++ b/test/function/simd/extract/static.logical.cpp
@@ -21,7 +21,7 @@ namespace bd = boost::dispatch;
 template <typename T, std::size_t N, typename Env, typename Idx>
 void unroll_step ( bs::pack<T,N> const& p, std::array<T,N> const& ref, Idx const&, Env& $)
 {
-  STF_EQUAL(bs::extract<Idx::value>(p), ref[Idx::value]);
+  STF_ULP_EQUAL(bs::extract<Idx::value>(p), ref[Idx::value], 0.5);
 }
 
 template <typename T, std::size_t N, typename Env, typename... Idx>

--- a/test/function/simd/ffs.cpp
+++ b/test/function/simd/ffs.cpp
@@ -41,7 +41,7 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   pi_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::ffs(aa1), bb);
+  STF_ULP_EQUAL(bs::ffs(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check ffs on pack" ,  STF_NUMERIC_TYPES)

--- a/test/function/simd/firstbitset.cpp
+++ b/test/function/simd/firstbitset.cpp
@@ -32,7 +32,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   pi_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::firstbitset(aa1), bb);
+  STF_ULP_EQUAL(bs::firstbitset(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check firstbitset on pack" ,  STF_NUMERIC_TYPES)

--- a/test/function/simd/firstbitunset.cpp
+++ b/test/function/simd/firstbitunset.cpp
@@ -32,7 +32,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   pi_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::firstbitunset(aa1), bb);
+  STF_ULP_EQUAL(bs::firstbitunset(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check firstbitunset on pack" ,  STF_NUMERIC_TYPES)

--- a/test/function/simd/floor.cpp
+++ b/test/function/simd/floor.cpp
@@ -29,8 +29,8 @@ void test(Env& $)
   }
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
-  STF_IEEE_EQUAL(bs::floor(aa1), bb);
-  STF_EQUAL(bs::std_(bs::floor)(aa1), bb);
+  STF_ULP_EQUAL(bs::floor(aa1), bb, 0.5);
+  STF_ULP_EQUAL(bs::std_(bs::floor)(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check floor on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/fma.cpp
+++ b/test/function/simd/fma.cpp
@@ -31,7 +31,7 @@ void test(Env& $)
   p_t aa2(&a2[0], &a2[0]+N);
   p_t aa3(&a3[0], &a3[0]+N);
   p_t bb (&b [0], &b [0]+N);
-  STF_EQUAL(bs::fma(aa1, aa2, aa3), bb);
+  STF_ULP_EQUAL(bs::fma(aa1, aa2, aa3), bb, 0.5);
 }
 
 STF_CASE_TPL("Check fma on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/genmask/arithmetic.cpp
+++ b/test/function/simd/genmask/arithmetic.cpp
@@ -28,7 +28,7 @@ void test(Env& $)
   }
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
-  STF_IEEE_EQUAL(bs::genmask(aa1), bb);
+  STF_ULP_EQUAL(bs::genmask(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check genmask on pack" , STF_SIGNED_NUMERIC_TYPES)
@@ -58,11 +58,11 @@ STF_CASE_TPL ("Check genmask behavior when re-targeted",  STF_NUMERIC_TYPES)
               , (bs::pack<char,N*sizeof(T)*2>)
               );
 
-  STF_EQUAL ( (genmask<bs::pack<char,N*sizeof(T)>>(bs::pack<T,N>(42)))
+  STF_ULP_EQUAL ( (genmask<bs::pack<char,N*sizeof(T)>>(bs::pack<T,N>(42)))
             , (bs::Allbits<bs::pack<char,N*sizeof(T)>>())
             );
 
-  // STF_EQUAL(genmask<bs::pack<char,N*sizeof(T)>>(T(0)) , char(0));
+  // STF_ULP_EQUAL(genmask<bs::pack<char,N*sizeof(T)>>(T(0)) , char(0), 0.5);
 }
 #endif
 
@@ -77,17 +77,17 @@ STF_CASE_TPL ("Check genmask behavior on IEEE754 special values",  STF_IEEE_TYPE
   using bs::genmask;
   static const std::size_t N = bs::pack<T>::static_size;
 
-  STF_IEEE_EQUAL(genmask(bs::Inf <bs::pack<T,N>>()) , (bs::Allbits<bs::pack<T,N>>()) );
-  STF_IEEE_EQUAL(genmask(bs::Minf<bs::pack<T,N>>()) , (bs::Allbits<bs::pack<T,N>>()) );
-  STF_IEEE_EQUAL(genmask(bs::Nan <bs::pack<T,N>>()) , (bs::Allbits<bs::pack<T,N>>()) );
+  STF_ULP_EQUAL(genmask(bs::Inf <bs::pack<T,N>>()) , (bs::Allbits<bs::pack<T,N>>()) , 0.5);
+  STF_ULP_EQUAL(genmask(bs::Minf<bs::pack<T,N>>()) , (bs::Allbits<bs::pack<T,N>>()) , 0.5);
+  STF_ULP_EQUAL(genmask(bs::Nan <bs::pack<T,N>>()) , (bs::Allbits<bs::pack<T,N>>()) , 0.5);
 
-  STF_IEEE_EQUAL(genmask(bs::Inf <bs::pack<T,N/2>>()) , (bs::Allbits<bs::pack<T,N/2>>()) );
-  STF_IEEE_EQUAL(genmask(bs::Minf<bs::pack<T,N/2>>()) , (bs::Allbits<bs::pack<T,N/2>>()) );
-  STF_IEEE_EQUAL(genmask(bs::Nan <bs::pack<T,N/2>>()) , (bs::Allbits<bs::pack<T,N/2>>()) );
+  STF_ULP_EQUAL(genmask(bs::Inf <bs::pack<T,N/2>>()) , (bs::Allbits<bs::pack<T,N/2>>()) , 0.5);
+  STF_ULP_EQUAL(genmask(bs::Minf<bs::pack<T,N/2>>()) , (bs::Allbits<bs::pack<T,N/2>>()) , 0.5);
+  STF_ULP_EQUAL(genmask(bs::Nan <bs::pack<T,N/2>>()) , (bs::Allbits<bs::pack<T,N/2>>()) , 0.5);
 
-  STF_IEEE_EQUAL(genmask(bs::Inf <bs::pack<T,N*2>>()) , (bs::Allbits<bs::pack<T,N*2>>()) );
-  STF_IEEE_EQUAL(genmask(bs::Minf<bs::pack<T,N*2>>()) , (bs::Allbits<bs::pack<T,N*2>>()) );
-  STF_IEEE_EQUAL(genmask(bs::Nan <bs::pack<T,N*2>>()) , (bs::Allbits<bs::pack<T,N*2>>()) );
+  STF_ULP_EQUAL(genmask(bs::Inf <bs::pack<T,N*2>>()) , (bs::Allbits<bs::pack<T,N*2>>()) , 0.5);
+  STF_ULP_EQUAL(genmask(bs::Minf<bs::pack<T,N*2>>()) , (bs::Allbits<bs::pack<T,N*2>>()) , 0.5);
+  STF_ULP_EQUAL(genmask(bs::Nan <bs::pack<T,N*2>>()) , (bs::Allbits<bs::pack<T,N*2>>()) , 0.5);
 }
 #endif
 

--- a/test/function/simd/genmask/logical.cpp
+++ b/test/function/simd/genmask/logical.cpp
@@ -29,7 +29,7 @@ void testl(Env& $)
   }
   pl_t aa1(&a1[0], &a1[0]+N);
   p_t bb(&b[0], &b[0]+N);
-  STF_IEEE_EQUAL(bs::genmask(aa1), bb);
+  STF_ULP_EQUAL(bs::genmask(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check genmask on pack of logical", STF_NUMERIC_TYPES)
@@ -53,7 +53,7 @@ STF_CASE_TPL("Check genmask on pack of logical", STF_NUMERIC_TYPES)
 
 //   STF_TYPE_IS(decltype(bs::genmask<char>(bs::logical<T>())),char);
 
-//   STF_IEEE_EQUAL(genmask<char>(bs::logical<T>(true)), bs::Allbits<char>());
-//   STF_EQUAL(genmask<char>(bs::logical<T>(false)) , char(0));
+//   STF_ULP_EQUAL(genmask<char>(bs::logical<T>(true)), bs::Allbits<char>(), 0.5);
+//   STF_ULP_EQUAL(genmask<char>(bs::logical<T>(false)) , char(0), 0.5);
 // }
 #endif

--- a/test/function/simd/group.cpp
+++ b/test/function/simd/group.cpp
@@ -46,7 +46,7 @@ void test( Env& $, std::true_type const& )
   p_t aa2(&a2[0], &a2[0]+N);
   g_t bb (&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::group(aa1,aa2), bb);
+  STF_ULP_EQUAL(bs::group(aa1,aa2), bb, 0.5);
 }
 
 STF_CASE_TPL("Check group on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/groups.cpp
+++ b/test/function/simd/groups.cpp
@@ -47,7 +47,7 @@ void test( Env& $, std::true_type const& )
   p_t aa2(&a2[0], &a2[0]+N);
   g_t cc (&c[0], &c[0]+2*N);
 
-  STF_EQUAL(bs::saturated_(bs::group)(aa1,aa2), cc);
+  STF_ULP_EQUAL(bs::saturated_(bs::group)(aa1,aa2), cc, 0.5);
 }
 
 STF_CASE_TPL("Check group on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/hi.cpp
+++ b/test/function/simd/hi.cpp
@@ -34,7 +34,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   i_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::hi(aa1), bb);
+  STF_ULP_EQUAL(bs::hi(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check hi on pack" ,  STF_NUMERIC_TYPES)

--- a/test/function/simd/hmsb.cpp
+++ b/test/function/simd/hmsb.cpp
@@ -28,7 +28,7 @@ void test(Env& $)
     r |= (bs::bits(a1[i]) >> (sizeof(T)*8 - 1)) << i;
   }
   p_t aa1(&a1[0], &a1[0]+N);
-  STF_EQUAL(bs::hmsb(aa1), r);
+  STF_ULP_EQUAL(bs::hmsb(aa1), r, 0.5);
 }
 
 STF_CASE_TPL("Check hmsb on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/iceil.cpp
+++ b/test/function/simd/iceil.cpp
@@ -32,7 +32,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   pi_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::iceil(aa1), bb);
+  STF_ULP_EQUAL(bs::iceil(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check iceil on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/if_else.cpp
+++ b/test/function/simd/if_else.cpp
@@ -35,7 +35,7 @@ void test(Env& $)
   p_t aa2(&a2[0], &a2[0]+N);
   p_t aa3(&a3[0], &a3[0]+N);
   p_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::if_else(aa1, aa2, aa3), bb);
+  STF_ULP_EQUAL(bs::if_else(aa1, aa2, aa3), bb, 0.5);
 }
 
 STF_CASE_TPL("Check if_else on pack" , STF_NUMERIC_TYPES)
@@ -69,7 +69,7 @@ void testl(Env& $)
   p_t aa2(&a2[0], &a2[0]+N);
   p_t aa3(&a3[0], &a3[0]+N);
   p_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::if_else(aa1, aa2, aa3), bb);
+  STF_ULP_EQUAL(bs::if_else(aa1, aa2, aa3), bb, 0.5);
 }
 
 STF_CASE_TPL("Check if_else on pack of logical" , STF_NUMERIC_TYPES)

--- a/test/function/simd/ifix.cpp
+++ b/test/function/simd/ifix.cpp
@@ -32,7 +32,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   pi_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::ifix(aa1), bb);
+  STF_ULP_EQUAL(bs::ifix(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check ifix on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/ifloor.cpp
+++ b/test/function/simd/ifloor.cpp
@@ -32,7 +32,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   pi_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::ifloor(aa1), bb);
+  STF_ULP_EQUAL(bs::ifloor(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check ifloor on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/ilog2.cpp
+++ b/test/function/simd/ilog2.cpp
@@ -39,7 +39,7 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   i_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::ilog2(aa1), bb);
+  STF_ULP_EQUAL(bs::ilog2(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check ilog2 on pack",  STF_NUMERIC_TYPES)

--- a/test/function/simd/ilogb.cpp
+++ b/test/function/simd/ilogb.cpp
@@ -32,7 +32,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   i_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::ilogb(aa1), bb);
+  STF_ULP_EQUAL(bs::ilogb(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check ilogb on pack" , // (float)(double)(int8_t)(int32_t)(uint64_t)(uint8_t)(uint32_t)(uint64_t))//

--- a/test/function/simd/inc.cpp
+++ b/test/function/simd/inc.cpp
@@ -30,8 +30,8 @@ void pre_test(Env& $)
   p_t bb(&b[0], &b[0]+N);
 
   aa2 = ++aa1;
-  STF_EQUAL(aa2, bb);
-  STF_EQUAL(aa1, bb);
+  STF_ULP_EQUAL(aa2, bb, 0.5);
+  STF_ULP_EQUAL(aa1, bb, 0.5);
 }
 
 STF_CASE_TPL("Check pre-increment on pack" , STF_NUMERIC_TYPES)
@@ -59,8 +59,8 @@ void post_test(Env& $)
   p_t bb(&b[0], &b[0]+N);
 
   aa2 = aa1++;
-  STF_EQUAL(aa2, prev);
-  STF_EQUAL(aa1, bb);
+  STF_ULP_EQUAL(aa2, prev, 0.5);
+  STF_ULP_EQUAL(aa1, bb, 0.5);
 }
 
 STF_CASE_TPL("Check post-increment on pack" , STF_NUMERIC_TYPES)
@@ -87,7 +87,7 @@ void tests(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::saturated_(bs::inc)(aa1), bb);
+  STF_ULP_EQUAL(bs::saturated_(bs::inc)(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check inc on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/inearbyint.cpp
+++ b/test/function/simd/inearbyint.cpp
@@ -34,8 +34,8 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   pi_t bb(&b[0], &b[0]+N);
   pi_t cc(&c[0], &c[0]+N);
-  STF_EQUAL(bs::fast_(bs::inearbyint)(aa1), bb);
-  STF_EQUAL(bs::inearbyint(aa1), cc);
+  STF_ULP_EQUAL(bs::fast_(bs::inearbyint)(aa1), bb, 0.5);
+  STF_ULP_EQUAL(bs::inearbyint(aa1), cc, 0.5);
 }
 
 STF_CASE_TPL("Check inearbyint on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/insert/dynamic.logical.cpp
+++ b/test/function/simd/insert/dynamic.logical.cpp
@@ -29,7 +29,7 @@ void test(Env& $)
     ref[i] = i%2 ? true : false;
   }
 
-  for(std::size_t i = 0;i < N; ++i) STF_EQUAL( p[i], ref[i] );
+  for(std::size_t i = 0;i < N; ++i) STF_EQUAL( p[i], ref[i]);
 }
 
 STF_CASE_TPL("Check dynamic insert on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/insert/static.logical.cpp
+++ b/test/function/simd/insert/static.logical.cpp
@@ -33,7 +33,7 @@ void test_st(Env& $)
 
   f( brigand::range<std::size_t, 0, N>(),ref,p);
 
-  for(std::size_t i = 0;i < N; ++i) STF_EQUAL( p[i], ref[i] );
+  for(std::size_t i = 0;i < N; ++i) STF_EQUAL( p[i], ref[i]);
 }
 
 STF_CASE_TPL("Check static insert on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/interleave.cpp
+++ b/test/function/simd/interleave.cpp
@@ -33,8 +33,8 @@ void test(Env& $, std::true_type const& = {})
   p_t aa2(&a2[0], &a2[0]+N);
 
   std::array<p_t,2> out = bs::interleave(aa1, aa2);
-  STF_EQUAL( out[0], bs::interleave_first(aa1,aa2)  );
-  STF_EQUAL( out[1], bs::interleave_second(aa1,aa2) );
+  STF_ULP_EQUAL( out[0], bs::interleave_first(aa1,aa2)  , 0.5);
+  STF_ULP_EQUAL( out[1], bs::interleave_second(aa1,aa2) , 0.5);
 }
 
 STF_CASE_TPL("Check interleave on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/interleave_even.cpp
+++ b/test/function/simd/interleave_even.cpp
@@ -37,7 +37,7 @@ void test(Env& $, std::true_type const& = {})
   p_t aa2(&a2[0], &a2[0]+N);
   p_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::interleave_even(aa1, aa2), bb);
+  STF_ULP_EQUAL(bs::interleave_even(aa1, aa2), bb, 0.5);
 }
 
 STF_CASE_TPL("Check interleave_even on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/interleave_first.cpp
+++ b/test/function/simd/interleave_first.cpp
@@ -38,7 +38,7 @@ void test(Env& $, std::true_type const& = {})
   p_t aa2(&a2[0], &a2[0]+N);
   p_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::interleave_first(aa1, aa2), bb);
+  STF_ULP_EQUAL(bs::interleave_first(aa1, aa2), bb, 0.5);
 }
 
 STF_CASE_TPL("Check interleave_first on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/interleave_odd.cpp
+++ b/test/function/simd/interleave_odd.cpp
@@ -38,7 +38,7 @@ void test(Env& $, std::true_type const& = {})
   p_t aa2(&a2[0], &a2[0]+N);
   p_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::interleave_odd(aa1, aa2), bb);
+  STF_ULP_EQUAL(bs::interleave_odd(aa1, aa2), bb, 0.5);
 }
 
 STF_CASE_TPL("Check interleave_odd on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/interleave_second.cpp
+++ b/test/function/simd/interleave_second.cpp
@@ -38,7 +38,7 @@ void test(Env& $, std::true_type const& = {})
   p_t aa2(&a2[0], &a2[0]+N);
   p_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::interleave_second(aa1, aa2), bb);
+  STF_ULP_EQUAL(bs::interleave_second(aa1, aa2), bb, 0.5);
 }
 
 STF_CASE_TPL("Check interleave_second on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/iround.cpp
+++ b/test/function/simd/iround.cpp
@@ -32,7 +32,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   pi_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::iround(aa1), bb);
+  STF_ULP_EQUAL(bs::iround(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check iround on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/is_equal.cpp
+++ b/test/function/simd/is_equal.cpp
@@ -34,8 +34,8 @@ void test(Env& $)
   p_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::is_equal(aa1, aa2), bb);
-  STF_EQUAL(aa1 == aa2, bb);
+  STF_ULP_EQUAL(bs::is_equal(aa1, aa2), bb, 0.5);
+  STF_ULP_EQUAL(aa1 == aa2, bb, 0.5);
 }
 
 STF_CASE_TPL("Check is_equal on pack", STF_NUMERIC_TYPES)
@@ -65,8 +65,8 @@ void testl(Env& $)
   pl_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::is_equal(aa1, aa2), bb);
-  STF_EQUAL(aa1 == aa2, bb);
+  STF_ULP_EQUAL(bs::is_equal(aa1, aa2), bb, 0.5);
+  STF_ULP_EQUAL(aa1 == aa2, bb, 0.5);
 }
 
 STF_CASE_TPL("Check is_equal on pack of logical", STF_NUMERIC_TYPES)

--- a/test/function/simd/is_eqz.cpp
+++ b/test/function/simd/is_eqz.cpp
@@ -30,7 +30,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::is_eqz(aa1), bb);
+  STF_ULP_EQUAL(bs::is_eqz(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check is_eqz on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/is_gez.cpp
+++ b/test/function/simd/is_gez.cpp
@@ -30,7 +30,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::is_gez(aa1), bb);
+  STF_ULP_EQUAL(bs::is_gez(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check is_gez on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/is_greater.cpp
+++ b/test/function/simd/is_greater.cpp
@@ -33,8 +33,8 @@ void test(Env& $)
   p_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::is_greater(aa1, aa2), bb);
-  STF_EQUAL(aa1 > aa2, bb);
+  STF_ULP_EQUAL(bs::is_greater(aa1, aa2), bb, 0.5);
+  STF_ULP_EQUAL(aa1 > aa2, bb, 0.5);
 }
 
 STF_CASE_TPL("Check is_greater on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/is_greater_equal.cpp
+++ b/test/function/simd/is_greater_equal.cpp
@@ -33,8 +33,8 @@ void test(Env& $)
   p_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::is_greater_equal(aa1, aa2), bb);
-  STF_EQUAL(aa1 >= aa2, bb);
+  STF_ULP_EQUAL(bs::is_greater_equal(aa1, aa2), bb, 0.5);
+  STF_ULP_EQUAL(aa1 >= aa2, bb, 0.5);
 }
 
 STF_CASE_TPL("Check is_greater_equal on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/is_gtz.cpp
+++ b/test/function/simd/is_gtz.cpp
@@ -30,7 +30,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::is_gtz(aa1), bb);
+  STF_ULP_EQUAL(bs::is_gtz(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check is_gtz on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/is_less.cpp
+++ b/test/function/simd/is_less.cpp
@@ -33,8 +33,8 @@ void test(Env& $)
   p_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::is_less(aa1, aa2), bb);
-  STF_EQUAL(aa1 < aa2, bb);
+  STF_ULP_EQUAL(bs::is_less(aa1, aa2), bb, 0.5);
+  STF_ULP_EQUAL(aa1 < aa2, bb, 0.5);
 }
 
 STF_CASE_TPL("Check is_less on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/is_less_equal.cpp
+++ b/test/function/simd/is_less_equal.cpp
@@ -33,8 +33,8 @@ void test(Env& $)
   p_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::is_less_equal(aa1, aa2), bb);
-  STF_EQUAL(aa1 <= aa2, bb);
+  STF_ULP_EQUAL(bs::is_less_equal(aa1, aa2), bb, 0.5);
+  STF_ULP_EQUAL(aa1 <= aa2, bb, 0.5);
 }
 
 STF_CASE_TPL("Check is_less_equal on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/is_lessgreater.cpp
+++ b/test/function/simd/is_lessgreater.cpp
@@ -36,8 +36,8 @@ void test(Env& $)
   pl_t bb(&b[0], &b[0]+N);
   pl_t cc(&c[0], &c[0]+N);
 
-  STF_EQUAL(bs::is_lessgreater(aa1, aa2), bb);
-  STF_EQUAL(bs::std_(bs::is_lessgreater)(aa1, aa2), cc);
+  STF_ULP_EQUAL(bs::is_lessgreater(aa1, aa2), bb, 0.5);
+  STF_ULP_EQUAL(bs::std_(bs::is_lessgreater)(aa1, aa2), cc, 0.5);
 }
 
 STF_CASE_TPL("Check is_lessgreater on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/is_lez.cpp
+++ b/test/function/simd/is_lez.cpp
@@ -30,7 +30,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::is_lez(aa1), bb);
+  STF_ULP_EQUAL(bs::is_lez(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check is_lez on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/is_ltz.cpp
+++ b/test/function/simd/is_ltz.cpp
@@ -30,7 +30,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::is_ltz(aa1), bb);
+  STF_ULP_EQUAL(bs::is_ltz(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check is_ltz on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/is_nez.cpp
+++ b/test/function/simd/is_nez.cpp
@@ -30,7 +30,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::is_nez(aa1), bb);
+  STF_ULP_EQUAL(bs::is_nez(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check is_nez on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/is_not_equal.cpp
+++ b/test/function/simd/is_not_equal.cpp
@@ -35,8 +35,8 @@ void test(Env& $)
   p_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::is_not_equal(aa1, aa2), bb);
-  STF_EQUAL(aa1 != aa2 , bb);
+  STF_ULP_EQUAL(bs::is_not_equal(aa1, aa2), bb, 0.5);
+  STF_ULP_EQUAL(aa1 != aa2 , bb, 0.5);
 }
 
 STF_CASE_TPL("Check is_not_equal on pack", STF_NUMERIC_TYPES)
@@ -67,8 +67,8 @@ void testl(Env& $)
   pl_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::is_not_equal(aa1, aa2), bb);
-  STF_EQUAL(aa1 != aa2 , bb);
+  STF_ULP_EQUAL(bs::is_not_equal(aa1, aa2), bb, 0.5);
+  STF_ULP_EQUAL(aa1 != aa2 , bb, 0.5);
 }
 
 STF_CASE_TPL("Check is_not_equal on pack of logical", STF_NUMERIC_TYPES)

--- a/test/function/simd/is_not_greater.cpp
+++ b/test/function/simd/is_not_greater.cpp
@@ -32,7 +32,7 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::is_not_greater(aa1, aa2), bb);
+  STF_ULP_EQUAL(bs::is_not_greater(aa1, aa2), bb, 0.5);
 }
 
 STF_CASE_TPL("Check is_not_greater on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/is_not_greater_equal.cpp
+++ b/test/function/simd/is_not_greater_equal.cpp
@@ -32,7 +32,7 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::is_not_greater_equal(aa1, aa2), bb);
+  STF_ULP_EQUAL(bs::is_not_greater_equal(aa1, aa2), bb, 0.5);
 }
 
 STF_CASE_TPL("Check is_not_greater_equal on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/is_not_less.cpp
+++ b/test/function/simd/is_not_less.cpp
@@ -32,7 +32,7 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::is_not_less(aa1, aa2), bb);
+  STF_ULP_EQUAL(bs::is_not_less(aa1, aa2), bb, 0.5);
 }
 
 STF_CASE_TPL("Check is_not_less on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/is_not_less_equal.cpp
+++ b/test/function/simd/is_not_less_equal.cpp
@@ -32,7 +32,7 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::is_not_less_equal(aa1, aa2), bb);
+  STF_ULP_EQUAL(bs::is_not_less_equal(aa1, aa2), bb, 0.5);
 }
 
 STF_CASE_TPL("Check is_not_less_equal on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/is_ord.cpp
+++ b/test/function/simd/is_ord.cpp
@@ -32,7 +32,7 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::is_ord(aa1, aa2), bb);
+  STF_ULP_EQUAL(bs::is_ord(aa1, aa2), bb, 0.5);
 }
 
 STF_CASE_TPL("Check is_ord on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/is_simd_logical.cpp
+++ b/test/function/simd/is_simd_logical.cpp
@@ -29,8 +29,8 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   p_t aa2(&a2[0], &a2[0]+N);
-  STF_EQUAL(bs::is_simd_logical(aa1), true);
-  STF_EQUAL(bs::is_simd_logical(aa2), false);
+  STF_ULP_EQUAL(bs::is_simd_logical(aa1), true, 0.5);
+  STF_ULP_EQUAL(bs::is_simd_logical(aa2), false, 0.5);
 }
 
 STF_CASE_TPL("Check is_simd_logical on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/is_unord.cpp
+++ b/test/function/simd/is_unord.cpp
@@ -36,9 +36,9 @@ void test(Env& $)
   pl_t bb(&b[0], &b[0]+N);
   pl_t cc(&c[0], &c[0]+N);
 
-  STF_EQUAL(bs::is_unord(aa1, aa2), bb);
-  STF_EQUAL(aa1 > aa2, bb);
-  STF_EQUAL(bs::std_(bs::is_unord)(aa1, aa2), cc);
+  STF_ULP_EQUAL(bs::is_unord(aa1, aa2), bb, 0.5);
+  STF_ULP_EQUAL(aa1 > aa2, bb, 0.5);
+  STF_ULP_EQUAL(bs::std_(bs::is_unord)(aa1, aa2), cc, 0.5);
 }
 
 STF_CASE_TPL("Check is_unord on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/isincluded.cpp
+++ b/test/function/simd/isincluded.cpp
@@ -33,7 +33,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   p_t aa2(&a2[0], &a2[0]+N);
-  STF_EQUAL(bs::isincluded(aa1, aa2), b);
+  STF_ULP_EQUAL(bs::isincluded(aa1, aa2), b, 0.5);
 }
 
 STF_CASE_TPL("Check isincluded on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/isincluded_c.cpp
+++ b/test/function/simd/isincluded_c.cpp
@@ -33,7 +33,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   p_t aa2(&a2[0], &a2[0]+N);
-  STF_EQUAL(bs::isincluded_c(aa1, aa2), b);
+  STF_ULP_EQUAL(bs::isincluded_c(aa1, aa2), b, 0.5);
 }
 
 STF_CASE_TPL("Check isincluded_c on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/itrunc.cpp
+++ b/test/function/simd/itrunc.cpp
@@ -32,7 +32,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   pi_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::itrunc(aa1), bb);
+  STF_ULP_EQUAL(bs::itrunc(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check itrunc on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/lo.cpp
+++ b/test/function/simd/lo.cpp
@@ -32,7 +32,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   i_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::lo(aa1), bb);
+  STF_ULP_EQUAL(bs::lo(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check lo on pack" ,  STF_NUMERIC_TYPES)

--- a/test/function/simd/logical_and.cpp
+++ b/test/function/simd/logical_and.cpp
@@ -35,8 +35,8 @@ void test(Env& $)
   p_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::logical_and(aa1, aa2), bb);
-  STF_EQUAL(aa1 && aa2, bb);
+  STF_ULP_EQUAL(bs::logical_and(aa1, aa2), bb, 0.5);
+  STF_ULP_EQUAL(aa1 && aa2, bb, 0.5);
 }
 
 STF_CASE_TPL("Check logical_and on pack" , STF_NUMERIC_TYPES)
@@ -66,8 +66,8 @@ void testl(Env& $)
   pl_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::logical_and(aa1, aa2), bb);
-  STF_EQUAL(aa1 && aa2, bb);
+  STF_ULP_EQUAL(bs::logical_and(aa1, aa2), bb, 0.5);
+  STF_ULP_EQUAL(aa1 && aa2, bb, 0.5);
 }
 
 STF_CASE_TPL("Check logical_and on pack of logical", STF_NUMERIC_TYPES)

--- a/test/function/simd/logical_andnot.cpp
+++ b/test/function/simd/logical_andnot.cpp
@@ -36,8 +36,8 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::logical_andnot(aa1, aa2), bb);
-//  STF_IEEE_EQUAL(aa1&&!aa2, bb);
+  STF_ULP_EQUAL(bs::logical_andnot(aa1, aa2), bb, 0.5);
+//  STF_ULP_EQUAL(aa1&&!aa2, bb, 0.5);
 }
 
 STF_CASE_TPL("Check logical_andnot on pack" , STF_NUMERIC_TYPES)
@@ -66,8 +66,8 @@ void testl(Env& $)
   pl_t aa1(&a1[0], &a1[0]+N);
   pl_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::logical_andnot(aa1, aa2), bb);
-//  STF_EQUAL(aa1&&!aa2, bb);
+  STF_ULP_EQUAL(bs::logical_andnot(aa1, aa2), bb, 0.5);
+//  STF_ULP_EQUAL(aa1&&!aa2, bb, 0.5);
 }
 
 STF_CASE_TPL("Check logical_andnot on pack of logical", STF_NUMERIC_TYPES)

--- a/test/function/simd/logical_not.cpp
+++ b/test/function/simd/logical_not.cpp
@@ -33,8 +33,8 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   pl_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::logical_not(aa1), bb);
-  STF_EQUAL(!aa1, bb);
+  STF_ULP_EQUAL(bs::logical_not(aa1), bb, 0.5);
+  STF_ULP_EQUAL(!aa1, bb, 0.5);
 }
 
 STF_CASE_TPL("Check logical_not on pack", STF_NUMERIC_TYPES)
@@ -63,8 +63,8 @@ void testl(Env& $)
   pl_t aa1(&a1[0], &a1[0]+N);
   pl_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::logical_not(aa1), bb);
-  STF_EQUAL(!aa1, bb);
+  STF_ULP_EQUAL(bs::logical_not(aa1), bb, 0.5);
+  STF_ULP_EQUAL(!aa1, bb, 0.5);
 }
 
 STF_CASE_TPL("Check logical_not on pack of logical", STF_NUMERIC_TYPES)

--- a/test/function/simd/logical_notand.cpp
+++ b/test/function/simd/logical_notand.cpp
@@ -36,8 +36,8 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::logical_notand(aa1, aa2), bb);
-//  STF_IEEE_EQUAL(!aa1&&aa2, bb);
+  STF_ULP_EQUAL(bs::logical_notand(aa1, aa2), bb, 0.5);
+//  STF_ULP_EQUAL(!aa1&&aa2, bb, 0.5);
 }
 
 STF_CASE_TPL("Check logical_notand on pack" , STF_NUMERIC_TYPES)
@@ -66,8 +66,8 @@ void testl(Env& $)
   pl_t aa1(&a1[0], &a1[0]+N);
   pl_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::logical_notand(aa1, aa2), bb);
-//  STF_EQUAL(!aa1&&aa2, bb);
+  STF_ULP_EQUAL(bs::logical_notand(aa1, aa2), bb, 0.5);
+//  STF_ULP_EQUAL(!aa1&&aa2, bb, 0.5);
 }
 
 STF_CASE_TPL("Check logical_notand on pack of logical", STF_NUMERIC_TYPES)

--- a/test/function/simd/logical_notor.cpp
+++ b/test/function/simd/logical_notor.cpp
@@ -36,8 +36,8 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::logical_notor(aa1, aa2), bb);
-//  STF_IEEE_EQUAL(!aa1||aa2, bb);
+  STF_ULP_EQUAL(bs::logical_notor(aa1, aa2), bb, 0.5);
+//  STF_ULP_EQUAL(!aa1||aa2, bb, 0.5);
 }
 
 STF_CASE_TPL("Check logical_notor on pack" , STF_NUMERIC_TYPES)
@@ -66,8 +66,8 @@ void testl(Env& $)
   pl_t aa1(&a1[0], &a1[0]+N);
   pl_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::logical_notor(aa1, aa2), bb);
-//  STF_EQUAL(!aa1||aa2, bb);
+  STF_ULP_EQUAL(bs::logical_notor(aa1, aa2), bb, 0.5);
+//  STF_ULP_EQUAL(!aa1||aa2, bb, 0.5);
 }
 
 STF_CASE_TPL("Check logical_notor on pack of logical", STF_NUMERIC_TYPES)

--- a/test/function/simd/logical_or.cpp
+++ b/test/function/simd/logical_or.cpp
@@ -34,8 +34,8 @@ void test(Env& $)
   p_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::logical_or(aa1, aa2), bb);
-  STF_EQUAL(aa1 || aa2, bb);
+  STF_ULP_EQUAL(bs::logical_or(aa1, aa2), bb, 0.5);
+  STF_ULP_EQUAL(aa1 || aa2, bb, 0.5);
 }
 
 STF_CASE_TPL("Check logical_or on pack" , STF_NUMERIC_TYPES)
@@ -65,8 +65,8 @@ void testl(Env& $)
   pl_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::logical_or(aa1, aa2), bb);
-  STF_EQUAL(aa1 || aa2, bb);
+  STF_ULP_EQUAL(bs::logical_or(aa1, aa2), bb, 0.5);
+  STF_ULP_EQUAL(aa1 || aa2, bb, 0.5);
 }
 
 STF_CASE_TPL("Check logical_or on pack of logical", STF_NUMERIC_TYPES)

--- a/test/function/simd/logical_ornot.cpp
+++ b/test/function/simd/logical_ornot.cpp
@@ -36,8 +36,8 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::logical_ornot(aa1, aa2), bb);
-//  STF_IEEE_EQUAL(aa1||!aa2, bb);
+  STF_ULP_EQUAL(bs::logical_ornot(aa1, aa2), bb, 0.5);
+//  STF_ULP_EQUAL(aa1||!aa2, bb, 0.5);
 }
 
 STF_CASE_TPL("Check logical_ornot on pack" , STF_NUMERIC_TYPES)
@@ -66,8 +66,8 @@ void testl(Env& $)
   pl_t aa1(&a1[0], &a1[0]+N);
   pl_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::logical_ornot(aa1, aa2), bb);
-//  STF_EQUAL(aa1||!aa2, bb);
+  STF_ULP_EQUAL(bs::logical_ornot(aa1, aa2), bb, 0.5);
+//  STF_ULP_EQUAL(aa1||!aa2, bb, 0.5);
 }
 
 STF_CASE_TPL("Check logical_ornot on pack of logical", STF_NUMERIC_TYPES)

--- a/test/function/simd/logical_xor.cpp
+++ b/test/function/simd/logical_xor.cpp
@@ -34,7 +34,7 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::logical_xor(aa1, aa2), bb);
+  STF_ULP_EQUAL(bs::logical_xor(aa1, aa2), bb, 0.5);
 }
 
 STF_CASE_TPL("Check logical_xor on pack" , STF_NUMERIC_TYPES)
@@ -63,7 +63,7 @@ void testl(Env& $)
   pl_t aa1(&a1[0], &a1[0]+N);
   pl_t aa2(&a2[0], &a2[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::logical_xor(aa1, aa2), bb);
+  STF_ULP_EQUAL(bs::logical_xor(aa1, aa2), bb, 0.5);
 }
 
 STF_CASE_TPL("Check logical_xor on pack of logical", STF_NUMERIC_TYPES)

--- a/test/function/simd/lookup.cpp
+++ b/test/function/simd/lookup.cpp
@@ -38,7 +38,7 @@ void test(Env& $)
   i_t aa2(&a2[0], &a2[0]+N);
   p_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::lookup(aa1, aa2), bb);
+  STF_ULP_EQUAL(bs::lookup(aa1, aa2), bb, 0.5);
 }
 
 STF_CASE_TPL("Check lookup on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/mask2logical.cpp
+++ b/test/function/simd/mask2logical.cpp
@@ -31,7 +31,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
   pl_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::mask2logical(aa1), bb);
+  STF_ULP_EQUAL(bs::mask2logical(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check mask2logical on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/max.cpp
+++ b/test/function/simd/max.cpp
@@ -29,7 +29,7 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t aa2(&a2[0], &a2[0]+N);
   p_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::max(aa1, aa2), bb);
+  STF_ULP_EQUAL(bs::max(aa1, aa2), bb, 0.5);
 }
 
 STF_CASE_TPL("Check max on integral pack" , STF_NUMERIC_TYPES)
@@ -48,8 +48,8 @@ STF_CASE_TPL("Check conformant max on nans  pack" , STF_IEEE_TYPES)
     using p_t = bs::pack<T, N>;
     p_t n =  bs::Nan<p_t>();
     p_t o =  bs::One<p_t>();
-    STF_IEEE_EQUAL(bs::conformant_(bs::max)(n, o), n);
-    STF_IEEE_EQUAL(bs::conformant_(bs::max)(o, n), o);
+    STF_ULP_EQUAL(bs::conformant_(bs::max)(n, o), n, 0.5);
+    STF_ULP_EQUAL(bs::conformant_(bs::max)(o, n), o, 0.5);
   }
 
 }

--- a/test/function/simd/maximum.cpp
+++ b/test/function/simd/maximum.cpp
@@ -30,8 +30,8 @@ void test(Env& $)
   }
   p_t aa1(&a1[0], &a1[0]+N);
 
-  STF_EQUAL(bs::maximum(aa1), b);
-  STF_EQUAL(bs::splatted_(bs::maximum)(aa1), p_t(b) );
+  STF_ULP_EQUAL(bs::maximum(aa1), b, 0.5);
+  STF_ULP_EQUAL(bs::splatted_(bs::maximum)(aa1), p_t(b) , 0.5);
 }
 
 STF_CASE_TPL("Check maximum on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/min.cpp
+++ b/test/function/simd/min.cpp
@@ -29,7 +29,7 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t aa2(&a2[0], &a2[0]+N);
   p_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::min(aa1, aa2), bb);
+  STF_ULP_EQUAL(bs::min(aa1, aa2), bb, 0.5);
 }
 
 STF_CASE_TPL("Check min on integral pack" , STF_NUMERIC_TYPES)
@@ -48,8 +48,8 @@ STF_CASE_TPL("Check conformant min on nans  pack" , STF_IEEE_TYPES)
     using p_t = bs::pack<T, N>;
     p_t n =  bs::Nan<p_t>();
     p_t o =  bs::One<p_t>();
-    STF_IEEE_EQUAL(bs::conformant_(bs::min)(n, o), n);
-    STF_IEEE_EQUAL(bs::conformant_(bs::min)(o, n), o);
+    STF_ULP_EQUAL(bs::conformant_(bs::min)(n, o), n, 0.5);
+    STF_ULP_EQUAL(bs::conformant_(bs::min)(o, n), o, 0.5);
   }
 
 }

--- a/test/function/simd/minimum.cpp
+++ b/test/function/simd/minimum.cpp
@@ -30,8 +30,8 @@ void test(Env& $)
   }
   p_t aa1(&a1[0], &a1[0]+N);
 
-  STF_EQUAL(bs::minimum(aa1), b);
-  STF_EQUAL(bs::splatted_(bs::minimum)(aa1), p_t(b) );
+  STF_ULP_EQUAL(bs::minimum(aa1), b, 0.5);
+  STF_ULP_EQUAL(bs::splatted_(bs::minimum)(aa1), p_t(b) , 0.5);
 }
 
 STF_CASE_TPL("Check minimum on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/minus.cpp
+++ b/test/function/simd/minus.cpp
@@ -34,8 +34,8 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t aa2(&a2[0], &a2[0]+N);
   p_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::minus(aa1, aa2), bb);
-  STF_EQUAL(aa1- aa2, bb);
+  STF_ULP_EQUAL(bs::minus(aa1, aa2), bb, 0.5);
+  STF_ULP_EQUAL(aa1- aa2, bb, 0.5);
 }
 
 STF_CASE_TPL("Check minus on pack" , STF_NUMERIC_TYPES)
@@ -67,7 +67,7 @@ void tests(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t aa2(&a2[0], &a2[0]+N);
   p_t bb(&b[0], &b[0]+N);
-  STF_IEEE_EQUAL(bs::saturated_(bs::minus)(aa1, aa2), bb);
+  STF_ULP_EQUAL(bs::saturated_(bs::minus)(aa1, aa2), bb, 0.5);
 }
 
 STF_CASE_TPL("Check minus on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/multiplies.cpp
+++ b/test/function/simd/multiplies.cpp
@@ -33,8 +33,8 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t aa2(&a2[0], &a2[0]+N);
   p_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::multiplies(aa1, aa2), bb);
-  STF_EQUAL(aa1*aa2, bb);
+  STF_ULP_EQUAL(bs::multiplies(aa1, aa2), bb, 0.5);
+  STF_ULP_EQUAL(aa1*aa2, bb, 0.5);
 }
 
 STF_CASE_TPL("Check multiplies on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/nbtrue.cpp
+++ b/test/function/simd/nbtrue.cpp
@@ -26,7 +26,7 @@ void test(Env& $)
    }
   p_t aa1(&a1[0], &a1[0]+N);
 
-  STF_EQUAL(bs::nbtrue(aa1), r);
+  STF_ULP_EQUAL(bs::nbtrue(aa1), r, 0.5);
 }
 
 STF_CASE_TPL("Check nbtrue on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/none.cpp
+++ b/test/function/simd/none.cpp
@@ -34,8 +34,8 @@ void test(Env& $)
   STF_EQUAL(bs::none(aa1), b);
   STF_EQUAL(bs::none(aa2), c);
 
-  STF_EQUAL(bs::splatted_(bs::none)(aa1), (bs::pack<bs::logical<T>,N>(b)) );
-  STF_EQUAL(bs::splatted_(bs::none)(aa2), (bs::pack<bs::logical<T>,N>(c)) );
+  STF_EQUAL(bs::splatted_(bs::none)(aa1), (bs::pack<bs::logical<T>,N>(b)));
+  STF_EQUAL(bs::splatted_(bs::none)(aa2), (bs::pack<bs::logical<T>,N>(c)));
 }
 
 STF_CASE_TPL("Check none on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/oneminus.cpp
+++ b/test/function/simd/oneminus.cpp
@@ -29,7 +29,7 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::oneminus(aa1), bb);
+  STF_ULP_EQUAL(bs::oneminus(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check oneminus saturated on pack" , STF_NUMERIC_TYPES)
@@ -56,7 +56,7 @@ void tests(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::saturated_(bs::oneminus)(aa1), bb);
+  STF_ULP_EQUAL(bs::saturated_(bs::oneminus)(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check oneminus on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/prod.cpp
+++ b/test/function/simd/prod.cpp
@@ -30,8 +30,8 @@ void test(Env& $)
   }
   p_t aa1(&a1[0], &a1[0]+N);
 
-  STF_EQUAL(bs::prod(aa1), b);
-  STF_EQUAL(bs::splatted_(bs::prod)(aa1), p_t(b) );
+  STF_ULP_EQUAL(bs::prod(aa1), b, 0.5);
+  STF_ULP_EQUAL(bs::splatted_(bs::prod)(aa1), p_t(b) , 0.5);
 }
 
 STF_CASE_TPL("Check prod on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/rem_2pi.cpp
+++ b/test/function/simd/rem_2pi.cpp
@@ -21,8 +21,6 @@ void test(Env& $)
   namespace bd = boost::dispatch;
 
   using p_t = bs::pack<T, N>;
-  using iT = bd::as_integer_t<T>;
-  using i_t = bs::pack<iT, N>;
 
   T a1[N], m[N];
   for(std::size_t i = 0; i < N; ++i)

--- a/test/function/simd/repeat_lower_half.cpp
+++ b/test/function/simd/repeat_lower_half.cpp
@@ -27,7 +27,7 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::repeat_lower_half(aa1), bb);
+  STF_ULP_EQUAL(bs::repeat_lower_half(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check repeat_lower_half on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/repeat_upper_half.cpp
+++ b/test/function/simd/repeat_upper_half.cpp
@@ -24,7 +24,7 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb(&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::repeat_upper_half(aa1), bb);
+  STF_ULP_EQUAL(bs::repeat_upper_half(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check repeat_lower_half on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/reverse.cpp
+++ b/test/function/simd/reverse.cpp
@@ -27,7 +27,7 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::reverse(aa1), bb);
+  STF_ULP_EQUAL(bs::reverse(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check reverse on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/round.cpp
+++ b/test/function/simd/round.cpp
@@ -33,8 +33,8 @@ void test(Env& $)
   }
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
-  STF_EQUAL(bs::round(aa1), bb);
-  STF_EQUAL(bs::std_(bs::round)(aa1), bb);
+  STF_ULP_EQUAL(bs::round(aa1), bb, 0.5);
+  STF_ULP_EQUAL(bs::std_(bs::round)(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check round on pack" , STF_NUMERIC_TYPES)
@@ -55,8 +55,8 @@ STF_CASE_TPL("Check round on halfs" , STF_IEEE_TYPES)
   p_t b(2.5);
   for(int i = 1; i <= 9; i+= 1)
   {
-    STF_IEEE_EQUAL(bs::round(p_t(i+T(0.5))), p_t(i+1));
-    STF_IEEE_EQUAL(bs::round(p_t(-i-T(0.5))),  p_t(-i-1));
+    STF_ULP_EQUAL(bs::round(p_t(i+T(0.5))), p_t(i+1), 0.5);
+    STF_ULP_EQUAL(bs::round(p_t(-i-T(0.5))),  p_t(-i-1), 0.5);
   }
   STF_EXPECT(bs::is_negative(round(bs::Mzero<T>())));
   STF_EXPECT(bs::is_positive(round(bs::Zero<T>())));

--- a/test/function/simd/rshl.cpp
+++ b/test/function/simd/rshl.cpp
@@ -36,8 +36,8 @@ void test(Env& $)
   p_t bb(&b[0], &b[0]+N);
   p_t cc(&c[0], &c[0]+N);
 
-  STF_EQUAL(bs::rshl(aa1, sh1), bb);
-  STF_EQUAL(bs::rshl(aa1, sh2), cc);
+  STF_ULP_EQUAL(bs::rshl(aa1, sh1), bb, 0.5);
+  STF_ULP_EQUAL(bs::rshl(aa1, sh2), cc, 0.5);
 }
 
 STF_CASE_TPL("Check rshl on pack with integral shift" , STF_SIGNED_INTEGRAL_TYPES)
@@ -69,7 +69,7 @@ void tests(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb(&b[0], &b[0]+N);
   i_t sh1(&sh[0], &sh[0]+N);
-  STF_EQUAL(bs::rshl(aa1, sh1), bb);
+  STF_ULP_EQUAL(bs::rshl(aa1, sh1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check rshl on pack with pack shift" , STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/simd/rshr.cpp
+++ b/test/function/simd/rshr.cpp
@@ -36,8 +36,8 @@ void test(Env& $)
   p_t bb(&b[0], &b[0]+N);
   p_t cc(&c[0], &c[0]+N);
 
-  STF_EQUAL(bs::rshr(aa1, sh1), bb);
-  STF_EQUAL(bs::rshr(aa1, sh2), cc);
+  STF_ULP_EQUAL(bs::rshr(aa1, sh1), bb, 0.5);
+  STF_ULP_EQUAL(bs::rshr(aa1, sh2), cc, 0.5);
 }
 
 STF_CASE_TPL("Check rshr on pack with integral shift" , STF_SIGNED_INTEGRAL_TYPES)
@@ -69,7 +69,7 @@ void tests(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb(&b[0], &b[0]+N);
   i_t sh1(&sh[0], &sh[0]+N);
-  STF_EQUAL(bs::rshr(aa1, sh1), bb);
+  STF_ULP_EQUAL(bs::rshr(aa1, sh1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check rshr on pack with pack shift" , STF_SIGNED_INTEGRAL_TYPES)

--- a/test/function/simd/shift_left.cpp
+++ b/test/function/simd/shift_left.cpp
@@ -36,10 +36,10 @@ void test(Env& $)
   p_t bb(&b[0], &b[0]+N);
   p_t cc(&c[0], &c[0]+N);
 
-  STF_EQUAL(bs::shift_left(aa1, sh1), bb);
-  STF_EQUAL(bs::shift_left(aa1, sh2), cc);
-  STF_EQUAL((aa1 << sh1), bb);
-  STF_EQUAL((aa1 << sh2), cc);
+  STF_ULP_EQUAL(bs::shift_left(aa1, sh1), bb, 0.5);
+  STF_ULP_EQUAL(bs::shift_left(aa1, sh2), cc, 0.5);
+  STF_ULP_EQUAL((aa1 << sh1), bb, 0.5);
+  STF_ULP_EQUAL((aa1 << sh2), cc, 0.5);
 }
 
 STF_CASE_TPL("Check shift_left on pack with integral shift" , STF_INTEGRAL_TYPES)
@@ -71,8 +71,8 @@ void tests(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb(&b[0], &b[0]+N);
   i_t sh1(&sh[0], &sh[0]+N);
-  STF_EQUAL(bs::shift_left(aa1, sh1), bb);
-  STF_EQUAL((aa1 << sh1), bb);
+  STF_ULP_EQUAL(bs::shift_left(aa1, sh1), bb, 0.5);
+  STF_ULP_EQUAL((aa1 << sh1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check shift_left on pack with pack shift" , STF_INTEGRAL_TYPES)

--- a/test/function/simd/shift_right.cpp
+++ b/test/function/simd/shift_right.cpp
@@ -36,10 +36,10 @@ void test(Env& $)
   p_t bb(&b[0], &b[0]+N);
   p_t cc(&c[0], &c[0]+N);
 
-  STF_EQUAL(bs::shift_right(aa1, sh1), bb);
-  STF_EQUAL(bs::shift_right(aa1, sh2), cc);
-  STF_EQUAL((aa1 >>  sh1), bb);
-  STF_EQUAL((aa1 >> sh2), cc);
+  STF_ULP_EQUAL(bs::shift_right(aa1, sh1), bb, 0.5);
+  STF_ULP_EQUAL(bs::shift_right(aa1, sh2), cc, 0.5);
+  STF_ULP_EQUAL((aa1 >>  sh1), bb, 0.5);
+  STF_ULP_EQUAL((aa1 >> sh2), cc, 0.5);
 }
 
 STF_CASE_TPL("Check shift_right on pack with integral shift" , STF_INTEGRAL_TYPES)
@@ -71,8 +71,8 @@ void tests(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb(&b[0], &b[0]+N);
   i_t sh1(&sh[0], &sh[0]+N);
-  STF_EQUAL(bs::shift_right(aa1, sh1), bb);
-  STF_EQUAL((aa1 >> sh1), bb);
+  STF_ULP_EQUAL(bs::shift_right(aa1, sh1), bb, 0.5);
+  STF_ULP_EQUAL((aa1 >> sh1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check shift_right on pack with pack shift" , STF_INTEGRAL_TYPES)

--- a/test/function/simd/shr.cpp
+++ b/test/function/simd/shr.cpp
@@ -36,8 +36,8 @@ void test(Env& $)
   p_t bb(&b[0], &b[0]+N);
   p_t cc(&c[0], &c[0]+N);
 
-  STF_EQUAL(bs::shr(aa1, sh1), bb);
-  STF_EQUAL(bs::shr(aa1, sh2), cc);
+  STF_ULP_EQUAL(bs::shr(aa1, sh1), bb, 0.5);
+  STF_ULP_EQUAL(bs::shr(aa1, sh2), cc, 0.5);
 }
 
 STF_CASE_TPL("Check shr on pack with integral shift" , STF_INTEGRAL_TYPES)
@@ -69,7 +69,7 @@ void tests(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb(&b[0], &b[0]+N);
   i_t sh1(&sh[0], &sh[0]+N);
-  STF_EQUAL(bs::shr(aa1, sh1), bb);
+  STF_ULP_EQUAL(bs::shr(aa1, sh1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check shr on pack with pack shift" , STF_INTEGRAL_TYPES)

--- a/test/function/simd/shuffle/cardinal.1.cpp
+++ b/test/function/simd/shuffle/cardinal.1.cpp
@@ -15,16 +15,16 @@ using namespace boost::simd;
 STF_CASE_TPL("Check unary shuffle behavior with direct permutation", STF_NUMERIC_TYPES)
 {
   using p_t = pack<T,1>;
-  STF_EQUAL( shuffle<-1>(p_t(4)), Zero<p_t>() );
-  STF_EQUAL( shuffle<0>(p_t(4)) , p_t(4) );
+  STF_ULP_EQUAL( shuffle<-1>(p_t(4)), Zero<p_t>() , 0.5);
+  STF_ULP_EQUAL( shuffle<0>(p_t(4)) , p_t(4) , 0.5);
 }
 
 STF_CASE_TPL("Check binary shuffle behavior with direct permutation", STF_NUMERIC_TYPES)
 {
   using p_t = pack<T,1>;
-  STF_EQUAL( shuffle<-1>(p_t(4),p_t(7)) , Zero<p_t>() );
-  STF_EQUAL( shuffle< 0>(p_t(4),p_t(7)) , p_t(4) );
-  STF_EQUAL( shuffle< 1>(p_t(4),p_t(7)) , p_t(7) );
+  STF_ULP_EQUAL( shuffle<-1>(p_t(4),p_t(7)) , Zero<p_t>() , 0.5);
+  STF_ULP_EQUAL( shuffle< 0>(p_t(4),p_t(7)) , p_t(4) , 0.5);
+  STF_ULP_EQUAL( shuffle< 1>(p_t(4),p_t(7)) , p_t(7) , 0.5);
 }
 
 template<int N> struct grab_
@@ -35,14 +35,14 @@ template<int N> struct grab_
 STF_CASE_TPL("Check unary shuffle behavior with direct meta-permutation", STF_NUMERIC_TYPES)
 {
   using p_t = pack<T,1>;
-  STF_EQUAL( shuffle<grab_<0>>(p_t(4)) , p_t(4) );
+  STF_ULP_EQUAL( shuffle<grab_<0>>(p_t(4)) , p_t(4) , 0.5);
 }
 
 STF_CASE_TPL("Check binary shuffle behavior with direct meta-permutation", STF_NUMERIC_TYPES)
 {
   using p_t = pack<T,1>;
-  STF_EQUAL( shuffle<grab_<0>>(p_t(4),p_t(7)) , p_t(4) );
-  STF_EQUAL( shuffle<grab_<1>>(p_t(4),p_t(7)) , p_t(7) );
+  STF_ULP_EQUAL( shuffle<grab_<0>>(p_t(4),p_t(7)) , p_t(4) , 0.5);
+  STF_ULP_EQUAL( shuffle<grab_<1>>(p_t(4),p_t(7)) , p_t(7) , 0.5);
 }
 
 #if !defined(BOOST_NO_CONSTEXPR)
@@ -55,7 +55,7 @@ constexpr int grab1(int /*i*/, int /*c*/) { return 1; }
 STF_CASE_TPL("Check unary shuffle behavior with constexpr-permutation", STF_NUMERIC_TYPES)
 {
   using p_t = pack<T,1>;
-  STF_EQUAL( shuffle<pattern<grab0>>(p_t(4),p_t(7)) , p_t(4) );
-  STF_EQUAL( shuffle<pattern<grab1>>(p_t(4),p_t(7)) , p_t(7) );
+  STF_ULP_EQUAL( shuffle<pattern<grab0>>(p_t(4),p_t(7)) , p_t(4) , 0.5);
+  STF_ULP_EQUAL( shuffle<pattern<grab1>>(p_t(4),p_t(7)) , p_t(7) , 0.5);
 }
 #endif

--- a/test/function/simd/signnz.cpp
+++ b/test/function/simd/signnz.cpp
@@ -28,7 +28,7 @@ void test(Env& $)
   }
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
-  STF_EQUAL(bs::signnz(aa1), bb);
+  STF_ULP_EQUAL(bs::signnz(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check signnz on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/sincpi.cpp
+++ b/test/function/simd/sincpi.cpp
@@ -28,7 +28,7 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
   p_t cc (&c[0], &c[0]+N);
-  STF_EQUAL(bs::sincpi(aa1), bb);
+  STF_ULP_EQUAL(bs::sincpi(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check sincpi on pack" , STF_IEEE_TYPES)

--- a/test/function/simd/slice/arithmetic.cpp
+++ b/test/function/simd/slice/arithmetic.cpp
@@ -30,8 +30,8 @@ void test( Env& $, brigand::bool_<true> const& = {} )
 
   auto sliced = bs::slice(value);
 
-  STF_EQUAL( sliced[0], first);
-  STF_EQUAL( sliced[1], second);
+  STF_ULP_EQUAL( sliced[0], first, 0.5);
+  STF_ULP_EQUAL( sliced[1], second, 0.5);
 }
 
 STF_CASE_TPL("slice pack<T,N> into 2 pack<T,N/2>", STF_NUMERIC_TYPES)

--- a/test/function/simd/slice/arithmetic.high.cpp
+++ b/test/function/simd/slice/arithmetic.high.cpp
@@ -26,7 +26,7 @@ void test( Env& $, brigand::bool_<true> const& = {} )
   bs::pack<T,N>   value (&ref[0]  , &ref[0]+N   );
   bs::pack<T,N/2> second(&ref[0]+N/2, &ref[0]+N );
 
-  STF_EQUAL( bs::slice_high(value), second);
+  STF_ULP_EQUAL( bs::slice_high(value), second, 0.5);
 }
 
 STF_CASE_TPL("slice_high pack<T,N> into a pack<T,N/2>", STF_NUMERIC_TYPES)

--- a/test/function/simd/slice/arithmetic.low.cpp
+++ b/test/function/simd/slice/arithmetic.low.cpp
@@ -26,7 +26,7 @@ void test( Env& $, brigand::bool_<true> const& = {} )
   bs::pack<T,N>   value (&ref[0], &ref[0]+N   );
   bs::pack<T,N/2> second(&ref[0], &ref[0]+N/2 );
 
-  STF_EQUAL( bs::slice_low(value), second);
+  STF_ULP_EQUAL( bs::slice_low(value), second, 0.5);
 }
 
 STF_CASE_TPL("slice_low pack<T,N> into a pack<T,N/2>", STF_NUMERIC_TYPES)

--- a/test/function/simd/slice/logical.cpp
+++ b/test/function/simd/slice/logical.cpp
@@ -31,8 +31,8 @@ void test( Env& $, brigand::bool_<true> const& = {} )
 
   auto sliced = bs::slice(value);
 
-  STF_EQUAL( sliced[0], first);
-  STF_EQUAL( sliced[1], second);
+  STF_ULP_EQUAL( sliced[0], first, 0.5);
+  STF_ULP_EQUAL( sliced[1], second, 0.5);
 }
 
 STF_CASE_TPL("slice pack<T,N> into 2 pack<T,N/2>", STF_NUMERIC_TYPES)

--- a/test/function/simd/slice/logical.high.cpp
+++ b/test/function/simd/slice/logical.high.cpp
@@ -27,7 +27,7 @@ void test( Env& $, brigand::bool_<true> const& = {} )
   bs::pack<bs::logical<T>,N>   value (&ref[0]  , &ref[0]+N   );
   bs::pack<bs::logical<T>,N/2> second(&ref[0]+N/2, &ref[0]+N );
 
-  STF_EQUAL( bs::slice_high(value), second);
+  STF_ULP_EQUAL( bs::slice_high(value), second, 0.5);
 }
 
 STF_CASE_TPL("slice_high pack<T,N> into a pack<T,N/2>", STF_NUMERIC_TYPES)

--- a/test/function/simd/slice/logical.low.cpp
+++ b/test/function/simd/slice/logical.low.cpp
@@ -27,7 +27,7 @@ void test( Env& $, brigand::bool_<true> const& = {} )
   bs::pack<bs::logical<T>,N>   value (&ref[0], &ref[0]+N   );
   bs::pack<bs::logical<T>,N/2> second(&ref[0], &ref[0]+N/2 );
 
-  STF_EQUAL( bs::slice_low(value), second);
+  STF_ULP_EQUAL( bs::slice_low(value), second, 0.5);
 }
 
 STF_CASE_TPL("slice_low pack<T,N> into a pack<T,N/2>", STF_NUMERIC_TYPES)

--- a/test/function/simd/slide/binary.arithmetic.cpp
+++ b/test/function/simd/slide/binary.arithmetic.cpp
@@ -25,23 +25,23 @@ template <typename T, int N, typename Env> void test(Env& $)
   p_t l = bs::load<p_t>(&data[  N]);
   p_t r = bs::load<p_t>(&data[2*N]);
 
-  STF_EQUAL( bs::slide<-N>(l,r), bs::slide<0>(r,l) );
-  if(N>1) STF_EQUAL( bs::slide<-N/2>(l,r), bs::slide<N/2>(r,l) );
-  STF_EQUAL( bs::slide<-1>(l,r), bs::slide<N-1>(r,l) );
+  STF_ULP_EQUAL( bs::slide<-N>(l,r), bs::slide<0>(r,l) , 0.5);
+  if(N>1) STF_ULP_EQUAL( bs::slide<-N/2>(l,r), bs::slide<N/2>(r,l) , 0.5);
+  STF_ULP_EQUAL( bs::slide<-1>(l,r), bs::slide<N-1>(r,l) , 0.5);
 
   ref = bs::load<p_t>(&data[N]);
-  STF_EQUAL( bs::slide<0>(l,r), ref );
+  STF_ULP_EQUAL( bs::slide<0>(l,r), ref , 0.5);
 
   ref = bs::load<p_t>(&data[N], +1);
-  STF_EQUAL( bs::slide<+1>(l,r), ref );
+  STF_ULP_EQUAL( bs::slide<+1>(l,r), ref , 0.5);
 
   ref = bs::load<p_t>(&data[N], N/2);
-  STF_EQUAL( bs::slide<N/2>(l,r), ref );
+  STF_ULP_EQUAL( bs::slide<N/2>(l,r), ref , 0.5);
 
   ref = bs::load<p_t>(&data[N], N-1);
-  STF_EQUAL( bs::slide<N-1>(l,r), ref );
+  STF_ULP_EQUAL( bs::slide<N-1>(l,r), ref , 0.5);
 
-  STF_EQUAL( bs::slide<N>(l,r), r );
+  STF_ULP_EQUAL( bs::slide<N>(l,r), r , 0.5);
 }
 
 STF_CASE_TPL( "Check binary slide behavior", STF_NUMERIC_TYPES )

--- a/test/function/simd/slide/binary.logical.cpp
+++ b/test/function/simd/slide/binary.logical.cpp
@@ -25,19 +25,19 @@ template <typename T, int N, typename Env> void test(Env& $)
   p_t l = bs::load<p_t>(&data[  N]);
   p_t r = bs::load<p_t>(&data[2*N]);
 
-  STF_EQUAL( bs::slide<-N>(l,r), bs::slide<0>(r,l) );
-  STF_EQUAL( bs::slide<-1>(l,r), bs::slide<N-1>(r,l) );
+  STF_ULP_EQUAL( bs::slide<-N>(l,r), bs::slide<0>(r,l) , 0.5);
+  STF_ULP_EQUAL( bs::slide<-1>(l,r), bs::slide<N-1>(r,l) , 0.5);
 
   ref = bs::load<p_t>(&data[N]);
-  STF_EQUAL( bs::slide<0>(l,r), ref );
+  STF_ULP_EQUAL( bs::slide<0>(l,r), ref , 0.5);
 
   ref = bs::load<p_t>(&data[N], +1);
-  STF_EQUAL( bs::slide<+1>(l,r), ref );
+  STF_ULP_EQUAL( bs::slide<+1>(l,r), ref , 0.5);
 
   ref = bs::load<p_t>(&data[N], N-1);
-  STF_EQUAL( bs::slide<N-1>(l,r), ref );
+  STF_ULP_EQUAL( bs::slide<N-1>(l,r), ref , 0.5);
 
-  STF_EQUAL( bs::slide<N>(l,r), r );
+  STF_ULP_EQUAL( bs::slide<N>(l,r), r , 0.5);
 }
 
 STF_CASE_TPL( "Check binary slide behavior", STF_NUMERIC_TYPES )

--- a/test/function/simd/slide/unary.arithmetic.cpp
+++ b/test/function/simd/slide/unary.arithmetic.cpp
@@ -22,30 +22,30 @@ template <typename T, int N, typename Env> void test(Env& $)
   using p_t = bs::pack<T,N>;
   p_t ref, p = bs::load<p_t>(&data[N], 0);
 
-  STF_EQUAL( bs::slide<-N>(p), bs::Zero<p_t>() );
+  STF_ULP_EQUAL( bs::slide<-N>(p), bs::Zero<p_t>() , 0.5);
 
   ref = bs::load<p_t>(&data[N], -N+1);
-  STF_EQUAL( bs::slide<-N+1>(p), ref );
+  STF_ULP_EQUAL( bs::slide<-N+1>(p), ref , 0.5);
 
   ref = bs::load<p_t>(&data[N], -N/2);
-  STF_EQUAL( bs::slide<-N/2>(p), ref );
+  STF_ULP_EQUAL( bs::slide<-N/2>(p), ref , 0.5);
 
   ref = bs::load<p_t>(&data[N], -1);
-  STF_EQUAL( bs::slide<-1>(p), ref );
+  STF_ULP_EQUAL( bs::slide<-1>(p), ref , 0.5);
 
   ref = bs::load<p_t>(&data[N]);
-  STF_EQUAL( bs::slide<0>(p), ref );
+  STF_ULP_EQUAL( bs::slide<0>(p), ref , 0.5);
 
   ref = bs::load<p_t>(&data[N], +1);
-  STF_EQUAL( bs::slide<+1>(p), ref );
+  STF_ULP_EQUAL( bs::slide<+1>(p), ref , 0.5);
 
   ref = bs::load<p_t>(&data[N], N/2);
-  STF_EQUAL( bs::slide<N/2>(p), ref );
+  STF_ULP_EQUAL( bs::slide<N/2>(p), ref , 0.5);
 
   ref = bs::load<p_t>(&data[N], N-1);
-  STF_EQUAL( bs::slide<N-1>(p), ref );
+  STF_ULP_EQUAL( bs::slide<N-1>(p), ref , 0.5);
 
-  STF_EQUAL( bs::slide<N>(p), bs::Zero<p_t>() );
+  STF_ULP_EQUAL( bs::slide<N>(p), bs::Zero<p_t>() , 0.5);
 }
 
 STF_CASE_TPL( "Check unary slide behavior", STF_NUMERIC_TYPES )

--- a/test/function/simd/slide/unary.logical.cpp
+++ b/test/function/simd/slide/unary.logical.cpp
@@ -22,18 +22,18 @@ template <typename T, int N, typename Env> void test(Env& $)
   using p_t = bs::pack<bs::logical<T>,N>;
   p_t ref, p = bs::load<p_t>(&data[N], 0);
 
-  STF_EQUAL( bs::slide<-N>(p), bs::Zero<p_t>() );
+  STF_ULP_EQUAL( bs::slide<-N>(p), bs::Zero<p_t>() , 0.5);
 
   ref = bs::load<p_t>(&data[N], -1);
-  STF_EQUAL( bs::slide<-1>(p), ref );
+  STF_ULP_EQUAL( bs::slide<-1>(p), ref , 0.5);
 
   ref = bs::load<p_t>(&data[N]);
-  STF_EQUAL( bs::slide<0>(p), ref );
+  STF_ULP_EQUAL( bs::slide<0>(p), ref , 0.5);
 
   ref = bs::load<p_t>(&data[N], +1);
-  STF_EQUAL( bs::slide<+1>(p), ref );
+  STF_ULP_EQUAL( bs::slide<+1>(p), ref , 0.5);
 
-  STF_EQUAL( bs::slide<N>(p), bs::Zero<p_t>() );
+  STF_ULP_EQUAL( bs::slide<N>(p), bs::Zero<p_t>() , 0.5);
 }
 
 STF_CASE_TPL( "Check unary slide behavior", STF_NUMERIC_TYPES )

--- a/test/function/simd/splat/logical.cpp
+++ b/test/function/simd/splat/logical.cpp
@@ -24,12 +24,12 @@ void test(Env& $)
   p_t ref;
   for(std::size_t i = 0; i < N; ++i) ref[i] = true;
 
-  STF_EQUAL(bs::splat<p_t>(T(2)), ref);
-  STF_EQUAL(bs::splat<p_t>(true), ref);
+  STF_ULP_EQUAL(bs::splat<p_t>(T(2)), ref, 0.5);
+  STF_ULP_EQUAL(bs::splat<p_t>(true), ref, 0.5);
 
   for(std::size_t i = 0; i < N; ++i) ref[i] = false;
-  STF_EQUAL(bs::splat<p_t>(T(0)) , ref);
-  STF_EQUAL(bs::splat<p_t>(false), ref);
+  STF_ULP_EQUAL(bs::splat<p_t>(T(0)) , ref, 0.5);
+  STF_ULP_EQUAL(bs::splat<p_t>(false), ref, 0.5);
 }
 
 STF_CASE_TPL( "Check splat behavior with all types", STF_NUMERIC_TYPES )

--- a/test/function/simd/split/arithmetic.high.cpp
+++ b/test/function/simd/split/arithmetic.high.cpp
@@ -31,7 +31,7 @@ void test( Env& $, std::true_type const& )
   bs::pack<T,N>                 value (&data[0], &data[0]+data.size() );
   bd::upgrade_t<bs::pack<T,N>>  ref   (&dref[0], &dref[0]+dref.size() );
 
-  STF_EQUAL( bs::split_high(value), ref);
+  STF_ULP_EQUAL( bs::split_high(value), ref, 0.5);
 }
 
 STF_CASE_TPL("split_high pack<T,N> into a pack<T*2,N/2>", STF_NUMERIC_TYPES)

--- a/test/function/simd/split/arithmetic.low.cpp
+++ b/test/function/simd/split/arithmetic.low.cpp
@@ -31,7 +31,7 @@ void test( Env& $, std::true_type const& )
   bs::pack<T,N>                 value (&data[0], &data[0]+data.size() );
   bd::upgrade_t<bs::pack<T,N>>  ref   (&dref[0], &dref[0]+dref.size() );
 
-  STF_EQUAL( bs::split_low(value), ref);
+  STF_ULP_EQUAL( bs::split_low(value), ref, 0.5);
 }
 
 STF_CASE_TPL("split_low pack<T,N> into a pack<T*2,N/2>", STF_NUMERIC_TYPES)

--- a/test/function/simd/split/arithmetic.pair.cpp
+++ b/test/function/simd/split/arithmetic.pair.cpp
@@ -35,8 +35,8 @@ void test( Env& $, std::true_type const& )
 
   auto values = bs::split(value);
 
-  STF_EQUAL( values[0] , refl);
-  STF_EQUAL( values[1] , refh);
+  STF_ULP_EQUAL( values[0] , refl, 0.5);
+  STF_ULP_EQUAL( values[1] , refh, 0.5);
 }
 
 STF_CASE_TPL("split pack<T,N> into a pair of pack<T*2,N/2>", STF_NUMERIC_TYPES)

--- a/test/function/simd/split/logical.high.cpp
+++ b/test/function/simd/split/logical.high.cpp
@@ -32,7 +32,7 @@ void test( Env& $, std::true_type const& )
   bs::pack<bs::logical<T>,N>                 value (&data[0], &data[0]+data.size() );
   bd::upgrade_t<bs::pack<bs::logical<T>,N>>  ref   (&dref[0], &dref[0]+dref.size() );
 
-  STF_EQUAL( bs::split_high(value), ref);
+  STF_ULP_EQUAL( bs::split_high(value), ref, 0.5);
 }
 
 STF_CASE_TPL("split_high pack<T,N> into a pack<T*2,N/2>", STF_NUMERIC_TYPES)

--- a/test/function/simd/split/logical.low.cpp
+++ b/test/function/simd/split/logical.low.cpp
@@ -32,7 +32,7 @@ void test( Env& $, std::true_type const& )
   bs::pack<bs::logical<T>,N>                 value (&data[0], &data[0]+data.size() );
   bd::upgrade_t<bs::pack<bs::logical<T>,N>>  ref   (&dref[0], &dref[0]+dref.size() );
 
-  STF_EQUAL( bs::split_low(value), ref);
+  STF_ULP_EQUAL( bs::split_low(value), ref, 0.5);
 }
 
 STF_CASE_TPL("split_low pack<T,N> into a pack<T*2,N/2>", STF_NUMERIC_TYPES)

--- a/test/function/simd/split/logical.pair.cpp
+++ b/test/function/simd/split/logical.pair.cpp
@@ -36,8 +36,8 @@ void test( Env& $, std::true_type const& )
 
   auto values = bs::split(value);
 
-  STF_EQUAL( values[0] , refl);
-  STF_EQUAL( values[1] , refh);
+  STF_ULP_EQUAL( values[0] , refl, 0.5);
+  STF_ULP_EQUAL( values[1] , refh, 0.5);
 }
 
 STF_CASE_TPL("split pack<T,N> into a pair of pack<T*2,N/2>", STF_NUMERIC_TYPES)

--- a/test/function/simd/split_multiplies.cpp
+++ b/test/function/simd/split_multiplies.cpp
@@ -36,8 +36,8 @@ void test( Env& $, std::true_type const& )
 
   std::tie(valuel,valueh) = bs::split_multiplies(value,value);
 
-  STF_EQUAL( valuel , refl);
-  STF_EQUAL( valueh , refh);
+  STF_ULP_EQUAL( valuel , refl, 0.5);
+  STF_ULP_EQUAL( valueh , refh, 0.5);
 }
 
 STF_CASE_TPL("split_multiplies two pack<T,N> into a pair of pack<T^2,N/2>", STF_NUMERIC_TYPES)

--- a/test/function/simd/sqr.cpp
+++ b/test/function/simd/sqr.cpp
@@ -29,7 +29,7 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::sqr(aa1), bb);
+  STF_ULP_EQUAL(bs::sqr(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check sqr on pack" , STF_NUMERIC_TYPES)
@@ -56,7 +56,7 @@ void tests(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::saturated_(bs::sqr)(aa1), bb);
+  STF_ULP_EQUAL(bs::saturated_(bs::sqr)(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check saturated sqr on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/store.cpp
+++ b/test/function/simd/store.cpp
@@ -58,7 +58,7 @@ void test_o(Env& $)
   bs::store(aa1, &a2[0], 3);
   p_t aa2(&a2[3], &a2[3]+N);
 
-  STF_EQUAL(aa1, aa2);
+  STF_ULP_EQUAL(aa1, aa2, 0.5);
 }
 
 STF_CASE_TPL( "Check offset store behavior with all types", STF_NUMERIC_TYPES )

--- a/test/function/simd/sum.cpp
+++ b/test/function/simd/sum.cpp
@@ -30,8 +30,8 @@ void test(Env& $)
   }
   p_t aa1(&a1[0], &a1[0]+N);
 
-  STF_EQUAL(bs::sum(aa1), b);
-  STF_EQUAL(bs::splatted_(bs::sum)(aa1), p_t(b) );
+  STF_ULP_EQUAL(bs::sum(aa1), b, 0.5);
+  STF_ULP_EQUAL(bs::splatted_(bs::sum)(aa1), p_t(b) , 0.5);
 }
 
 STF_CASE_TPL("Check sum on pack", STF_NUMERIC_TYPES)

--- a/test/function/simd/tanh.cpp
+++ b/test/function/simd/tanh.cpp
@@ -28,7 +28,7 @@ void test(Env& $)
 
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
-  STF_EQUAL(bs::tanh(aa1), bb);
+  STF_ULP_EQUAL(bs::tanh(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check tanh saturated on pack" , STF_IEEE_TYPES)

--- a/test/function/simd/toint.cpp
+++ b/test/function/simd/toint.cpp
@@ -30,7 +30,7 @@ void test(Env& $)
   }
   p_t aa1(&a1[0], &a1[0]+N);
   i_t bb (&b[0], &b[0]+N);
-  STF_EQUAL(bs::toint(aa1), bb);
+  STF_ULP_EQUAL(bs::toint(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check toint on pack" , STF_IEEE_TYPES)

--- a/test/function/simd/toint.saturated.cpp
+++ b/test/function/simd/toint.saturated.cpp
@@ -30,7 +30,7 @@ void test(Env& $)
   }
   p_t aa1(&a1[0], &a1[0]+N);
   i_t bb (&b[0], &b[0]+N);
-  STF_EQUAL(bs::saturated_(bs::toint)(aa1), bb);
+  STF_ULP_EQUAL(bs::saturated_(bs::toint)(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check toint_s on pack" , STF_IEEE_TYPES)

--- a/test/function/simd/touint.cpp
+++ b/test/function/simd/touint.cpp
@@ -30,7 +30,7 @@ void test(Env& $)
   }
   p_t aa1(&a1[0], &a1[0]+N);
   i_t bb (&b[0], &b[0]+N);
-  STF_EQUAL(bs::touint(aa1), bb);
+  STF_ULP_EQUAL(bs::touint(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check touint on pack" , STF_IEEE_TYPES)

--- a/test/function/simd/touint.saturated.cpp
+++ b/test/function/simd/touint.saturated.cpp
@@ -30,7 +30,7 @@ void test(Env& $)
   }
   p_t aa1(&a1[0], &a1[0]+N);
   i_t bb (&b[0], &b[0]+N);
-  STF_EQUAL(bs::saturated_(bs::touint)(aa1), bb);
+  STF_ULP_EQUAL(bs::saturated_(bs::touint)(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check touint_s on pack" , STF_IEEE_TYPES)

--- a/test/function/simd/trunc.cpp
+++ b/test/function/simd/trunc.cpp
@@ -29,8 +29,8 @@ void test(Env& $)
   }
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
-  STF_IEEE_EQUAL(bs::trunc(aa1), bb);
-  STF_EQUAL(bs::std_(bs::trunc)(aa1), bb);
+  STF_ULP_EQUAL(bs::trunc(aa1), bb, 0.5);
+  STF_ULP_EQUAL(bs::std_(bs::trunc)(aa1), bb, 0.5);
 }
 
 STF_CASE_TPL("Check trunc on pack" , STF_NUMERIC_TYPES)

--- a/test/function/simd/unary_minus.cpp
+++ b/test/function/simd/unary_minus.cpp
@@ -28,8 +28,8 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::unary_minus(aa1), bb);
-  STF_EQUAL(-aa1, bb);
+  STF_ULP_EQUAL(bs::unary_minus(aa1), bb, 0.5);
+  STF_ULP_EQUAL(-aa1, bb, 0.5);
 }
 
 STF_CASE_TPL("Check unary_minus on pack" , STF_SIGNED_NUMERIC_TYPES)

--- a/test/function/simd/unary_plus.cpp
+++ b/test/function/simd/unary_plus.cpp
@@ -27,8 +27,8 @@ void test(Env& $)
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
 
-  STF_EQUAL(bs::unary_plus(aa1), bb);
-  STF_EQUAL(+aa1, bb);
+  STF_ULP_EQUAL(bs::unary_plus(aa1), bb, 0.5);
+  STF_ULP_EQUAL(+aa1, bb, 0.5);
 }
 
 STF_CASE_TPL("Check unary_plus on pack" , STF_NUMERIC_TYPES)


### PR DESCRIPTION
whenever floating are used and result can differ due to IEEE computation  STF_EQUAL(...) is replaced by STF_ULP_EQUAL(...,0.5)
