### PR TITLE
Rework hmsb return type to use bitset

### DIFF
--- a/include/boost/simd/arch/common/scalar/function/hmsb.hpp
+++ b/include/boost/simd/arch/common/scalar/function/hmsb.hpp
@@ -1,12 +1,10 @@
 //==================================================================================================
-/*!
-  @file
-
-  @copyright 2016 NumScale SAS
+/**
+  Copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #ifndef BOOST_SIMD_ARCH_COMMON_SCALAR_FUNCTION_HMSB_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_SCALAR_FUNCTION_HMSB_HPP_INCLUDED
@@ -16,24 +14,23 @@
 #include <boost/simd/detail/dispatch/function/overload.hpp>
 #include <boost/simd/detail/dispatch/meta/as_integer.hpp>
 #include <boost/config.hpp>
-// TODO is size_t the good result type ?
+#include <bitset>
 
 namespace boost { namespace simd { namespace ext
 {
   namespace bd = boost::dispatch;
+
   BOOST_DISPATCH_OVERLOAD ( hmsb_
                           , (typename A0)
                           , bd::cpu_
                           , bd::scalar_< bd::fundamental_<A0> >
                           )
   {
-    BOOST_FORCEINLINE std::size_t operator() ( A0  a0) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE std::bitset<1> operator()(A0 a0) const BOOST_NOEXCEPT
     {
-      using i_t = bd::as_integer_t<A0>;
-      return bitwise_and(Signmask<i_t>(), a0) != 0;
+      return {bitwise_and(Signmask<bd::as_integer_t<A0>>(), a0) != 0};
     }
   };
 } } }
-
 
 #endif

--- a/include/boost/simd/arch/common/simd/function/all.hpp
+++ b/include/boost/simd/arch/common/simd/function/all.hpp
@@ -28,13 +28,9 @@ namespace boost { namespace simd { namespace ext
                             , bs::pack_<bd::fundamental_<A0>, X>
                             )
   {
-    // MSVC has some issue with >> in template declaration
-    static const std::size_t cnt = (std::size_t(-1) >> (64 - A0::static_size));
-    using count = std::integral_constant<std::size_t,cnt>;
-
     BOOST_FORCEINLINE bool operator()(const A0& a0) const BOOST_NOEXCEPT
     {
-      return hmsb(genmask(a0)) == count::value;
+      return hmsb(genmask(a0)).all();
     }
   };
 

--- a/include/boost/simd/arch/common/simd/function/any.hpp
+++ b/include/boost/simd/arch/common/simd/function/any.hpp
@@ -29,7 +29,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE bool operator()( const A0& a0) const BOOST_NOEXCEPT
     {
-      return hmsb(genmask(a0)) != 0;
+      return hmsb(genmask(a0)).any();
     }
   };
 

--- a/include/boost/simd/arch/common/simd/function/hmsb.hpp
+++ b/include/boost/simd/arch/common/simd/function/hmsb.hpp
@@ -1,63 +1,69 @@
 //==================================================================================================
-/*!
-  @file
-
-  @copyright 2016 NumScale SAS
+/**
+  Copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #ifndef BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_HMSB_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_HMSB_HPP_INCLUDED
-#include <boost/simd/detail/overload.hpp>
 
-#include <boost/simd/meta/hierarchy/simd.hpp>
-#include <boost/simd/function/bitwise_cast.hpp>
-#include <boost/simd/detail/dispatch/meta/as_integer.hpp>
+#include <boost/simd/detail/overload.hpp>
+#include <boost/simd/function/bitwise_and.hpp>
 #include <boost/simd/function/genmask.hpp>
-#include <boost/simd/detail/dispatch/meta/scalar_of.hpp>
-#include <climits>
+#include <boost/simd/function/extract.hpp>
+#include <boost/simd/constant/signmask.hpp>
+#include <boost/simd/detail/dispatch/meta/as_integer.hpp>
 #include <cstddef>
 
 namespace boost { namespace simd { namespace ext
 {
-   namespace bd = boost::dispatch;
-   namespace bs = boost::simd;
-   BOOST_DISPATCH_OVERLOAD(hmsb_
-                          , (typename A0, typename X)
-                          , bd::cpu_
-                          , bs::pack_<bd::arithmetic_<A0>, X>
-                          )
-   {
-      BOOST_FORCEINLINE std::size_t operator()( const A0& a0) const BOOST_NOEXCEPT
-      {
-        using stype = bd::scalar_of_t<A0>;
-        using itype = bd::as_integer_t<stype, unsigned>;
-        std::size_t z = 0;
-        const std::size_t N = A0::static_size;
-        for(std::size_t i = 0; i != N; ++i)
-        {
-          stype t = a0[i]; // TO DO why must I use t or else bitwise_cast does not compile (clang 3.6)?
-          z |= size_t((bitwise_cast<itype>(t) >> (sizeof(stype)*CHAR_BIT - 1)) << i);
-        }
-         return z;
-      }
-   };
+  namespace bd = boost::dispatch;
+  namespace bs = boost::simd;
 
-   BOOST_DISPATCH_OVERLOAD(hmsb_
+  BOOST_DISPATCH_OVERLOAD(hmsb_
+                        , (typename A0, typename X)
+                        , bd::cpu_
+                        , bs::pack_<bd::arithmetic_<A0>, X>
+                        )
+  {
+    using result_t = std::bitset<cardinal_of<A0>::value>;
+
+    template<typename I> BOOST_FORCEINLINE void piece(const A0& a0, result_t& r) const BOOST_NOEXCEPT
+    {
+      r.set ( I::value
+            , bs::bitwise_and ( bs::Signmask<bd::as_integer_t<typename A0::value_type>>()
+                              , bs::extract<I::value>(a0)
+                              ) != 0
+            );
+    }
+
+    template<typename... N>
+    BOOST_FORCEINLINE void do_(const A0& a0, result_t& r, brigand::list<N...> const&) const BOOST_NOEXCEPT
+    {
+      (void)(std::initializer_list<bool>{(piece<N>(a0,r),true)...});
+    }
+
+    BOOST_FORCEINLINE result_t operator()(const A0& a0) const BOOST_NOEXCEPT
+    {
+      result_t r;
+      do_(a0,r,typename A0::traits::element_range());
+      return r;
+    }
+  };
+
+  BOOST_DISPATCH_OVERLOAD ( hmsb_
                           , (typename A0, typename X)
                           , bd::cpu_
                           , bs::pack_<bs::logical_<A0>, X>
                           )
-   {
-     BOOST_FORCEINLINE std::size_t operator()( const A0& a0) const BOOST_NOEXCEPT
-      {
-        return bs::hmsb(bs::genmask(a0));
-      }
-   };
-
+  {
+    BOOST_FORCEINLINE std::bitset<cardinal_of<A0>::value> operator()(const A0& a0) const BOOST_NOEXCEPT
+    {
+      return bs::hmsb(bs::genmask(a0));
+    }
+  };
 } } }
 
 #endif
-

--- a/include/boost/simd/arch/x86/avx/simd/function/hmsb.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/hmsb.hpp
@@ -13,61 +13,68 @@
 #include <boost/simd/function/slice.hpp>
 #include <boost/simd/function/bitwise_cast.hpp>
 #include <boost/simd/detail/dispatch/meta/as_floating.hpp>
+#include <bitset>
 
 namespace boost { namespace simd { namespace ext
 {
-   namespace bd = boost::dispatch;
-   namespace bs = boost::simd;
+  namespace bd = boost::dispatch;
+  namespace bs = boost::simd;
 
-   BOOST_DISPATCH_OVERLOAD( hmsb_
+  BOOST_DISPATCH_OVERLOAD ( hmsb_
                           , (typename A0)
                           , bs::avx_
                           , bs::pack_<bd::type32_<A0>, bs::avx_>
                           )
-   {
-     BOOST_FORCEINLINE std::size_t operator()(A0 const& a0) const
-      {
-        return _mm256_movemask_ps(bitwise_cast<bd::as_floating_t<A0>>(a0));
-      }
-   };
+  {
+    BOOST_FORCEINLINE std::bitset<8> operator()(A0 const& a0) const
+    {
+      return _mm256_movemask_ps(bitwise_cast<bd::as_floating_t<A0>>(a0));
+    }
+  };
 
-   BOOST_DISPATCH_OVERLOAD( hmsb_
+  BOOST_DISPATCH_OVERLOAD ( hmsb_
                           , (typename A0)
                           , bs::avx_
                           , bs::pack_<bd::type64_<A0>, bs::avx_>
                           )
-   {
-     BOOST_FORCEINLINE std::size_t operator()(A0 const& a0) const
-      {
-        return _mm256_movemask_pd(bitwise_cast<bd::as_floating_t<A0>>(a0));
-      }
-   };
+  {
+    BOOST_FORCEINLINE std::bitset<4> operator()(A0 const& a0) const
+    {
+      return _mm256_movemask_pd(bitwise_cast<bd::as_floating_t<A0>>(a0));
+    }
+  };
 
-   BOOST_DISPATCH_OVERLOAD( hmsb_
+  BOOST_DISPATCH_OVERLOAD ( hmsb_
                           , (typename A0)
                           , bs::avx_
                           , bs::pack_<bd::ints8_<A0>, bs::avx_>
                           )
-   {
-     BOOST_FORCEINLINE std::size_t operator()(A0 const& a0) const
-      {
-        auto const s = slice(a0);
-        return std::uint32_t(_mm_movemask_epi8(s[0]) | (_mm_movemask_epi8(s[1]) << 16));
-      }
-   };
+  {
+    BOOST_FORCEINLINE std::bitset<32> operator()(A0 const& a0) const
+    {
+      auto h = _mm_movemask_epi8(slice_high(a0));
+      auto l = _mm_movemask_epi8(slice_low (a0));
+      return l | (h << 16);
+    }
+  };
 
-   BOOST_DISPATCH_OVERLOAD( hmsb_
-                          , (typename A0)
-                          , bs::avx_
-                          , bs::pack_<bd::ints16_<A0>, bs::avx_>
-                          )
-   {
-     BOOST_FORCEINLINE std::size_t operator()(A0 const& a0) const
-      {
-        auto const s = slice(a0);
-        return hmsb(s[0]) | (hmsb(s[1]) << 8);
-      }
-   };
+  BOOST_DISPATCH_OVERLOAD( hmsb_
+                      , (typename A0)
+                      , bs::avx_
+                      , bs::pack_<bd::ints16_<A0>, bs::avx_>
+                      )
+  {
+    BOOST_FORCEINLINE std::bitset<16> operator()(A0 const& a0) const
+    {
+      using s8type = typename A0::template retype<int8_t, 16>;
+      s8type mask = {1,3,5,7,9,11,13,15,-128,-128,-128,-128,-128,-128,-128,-128};
+
+      auto l = _mm_movemask_epi8(_mm_shuffle_epi8(bitwise_cast<s8type>(slice_low(a0)), mask));
+      auto h = _mm_movemask_epi8(_mm_shuffle_epi8(bitwise_cast<s8type>(slice_high(a0)), mask));
+
+      return l | (h << 8);
+    }
+  };
 } } }
 
 #endif

--- a/include/boost/simd/arch/x86/avx2/simd/function/hmsb.hpp
+++ b/include/boost/simd/arch/x86/avx2/simd/function/hmsb.hpp
@@ -10,23 +10,24 @@
 #define BOOST_SIMD_ARCH_X86_AVX2_SIMD_FUNCTION_HMSB_HPP_INCLUDED
 
 #include <boost/simd/detail/overload.hpp>
+#include <bitset>
 
 namespace boost { namespace simd { namespace ext
 {
-   namespace bd = boost::dispatch;
-   namespace bs = boost::simd;
+  namespace bd = boost::dispatch;
+  namespace bs = boost::simd;
 
-   BOOST_DISPATCH_OVERLOAD( hmsb_
+  BOOST_DISPATCH_OVERLOAD ( hmsb_
                           , (typename A0)
                           , bs::avx2_
                           , bs::pack_<bd::ints8_<A0>, bs::avx_>
                           )
-   {
-     BOOST_FORCEINLINE std::size_t operator()(A0 const& a0) const
-      {
-        return _mm256_movemask_epi8(a0);
-      }
-   };
+  {
+    BOOST_FORCEINLINE std::bitset<32> operator()(A0 const& a0) const
+    {
+      return _mm256_movemask_epi8(a0);
+    }
+  };
 } } }
 
 #endif

--- a/include/boost/simd/arch/x86/sse1/simd/function/hmsb.hpp
+++ b/include/boost/simd/arch/x86/sse1/simd/function/hmsb.hpp
@@ -1,36 +1,33 @@
 //==================================================================================================
-/*!
-    @file
+/**
+  Copyright 2016 Numscale SAS
 
-    @Copyright 2016 Numscale SAS
-
-    Distributed under the Boost Software License, Version 1.0.
-    (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
 //==================================================================================================
 #ifndef BOOST_SIMD_ARCH_X86_SSE1_SIMD_FUNCTION_HMSB_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_X86_SSE1_SIMD_FUNCTION_HMSB_HPP_INCLUDED
-#include <boost/simd/detail/overload.hpp>
 
-#include <boost/simd/detail/dispatch/meta/as_floating.hpp>
-#include <boost/simd/function/bitwise_cast.hpp>
+#include <boost/simd/detail/overload.hpp>
+#include <bitset>
 
 namespace boost { namespace simd { namespace ext
 {
   namespace bd =  boost::dispatch;
   namespace bs =  boost::simd;
+
   BOOST_DISPATCH_OVERLOAD ( hmsb_
                           , (typename A0)
                           , bs::sse1_
                           , bs::pack_<bd::single_<A0>, bs::sse_>
                          )
   {
-    BOOST_FORCEINLINE std::size_t operator() ( const A0 & a0 ) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE std::bitset<4> operator()( const A0 & a0 ) const BOOST_NOEXCEPT
     {
       return _mm_movemask_ps(a0);
-   }
+    }
   };
 } } }
 
 #endif
-

--- a/include/boost/simd/arch/x86/sse2/simd/function/hmsb.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/hmsb.hpp
@@ -14,45 +14,48 @@
 #include <boost/simd/detail/dispatch/meta/as_floating.hpp>
 #include <boost/simd/function/bitwise_cast.hpp>
 #include <boost/simd/function/genmask.hpp>
+#include <bitset>
 
 namespace boost { namespace simd { namespace ext
 {
   namespace bs =  boost::simd;
   namespace bd =  boost::dispatch;
+
   BOOST_DISPATCH_OVERLOAD ( hmsb_
                           , (typename A0)
                           , bs::sse2_
                           , bs::pack_<bd::type8_<A0>, bs::sse_>
                          )
   {
-    BOOST_FORCEINLINE std::size_t operator() ( const A0 & a0) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE std::bitset<16> operator() ( const A0 & a0) const BOOST_NOEXCEPT
     {
       return _mm_movemask_epi8(a0);
     }
   };
+
   BOOST_DISPATCH_OVERLOAD ( hmsb_
                           , (typename A0)
                           , bs::sse2_
                           , bs::pack_<bd::ints32_<A0>, bs::sse_>
                          )
   {
-    BOOST_FORCEINLINE std::size_t operator() ( const A0 & a0) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE std::bitset<4> operator() ( const A0 & a0) const BOOST_NOEXCEPT
     {
       return _mm_movemask_ps(bitwise_cast<bd::as_floating_t<A0>>(a0));
     }
   };
+
   BOOST_DISPATCH_OVERLOAD ( hmsb_
                           , (typename A0)
                           , bs::sse2_
                           , bs::pack_<bd::type64_<A0>, bs::sse_>
                          )
   {
-    BOOST_FORCEINLINE std::size_t operator() ( const A0 & a0) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE std::bitset<2> operator() ( const A0 & a0) const BOOST_NOEXCEPT
     {
       return _mm_movemask_pd(bitwise_cast<bd::as_floating_t<A0>>(a0));
     }
   };
-
 } } }
 
 #endif

--- a/include/boost/simd/arch/x86/ssse3/simd/function/hmsb.hpp
+++ b/include/boost/simd/arch/x86/ssse3/simd/function/hmsb.hpp
@@ -11,6 +11,7 @@
 
 #include <boost/simd/detail/overload.hpp>
 #include <boost/simd/function/bitwise_cast.hpp>
+#include <bitset>
 
 namespace boost { namespace simd { namespace ext
 {
@@ -23,14 +24,14 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::ints16_<A0>, bs::sse_>
                          )
   {
-    BOOST_FORCEINLINE std::size_t operator() ( const A0 & a0) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE std::bitset<8> operator()(const A0 & a0) const BOOST_NOEXCEPT
     {
       using s8type = typename A0::template retype<int8_t, 16>;
       s8type mask = { 0x01,0x03,0x05,0x07,0x09,0x0B,0x0D,0x0F
                     ,-128,-128,-128,-128,-128,-128,-128,-128
                     };
 
-      return _mm_movemask_epi8( _mm_shuffle_epi8(bitwise_cast<s8type>(a0), mask));
+      return _mm_movemask_epi8(_mm_shuffle_epi8(bitwise_cast<s8type>(a0), mask));
     }
   };
 } } }

--- a/include/boost/simd/function/hmsb.hpp
+++ b/include/boost/simd/function/hmsb.hpp
@@ -14,33 +14,16 @@
 #if defined(DOXYGEN_ONLY)
 namespace boost { namespace simd
 {
-
- /*!
-
+  /*!
     @ingroup group-reduction
-    Function object implementing hmsb capabilities
 
-    Returns a std::size_t value composed by the highiest bits.
-    of each vector element
+    Returns a std::bitset build from the most significant bit of each value its argument.
 
-    @par Semantic:
-
-    @code
-    std::size_t r = hmsb(x);
-    @endcode
-
-    is similar to:
-
-    @code
-      std::size_t r = 0;
-      for(result_type i = 0; i != cardinal_of<T>; ++i)
-      {
-        r |= (bits(x[i]) >> (sizeof(stype)*8 - 1)) << i;
-      }
-    @endcode
-
+    @param  v Value to process
+    @return A std::bitset of the size of cardinal(v) containing the most signiicant bits of each
+    elements of v.
   **/
-  std::size_t hmsb(Value const & v0);
+  std::bitset<cardinal_of<Value>::value> hmsb(Value const & v);
 } }
 #endif
 

--- a/test/function/scalar/hmsb.cpp
+++ b/test/function/scalar/hmsb.cpp
@@ -1,48 +1,24 @@
 //==================================================================================================
-/*!
-
+/**
   Copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #include <boost/simd/function/scalar/hmsb.hpp>
-#include <scalar_test.hpp>
-#include <boost/simd/detail/dispatch/meta/as_integer.hpp>
-#include <boost/simd/constant/inf.hpp>
-#include <boost/simd/constant/minf.hpp>
-#include <boost/simd/constant/mone.hpp>
-#include <boost/simd/constant/nan.hpp>
-#include <boost/simd/constant/one.hpp>
-#include <boost/simd/constant/zero.hpp>
 #include <boost/simd/constant/allbits.hpp>
-#include <boost/simd/function/shr.hpp>
+#include <boost/simd/constant/nan.hpp>
+#include <scalar_test.hpp>
 
-STF_CASE_TPL (" hmsb real",  STF_IEEE_TYPES)
+STF_CASE_TPL ("Check hmsb", STF_NUMERIC_TYPES)
 {
-  namespace bs = boost::simd;
-  namespace bd = boost::dispatch;
-  using bs::hmsb;
+  STF_EQUAL(boost::simd::hmsb(boost::simd::Allbits<T>()).size(), 1ULL);
 
-  // specific values tests
-  STF_EQUAL(hmsb(bs::Allbits<T>()), 1u);
-  STF_EQUAL(hmsb(bs::Inf<T>()), 0u);
-  STF_EQUAL(hmsb(bs::Minf<T>()), 1u);
-  STF_EQUAL(hmsb(bs::Mone<T>()), 1u);
-  STF_EQUAL(hmsb(bs::Nan<T>()), 1u);
-  STF_EQUAL(hmsb(bs::One<T>()), 0u);
-  STF_EQUAL(hmsb(bs::Signmask<T>()), 1u);
-  STF_EQUAL(hmsb(bs::Zero<T>()), 0u);
-} // end of test for real_
+  STF_EXPECT(boost::simd::hmsb(boost::simd::Signmask<T>()).all());
+  STF_EXPECT(boost::simd::hmsb(boost::simd::Allbits<T>()).all());
+  STF_EXPECT(boost::simd::hmsb(T(-1)).all());
 
-
-
-
-
-
-
-  namespace bs = boost::simd;
-  namespace bd = boost::dispatch;
-//
-
+  STF_EXPECT(boost::simd::hmsb(T(0)).none());
+  STF_EXPECT(boost::simd::hmsb(T(1)).none());
+}

--- a/test/function/simd/hmsb.cpp
+++ b/test/function/simd/hmsb.cpp
@@ -1,34 +1,34 @@
 //==================================================================================================
-/*!
-  @file
-
+/**
   Copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #include <boost/simd/function/hmsb.hpp>
 #include <boost/simd/pack.hpp>
-#include <boost/simd/function/bits.hpp>
 #include <simd_test.hpp>
 
 namespace bs = boost::simd;
+namespace bd = boost::dispatch;
 
 template <typename T,int N, typename Env>
 void test(Env& $)
 {
   using p_t = bs::pack<T, N>;
 
-  T a1[N];
-  std::size_t r = 0;
+  T a[N];
+  std::bitset<N> r;
+
   for(int i = 0; i < N; ++i)
   {
-    a1[i] = (i%2) ? T(i) : T(-i);
-    r |= (bs::bits(a1[i]) >> (sizeof(T)*8 - 1)) << i;
+    a[i] = (i%2) ? T(i) : T(-i);
+    r[i] = bs::bitwise_and(bs::Signmask<bd::as_integer_t<T>>(), a[i]) != 0;
   }
-  p_t aa1(&a1[0], &a1[0]+N);
-  STF_EQUAL(bs::hmsb(aa1), r);
+
+  p_t aa(&a[0], &a[0]+N);
+  STF_EQUAL(bs::hmsb(aa), r);
 }
 
 STF_CASE_TPL("Check hmsb on pack" , STF_NUMERIC_TYPES)


### PR DESCRIPTION
After multiple failure to get computation right and to
find a way to return a sensible value for pack of more
than 128 elements, hmsb now returns a std::bitset.

Related functions has been modified (all and any mostly).
