### PR TITLE
Rec imprvmnt

### DIFF
--- a/bench/function/simd/CMakeLists.txt
+++ b/bench/function/simd/CMakeLists.txt
@@ -269,6 +269,7 @@ set(SOURCES
     prev.cpp
     rec.regular.cpp
     rec.fast.cpp
+    rec.raw.cpp
     rem.regular.cpp
     rem.fast.cpp
     rem_pio2_cephes.cpp

--- a/bench/function/simd/divides.fast.cpp
+++ b/bench/function/simd/divides.fast.cpp
@@ -5,22 +5,17 @@
 //                        See accompanying file LICENSE.txt or copy at
 //                            http://www.boost.org/LICENSE_1_0.txt
 // -------------------------------------------------------------------------------------------------
-#define BOOST_SIMD_NO_DENORMALS
-#define BOOST_SIMD_NO_INFINITIES
+
 #include <simd_bench.hpp>
-#include <boost/simd/function/simd/rec.hpp>
+#include <boost/simd/function/simd/divides.hpp>
 #include <boost/simd/pack.hpp>
 
 namespace nsb = ns::bench;
 namespace bs =  boost::simd;
 
-DEFINE_SIMD_BENCH(simd_rec, bs::rec);
+DEFINE_SIMD_BENCH(simd_divides, bs::fast_(bs::divides));
 
 DEFINE_BENCH_MAIN()
 {
-  nsb::for_each<simd_rec, NS_BENCH_IEEE_TYPES>(-10, 10);
-  nsb::for_each<simd_rec, float>(0.0f, 1.0e-45f);
-  nsb::for_each<simd_rec, double>(0.0, 1.0e-308);  
-  nsb::for_each<simd_rec, float>(0.0f, 10.0f);
-  nsb::for_each<simd_rec, double>(0.0, 10.0);  
+  nsb::for_each<simd_divides, NS_BENCH_IEEE_TYPES>(-10, 10,-10, 10);
 }

--- a/bench/function/simd/rec.raw.cpp
+++ b/bench/function/simd/rec.raw.cpp
@@ -1,0 +1,21 @@
+// -------------------------------------------------------------------------------------------------
+//                              Copyright 2016 - NumScale SAS
+//
+//                   Distributed under the Boost Software License, Version 1.0.
+//                        See accompanying file LICENSE.txt or copy at
+//                            http://www.boost.org/LICENSE_1_0.txt
+// -------------------------------------------------------------------------------------------------
+
+#include <simd_bench.hpp>
+#include <boost/simd/function/simd/rec.hpp>
+#include <boost/simd/pack.hpp>
+
+namespace nsb = ns::bench;
+namespace bs =  boost::simd;
+
+DEFINE_SIMD_BENCH(simd_rec, bs::raw_(bs::rec));
+
+DEFINE_BENCH_MAIN()
+{
+  nsb::for_each<simd_rec, NS_BENCH_IEEE_TYPES>(-10, 10);
+}

--- a/exhaustive/function/simd/CMakeLists.txt
+++ b/exhaustive/function/simd/CMakeLists.txt
@@ -59,7 +59,9 @@ log2.cpp
 log.cpp
 nthroot.cpp
 oneminus.cpp
-rec.cpp
+rec.regular.cpp
+rec.fast.cpp
+rec.raw.cpp
 rsqrt.cpp
 sign.cpp
 signnz.cpp

--- a/exhaustive/function/simd/rec.fast.cpp
+++ b/exhaustive/function/simd/rec.fast.cpp
@@ -1,0 +1,40 @@
+//==============================================================================
+//         Copyright 2016        NumScale SAS
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <boost/simd/function/rec.hpp>
+#include <boost/simd/constant/zero.hpp>
+#include <boost/simd/constant/valmax.hpp>
+
+#include <boost/simd/pack.hpp>
+#include <exhaustive.hpp>
+
+#include <cmath>
+#include <cstdlib>
+
+struct raw_rec
+{
+  float operator()(float x) const
+  {
+    return 1.0/(double(x));
+  }
+};
+
+int main(int argc, char* argv[])
+{
+  float mini = bs::Zero<float>();
+  float maxi = bs::Valmax<float>();
+  if(argc >= 2) mini = std::atof(argv[1]);
+  if(argc >= 3) maxi = std::atof(argv[2]);
+  bs::exhaustive_test<bs::pack<float>> ( mini
+                                       , maxi
+                                       , bs::fast_(bs::rec)
+                                       , raw_rec()
+                                       );
+
+  return 0;
+}
+

--- a/exhaustive/function/simd/rec.raw.cpp
+++ b/exhaustive/function/simd/rec.raw.cpp
@@ -1,0 +1,40 @@
+//==============================================================================
+//         Copyright 2016        NumScale SAS
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <boost/simd/function/rec.hpp>
+#include <boost/simd/constant/zero.hpp>
+#include <boost/simd/constant/valmax.hpp>
+
+#include <boost/simd/pack.hpp>
+#include <exhaustive.hpp>
+
+#include <cmath>
+#include <cstdlib>
+
+struct raw_rec
+{
+  float operator()(float x) const
+  {
+    return 1.0/(double(x));
+  }
+};
+
+int main(int argc, char* argv[])
+{
+  float mini = bs::Zero<float>();
+  float maxi = bs::Valmax<float>();
+  if(argc >= 2) mini = std::atof(argv[1]);
+  if(argc >= 3) maxi = std::atof(argv[2]);
+  bs::exhaustive_test<bs::pack<float>> ( mini
+                                       , maxi
+                                       , bs::raw_(bs::rec)
+                                       , raw_rec()
+                                       );
+
+  return 0;
+}
+

--- a/exhaustive/function/simd/rec.regular.cpp
+++ b/exhaustive/function/simd/rec.regular.cpp
@@ -1,0 +1,40 @@
+//==============================================================================
+//         Copyright 2016        NumScale SAS
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <boost/simd/function/rec.hpp>
+#include <boost/simd/constant/zero.hpp>
+#include <boost/simd/constant/valmax.hpp>
+
+#include <boost/simd/pack.hpp>
+#include <exhaustive.hpp>
+
+#include <cmath>
+#include <cstdlib>
+
+struct raw_rec
+{
+  float operator()(float x) const
+  {
+    return bs::rec(double(x));
+  }
+};
+
+int main(int argc, char* argv[])
+{
+  float mini = bs::Zero<float>();
+  float maxi = bs::Valmax<float>();
+  if(argc >= 2) mini = std::atof(argv[1]);
+  if(argc >= 3) maxi = std::atof(argv[2]);
+  bs::exhaustive_test<bs::pack<float>> ( mini
+                              , maxi
+                              , bs::rec
+                              , raw_rec()
+                              );
+
+  return 0;
+}
+

--- a/include/boost/simd/arch/common/simd/function/rec.hpp
+++ b/include/boost/simd/arch/common/simd/function/rec.hpp
@@ -11,14 +11,24 @@
 
 #include <boost/simd/detail/overload.hpp>
 #include <boost/simd/detail/traits.hpp>
+#include <boost/simd/function/any.hpp>
+#include <boost/simd/function/bitwise_or.hpp>
+#include <boost/simd/function/bitwise_and.hpp>
 #include <boost/simd/function/if_one_else_zero.hpp>
-#include <boost/simd/function/divides.hpp>
+#include <boost/simd/function/if_else.hpp>
+#include <boost/simd/function/is_denormal.hpp>
+#include <boost/simd/function/is_eqz.hpp>
 #include <boost/simd/function/refine_rec.hpp>
 #include <boost/simd/function/abs.hpp>
 #include <boost/simd/function/fast.hpp>
 #include <boost/simd/function/raw.hpp>
 #include <boost/simd/constant/valmax.hpp>
 #include <boost/simd/constant/one.hpp>
+#include <boost/simd/constant/zero.hpp>
+#include <boost/simd/constant/mzero.hpp>
+#include <boost/simd/constant/inf.hpp>
+#include <boost/simd/constant/inveps.hpp>
+
 
 namespace boost { namespace simd { namespace ext
 {
@@ -58,9 +68,34 @@ namespace boost { namespace simd { namespace ext
                             , bs::pack_<bd::floating_<A0>, X>
                             )
   {
-    BOOST_FORCEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE A0 operator()( const A0& a00) const BOOST_NOEXCEPT
     {
-      return One<A0>()/a0;
+      A0 a0 = a00;
+      #ifndef BOOST_SIMD_NO_DENORMALS
+      auto is_den = is_denormal(a00);
+      auto any_is =  any(is_den);
+      A0 fac;
+      if (BOOST_UNLIKELY((any_is)))
+      {
+        fac = if_else(is_den, Inveps<A0>(), One<A0>());
+        a0 *=  fac;
+      }
+
+      #endif
+      a0 =  if_else(is_eqz(a0),
+                    bitwise_or(a0, Inf<A0>()),
+                    fast_(rec)(a0)
+                   );
+      #ifndef BOOST_SIMD_NO_INFINITIES
+      a0 = if_else(is_inf(a00),
+                      bitwise_and(a00, Zero<A0>()),
+                      a0
+                     );
+      #endif
+      #ifndef BOOST_SIMD_NO_DENORMALS
+      if (BOOST_UNLIKELY((any_is))) a0 *= fac;
+      #endif
+      return a0;
     }
   };
 
@@ -76,7 +111,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE A0 operator()(bs::fast_tag const&, A0 const& a0) const BOOST_NOEXCEPT
     {
-      return refine_rec(a0, raw_(rec)(a0) );
+      return  refine_rec(a0, refine_rec(a0, raw_(rec)(a0) ));
     }
   };
 

--- a/include/boost/simd/arch/common/simd/function/rec.hpp
+++ b/include/boost/simd/arch/common/simd/function/rec.hpp
@@ -80,6 +80,24 @@ namespace boost { namespace simd { namespace ext
     }
   };
 
+
+  BOOST_DISPATCH_OVERLOAD_IF( rec_
+                            , (typename A0, typename X)
+                            , (detail::is_native<X>)
+                            , bd::cpu_
+                            , bs::fast_tag
+                            , bs::pack_<bd::double_<A0>, X>
+                            )
+  {
+    BOOST_FORCEINLINE A0 operator()(bs::fast_tag const&, A0 const& a0) const BOOST_NOEXCEPT
+    {
+      return refine_rec(a0, refine_rec(a0, refine_rec(a0, raw_(rec)(a0) )));
+    }
+  };
+
+
+
+
   BOOST_DISPATCH_OVERLOAD_IF ( rec_
                              , (typename T, typename X)
                              , (detail::is_native<X>)

--- a/include/boost/simd/arch/x86/avx/simd/function/rec.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/rec.hpp
@@ -39,7 +39,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE A0 operator()(raw_tag const&, A0 const& a0) const BOOST_NOEXCEPT
     {
-      return _mm256_cvtps_pd(_mm256_rcp_ps( _mm_cvtpd_ps(a0) );
+      return _mm256_cvtps_pd(_mm_rcp_ps( _mm256_cvtpd_ps(a0) ));
     }
   };
 

--- a/include/boost/simd/arch/x86/avx/simd/function/rec.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/rec.hpp
@@ -29,6 +29,21 @@ namespace boost { namespace simd { namespace ext
       return _mm256_rcp_ps( a0 );
     }
   };
+
+  BOOST_DISPATCH_OVERLOAD ( rec_
+                          , (typename A0)
+                          , bs::avx_
+                          , bs::raw_tag
+                          , bs::pack_<bd::double_<A0>, bs::avx_>
+                          )
+  {
+    BOOST_FORCEINLINE A0 operator()(raw_tag const&, A0 const& a0) const BOOST_NOEXCEPT
+    {
+      return _mm256_cvtps_pd(_mm256_rcp_ps( _mm_cvtpd_ps(a0) );
+    }
+  };
+
+
 } } }
 
 #endif

--- a/include/boost/simd/arch/x86/sse2/simd/function/rec.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/rec.hpp
@@ -1,0 +1,35 @@
+//==================================================================================================
+/**
+  Copyright 2016 Numscale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_X86_SSE2_SIMD_FUNCTION_REC_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_X86_SSE2_SIMD_FUNCTION_REC_HPP_INCLUDED
+
+#include <boost/simd/detail/overload.hpp>
+#include <boost/simd/function/raw.hpp>
+
+namespace boost { namespace simd { namespace ext
+{
+  namespace bd =  boost::dispatch;
+  namespace bs =  boost::simd;
+
+  BOOST_DISPATCH_OVERLOAD ( rec_
+                          , (typename A0)
+                          , bs::sse2_
+                          , bs::raw_tag
+                          , bs::pack_<bd::double_<A0>, bs::sse_>
+                         )
+  {
+    BOOST_FORCEINLINE A0 operator()(raw_tag const&, const A0 & a0) const BOOST_NOEXCEPT
+    {
+
+      return  _mm_cvtps_pd(_mm_rcp_ps( _mm_cvtpd_ps(a0) ));
+    }
+  };
+} } }
+
+#endif

--- a/include/boost/simd/constant/definition/inveps.hpp
+++ b/include/boost/simd/constant/definition/inveps.hpp
@@ -1,0 +1,50 @@
+//==================================================================================================
+/*!
+  @file
+
+  @copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#ifndef BOOST_SIMD_CONSTANT_DEFINITION_INVEPS_HPP_INCLUDED
+#define BOOST_SIMD_CONSTANT_DEFINITION_INVEPS_HPP_INCLUDED
+
+#include <boost/simd/config.hpp>
+#include <boost/simd/detail/brigand.hpp>
+#include <boost/simd/detail/dispatch.hpp>
+#include <boost/simd/detail/constant_traits.hpp>
+#include <boost/simd/detail/dispatch/function/make_callable.hpp>
+#include <boost/simd/detail/dispatch/hierarchy/functions.hpp>
+#include <boost/simd/detail/dispatch/as.hpp>
+
+namespace boost { namespace simd
+{
+  namespace tag
+  {
+    struct inveps_ : boost::dispatch::constant_value_<inveps_>
+    {
+      BOOST_DISPATCH_MAKE_CALLABLE(ext,inveps_,boost::dispatch::constant_value_<inveps_>);
+      BOOST_SIMD_REGISTER_CONSTANT(1, 0x4b000000UL, 0x4330000000000000ULL);
+    };
+  }
+
+  namespace ext
+  {
+    BOOST_DISPATCH_FUNCTION_DECLARATION(tag,inveps_);
+  }
+
+  namespace detail
+  {
+    BOOST_DISPATCH_CALLABLE_DEFINITION(tag::inveps_,inveps);
+  }
+
+  template<typename T> BOOST_FORCEINLINE auto Inveps()
+  BOOST_NOEXCEPT_DECLTYPE(detail::inveps( boost::dispatch::as_<T>{}))
+  {
+    return detail::inveps( boost::dispatch::as_<T>{} );
+  }
+} }
+
+#endif

--- a/include/boost/simd/constant/inveps.hpp
+++ b/include/boost/simd/constant/inveps.hpp
@@ -1,0 +1,55 @@
+//==================================================================================================
+/*!
+  @file
+
+  @copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#ifndef BOOST_SIMD_CONSTANT_INVEPS_HPP_INCLUDED
+#define BOOST_SIMD_CONSTANT_INVEPS_HPP_INCLUDED
+
+#if defined(DOXYGEN_ONLY)
+namespace boost { namespace simd
+{
+  /*!
+    @ingroup group-constant
+
+    Generate  value \f$\sqrt2\f$
+
+    @par Semantic:
+
+    @code
+    T r = inveps<T>();
+    @endcode
+
+    is similar to:
+
+    @code
+    T r = rec(Eps<T>());
+    @endcode
+
+    @return The inveps constant for the proper type
+  **/
+  template<typename T> T inveps();
+
+  namespace functional
+  {
+    /*!
+      @ingroup group-callable-constant
+      Generate the  constant inveps.
+
+      @return The inveps constant for the proper type
+    **/
+    const boost::dispatch::functor<tag::inveps_> inveps = {};
+  }
+} }
+#endif
+
+#include <boost/simd/constant/definition/inveps.hpp>
+#include <boost/simd/arch/common/scalar/constant/constant_value.hpp>
+#include <boost/simd/arch/common/simd/constant/constant_value.hpp>
+
+#endif

--- a/include/boost/simd/function/simd/rec.hpp
+++ b/include/boost/simd/function/simd/rec.hpp
@@ -18,6 +18,9 @@
 #  if BOOST_HW_SIMD_X86_OR_AMD >= BOOST_HW_SIMD_X86_SSE_VERSION
 #    include <boost/simd/arch/x86/sse1/simd/function/rec.hpp>
 #  endif
+#  if BOOST_HW_SIMD_X86_OR_AMD >= BOOST_HW_SIMD_X86_SSE2_VERSION
+#    include <boost/simd/arch/x86/sse2/simd/function/rec.hpp>
+#  endif
 #  if BOOST_HW_SIMD_X86_OR_AMD >= BOOST_HW_SIMD_X86_AVX_VERSION
 #    include <boost/simd/arch/x86/avx/simd/function/rec.hpp>
 #  endif

--- a/test/function/simd/rec.cpp
+++ b/test/function/simd/rec.cpp
@@ -18,6 +18,10 @@
 #include <boost/simd/constant/one.hpp>
 #include <boost/simd/constant/zero.hpp>
 #include <boost/simd/constant/mzero.hpp>
+#include <boost/simd/constant/two.hpp>
+#include <boost/simd/constant/mtwo.hpp>
+#include <boost/simd/constant/half.hpp>
+#include <boost/simd/constant/mhalf.hpp>
 
 namespace bs = boost::simd;
 
@@ -122,5 +126,23 @@ STF_CASE_TPL("regular rec",  STF_IEEE_TYPES)
   STF_IEEE_EQUAL(rec(bs::Nan<p_t>()), bs::Nan<p_t>());
   STF_EQUAL(rec(bs::One<p_t>()), bs::One<p_t>());
   STF_EQUAL(rec(bs::Zero<p_t>()), bs::Inf<p_t>());
+} // end of test for floating_
+
+STF_CASE_TPL("fast rec",  STF_IEEE_TYPES)
+{
+  namespace bs = boost::simd;
+  namespace bd = boost::dispatch;
+  using bs::rec;
+  using p_t = bs::pack<T>;
+
+  // return type conformity test
+  STF_EXPR_IS( bs::fast_(rec)(p_t()) , p_t );
+
+  // specific values tests
+  STF_EQUAL(bs::fast_(rec)(bs::Mtwo<p_t>()), bs::Mhalf<p_t>());
+  STF_EQUAL(bs::fast_(rec)(bs::Mone<p_t>()), bs::Mone<p_t>());
+  STF_IEEE_EQUAL(bs::fast_(rec)(bs::Nan<p_t>()), bs::Nan<p_t>());
+  STF_EQUAL(bs::fast_(rec)(bs::One<p_t>()), bs::One<p_t>());
+  STF_EQUAL(bs::fast_(rec)(bs::Two<p_t>()), bs::Half<p_t>());
 } // end of test for floating_
 

--- a/test/function/simd/rec.cpp
+++ b/test/function/simd/rec.cpp
@@ -61,7 +61,7 @@ void test_fast(Env& $)
   }
   p_t aa1(&a1[0], &a1[0]+N);
   p_t bb (&b[0], &b[0]+N);
-  STF_ULP_EQUAL(bs::fast_(bs::rec)(aa1), bb, 16);
+  STF_ULP_EQUAL(bs::fast_(bs::rec)(aa1), bb, 1);
 }
 
 STF_CASE_TPL("Check fast(rec) on pack", STF_IEEE_TYPES)


### PR DESCRIPTION
_mm_rcp_ps can be used as a basis for rec computation also for double in avx and sse2 with a better performance than the div_pd intrinsic