### PR TITLE
Fixed comments and documentation

### DIFF
--- a/include/boost/simd/detail/predef/hardware/simd/x86/versions.h
+++ b/include/boost/simd/detail/predef/hardware/simd/x86/versions.h
@@ -112,7 +112,7 @@ http://www.boost.org/LICENSE_1_0.txt)
  The [@https://en.wikipedia.org/wiki/AVX-512 AVX-512] x86 extension
  version number.
 
- Version number is: *9.0.0*.
+ Version number is: *6.0.0*.
  */
 #define BOOST_HW_SIMD_X86_AVX512_VERSION BOOST_VERSION_NUMBER(6, 0, 0)
 

--- a/include/boost/simd/function/if_allbits_else.hpp
+++ b/include/boost/simd/function/if_allbits_else.hpp
@@ -20,20 +20,20 @@ namespace boost { namespace simd
     @ingroup group-boolean
     Function object implementing if_allbits_else capabilities
 
-    If cond is @ref True returns allbits else returns f
+    If @c c is @ref True returns @ref Allbits else returns @c f
 
     @par Semantic:
 
-    For every parameters @c cond of type @c C, @c f of type @c T:
+    For every parameters @c c of type @c C and @c f of type @c T:
 
     @code
-    T r = if_allbits_else(cond,f);
+    T r = if_allbits_else(c, f);
     @endcode
 
     is similar to:
 
     @code
-    T r = cond ? Allbits : f;
+    T r = c ? Allbits<T>() : f;
     @endcode
 
     @par Alias:

--- a/include/boost/simd/function/if_dec.hpp
+++ b/include/boost/simd/function/if_dec.hpp
@@ -24,16 +24,16 @@ namespace boost { namespace simd
 
     @par Semantic:
 
-    For every parameters @c c of type @c C and @c t of type @c T:
+    For every parameters @c c of type @c C and @c t of type @c T :
 
     @code
-    T r = if_dec(cond,t);
+    T r = if_dec(c, t);
     @endcode
 
     is similar to:
 
     @code
-    T r = cond ? t-One<T>() : t;
+    T r = c ? t - One<T>() : t;
     @endcode
   **/
   Value if_dec(Value const& c, Value const& v0);

--- a/include/boost/simd/function/if_else.hpp
+++ b/include/boost/simd/function/if_else.hpp
@@ -19,31 +19,31 @@ namespace boost { namespace simd
     @ingroup group-boolean
     Function object implementing if_else capabilities
 
-    If cond is @ref True returns t else returns f
+    If @c c is @ref True returns @c t else returns @c f
 
     If vectors, the types involved in the call must share the same number of elements.
 
     @par Semantic:
 
-    For every parameters @c c of type @c C, @c t and @c f of type @c T:
+    For every parameters @c c of type @c C, @c t and @c f of type @c T :
 
     @code
-    T r = if_else(cond,t,f);
+    T r = if_else(c, t, f);
     @endcode
 
     is similar to:
 
     @code
-    T r = cond ? t : f;
+    T r = c ? t : f;
     @endcode
 
     @see  if_else_zero, if_else_allbits, if_zero_else,
     if_allbits_else, if_one_else_zero, if_zero_else_one, bitwise_select
   **/
-  Value if_else(Value const& c, Value const& v0);
+  Value if_else(Value const& c, Value const& t, Value const& f);
 
   //@overload
-  Value if_else(LogicalValue const& c, Value const& v0);
+  Value if_else(LogicalValue const& c, Value const& t, Value const& f);
 } }
 #endif
 

--- a/include/boost/simd/function/if_else_allbits.hpp
+++ b/include/boost/simd/function/if_else_allbits.hpp
@@ -20,20 +20,20 @@ namespace boost { namespace simd
     @ingroup group-boolean
     Function object implementing if_else_allbits capabilities
 
-    If cond is @ref True returns t else returns allbits
+    If @c c is @ref True returns @c t else returns @ref Allbits
 
     @par Semantic:
 
-    For every parameters @c c of type @c C and @c t of type @c T:
+    For every parameters @c c of type @c C and @c t of type @c T :
 
     @code
-    T r = if_else_allbits(cond,t);
+    T r = if_else_allbits(c, t);
     @endcode
 
     is similar to:
 
     @code
-    T r = cond ? t : Allbits<T>();
+    T r = c ? t : Allbits<T>();
     @endcode
 
     @par Alias:

--- a/include/boost/simd/function/if_else_nan.hpp
+++ b/include/boost/simd/function/if_else_nan.hpp
@@ -20,7 +20,7 @@ namespace boost { namespace simd
     @ingroup group-boolean
     Function object implementing if_else_nan capabilities
 
-    If cond is @ref True returns t else returns allbits
+    If @c c is @ref True returns @c v0 else returns @ref Allbits
 
     This is a convenience alias of @ref if_else_allbits
   **/

--- a/include/boost/simd/function/if_else_zero.hpp
+++ b/include/boost/simd/function/if_else_zero.hpp
@@ -20,20 +20,20 @@ namespace boost { namespace simd
     @ingroup group-boolean
     Function object implementing if_else_zero capabilities
 
-    If x is @ref True returns t else returns zero
+    If @c x is @ref True returns @c t else returns @ref Zero
 
     @par Semantic:
 
-    For every parameters @c c of type @c C and @c t of type @c T:
+    For every parameters @c c of type @c C and @c t of type @c T :
 
     @code
-    T r = if_else_zero(cond,t);
+    T r = if_else_zero(c, t);
     @endcode
 
     is similar to:
 
     @code
-    T r = cond ? t : Zero<T>();
+    T r = c ? t : Zero<T>();
     @endcode
 
   **/

--- a/include/boost/simd/function/if_inc.hpp
+++ b/include/boost/simd/function/if_inc.hpp
@@ -20,20 +20,20 @@ namespace boost { namespace simd
     @ingroup group-boolean
     Function object implementing if_inc capabilities
 
-    Increments a value by @ref One if a predicate is @ref True.
+    Increments a value by @ref One if a predicate is @ref True .
 
     @par Semantic:
 
-    For every parameters @c c of type @c C and @c t of type @c T:
+    For every parameters @c c of type @c C and @c t of type @c T :
 
     @code
-    T r = if_inc(cond,y);
+    T r = if_inc(c, t);
     @endcode
 
     is similar to:
 
     @code
-    T r = cond ? t+One<T>() : t;
+    T r = c ? t + One<T>() : t;
     @endcode
   **/
   Value if_inc(Value const& c, Value const& v0);

--- a/include/boost/simd/function/if_minus.hpp
+++ b/include/boost/simd/function/if_minus.hpp
@@ -20,13 +20,13 @@ namespace boost { namespace simd
     @ingroup group-boolean
     Function object implementing if_minus capabilities
 
-    The function returns the second entry or the difference of the
-    second and third entries, according to the first entry being @ref False
-    or @ref True
+    The function returns either the second parameter or the difference between the
+    second and third parameter, depending on whether the first parameter is
+	@ref False or @ref True .
 
     @par Semantic:
 
-    For every parameters @c c of type @c C and @c x, @c y of type @c T:
+    For every parameters @c c of type @c C and @c x, @c y of type @c T :
 
     @code
     T1 r = if_minus(c, x, y);
@@ -35,7 +35,7 @@ namespace boost { namespace simd
     is similar to:
 
     @code
-    T1 r = c ? x-y : x;
+    T1 r = c ? x - y : x;
     @endcode
   **/
   Value if_minus(Value const& c, Value const& x, Value const&  y);

--- a/include/boost/simd/function/if_nan_else.hpp
+++ b/include/boost/simd/function/if_nan_else.hpp
@@ -20,7 +20,7 @@ namespace boost { namespace simd
     @ingroup group-boolean
     Function object implementing if_nan_else capabilities
 
-    If cond is @ref True returns @ref Allbits else returns f
+    If @c r is @ref True returns @ref Allbits else returns @c v0
 
     This is a convenience alias of @ref if_allbits_else
   **/

--- a/include/boost/simd/function/if_one_else_zero.hpp
+++ b/include/boost/simd/function/if_one_else_zero.hpp
@@ -20,26 +20,26 @@ namespace boost { namespace simd
     @ingroup group-boolean
     Function object implementing if_one_else_zero capabilities
 
-    If cond is @ref True returns @ref One else returns @ref Zero
+    If @c c is @ref True returns @ref One else returns @ref Zero .
 
     @par Semantic:
 
-    For every parameter @c cond of type C:
+    For every parameter @c c of type @c C :
 
     @code
-    auto r = if_one_else_zero(cond);
+    auto r = if_one_else_zero(c);
     @endcode
 
     is similar to:
 
     @code
-    auto r = cond ? One : Zero;
+    auto r = c ? One : Zero;
     @endcode
 
     @par Note:
 
-    The return type is generally C except in the case where C is as_logical_t<T>. in which case
-    the return type is T.
+    The return type is generally @c C except in the case where @c C is <tt>as_logical_t<T></tt> in which case
+    the return type is @c T .
 
   **/
   Value if_one_else_zero(Value const& c);

--- a/include/boost/simd/function/if_plus.hpp
+++ b/include/boost/simd/function/if_plus.hpp
@@ -20,22 +20,22 @@ namespace boost { namespace simd
     @ingroup group-boolean
     Function object implementing if_plus capabilities
 
-    The function returns the second entry or the sum of the second
-    and third entries, according to the first entry being @ref False or
-    @ref True
+    The function returns either the second parameter or the sum of the second
+    and third parameters, depending on whether the first parameter is
+	@ref False or @ref True .
 
     @par Semantic:
 
-    For every parameters @c c of type @c C and @c, @c y of type @c T:
+    For every parameter @c c of type @c C and @c x, @c y of type @c T :
 
     @code
-    T r = if_plus(cond,x,y);
+    T r = if_plus(c, x, y);
     @endcode
 
     is similar to:
 
     @code
-    T r = cond ? x+y : x;
+    T r = c ? x + y : x;
     @endcode
   **/
   Value if_plus(Value const& c, Value const& x, Value const& y);

--- a/include/boost/simd/function/if_zero_else.hpp
+++ b/include/boost/simd/function/if_zero_else.hpp
@@ -20,20 +20,20 @@ namespace boost { namespace simd
     @ingroup group-boolean
     Function object implementing if_zero_else capabilities
 
-    If cond is @ref True returns @ref Zero else returns f
+    If @c c is @ref True returns @ref Zero else returns @c x .
 
     @par Semantic:
 
-    For every parameters @c c of type @c C and @c x of type @c T:
+    For every parameters @c c of type @c C and @c x of type @c T :
 
     @code
-    T r = if_zero_else(cond, x);
+    T r = if_zero_else(c, x);
     @endcode
 
     is similar to:
 
     @code
-    T r = cond ? Zero<T>() : x;
+    T r = c ? Zero<T>() : x;
     @endcode
 
   **/

--- a/include/boost/simd/function/if_zero_else_allbits.hpp
+++ b/include/boost/simd/function/if_zero_else_allbits.hpp
@@ -20,8 +20,8 @@ namespace boost { namespace simd
     @ingroup group-boolean
     Function object implementing if_zero_else_allbits capabilities
 
-    Returns a mask of bits. All ones if the
-    input element is @ref Zero else all zeros.
+    Returns a mask of bits. Returns @ref Allbits if @c c
+    is @ref Zero and returns @ref Zero if it isn't.
 
     This is a convenience alias of @ref genmaskc
   **/

--- a/include/boost/simd/function/if_zero_else_one.hpp
+++ b/include/boost/simd/function/if_zero_else_one.hpp
@@ -20,26 +20,26 @@ namespace boost { namespace simd
     @ingroup group-boolean
     Function object implementing if_zero_else_one capabilities
 
-    If cond is @ref True returns @ref Zero else returns one
+    If @c c is @ref True returns @ref Zero else returns @ref One .
 
     @par Semantic:
 
-    For every parameters of type @c C:
+    For every parameter @c c of type @c C :
 
     @code
-    T r = if_zero_else_one(cond);
+    auto r = if_zero_else_one(c);
     @endcode
 
     is similar to:
 
     @code
-    T r =  cond ? Zero : One;
+    auto r = c ? Zero : One;
     @endcode
 
     @par Note:
 
-    The return type is generally C except in the case where C is as_logical_t<T>. in which case
-    the return type is T.
+    The return type is generally @c C except in the case where @c C is <tt>as_logical_t<T></tt>. in which case
+    the return type is @c T .
 
   **/
   Value if_zero_else_one(Value const& c);


### PR DESCRIPTION
My changes concern the files _detail/predef/hardware/simd/x86/versions.h_ and _function/if*.hpp_.

There was a mismatch between the comment and the code in _version.h_.

Changes to the _function/if*.hpp_ files:
Often times the documentation was referring to a parameter called `cond` which doesn't exist. The conditional parameter is labeled `c` throughout the concerned parts of the documentations, including the function signatures.
Furthermore, the documentation seemed to be very inconsistent regarding `@c` and `@ref` tags; so I've made use of them wherever possible.
There also were some incorrect code samles with missing `<T>()` e.g. after `Allbits`.
Also fixed formatting and incorrect phrasing.

Important: The function signature as seen previously in _if_else.hpp_ was incorrect. Although I've fixed it, I'm uncertain whether or not this change entails further need for fixes along the library.
