### PR TITLE
Make static indexing more flexible

### DIFF
--- a/include/boost/simd/litteral.hpp
+++ b/include/boost/simd/litteral.hpp
@@ -1,0 +1,53 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_LITTERALS_HPP_INCLUDED
+#define BOOST_SIMD_LITTERALS_HPP_INCLUDED
+
+#include <boost/simd/detail/brigand.hpp>
+
+namespace boost { namespace simd
+{
+  namespace detail
+  {
+    // Turn '4' into 4
+    constexpr int to_int(char c) { return static_cast<int>(c) - 48; }
+
+    // Terminal case for char recursion
+    template< std::size_t N>
+    constexpr std::uint64_t parse(int,const char (&)[N], brigand::uint64_t<0> const&)
+    {
+      return 0;
+    }
+
+    // Extract a char, get its value, multiply by current base, repeat
+    template< std::size_t N, std::size_t I>
+    constexpr std::uint64_t parse(int base, const char (&arr)[N], brigand::uint64_t<I> const&)
+    {
+      return to_int(arr[I - 1]) * base + parse<N>(base*10, arr,brigand::uint64_t<I-1>{});
+    }
+
+    // Intermediate trampoline so MSVC doesn't cry
+    template<std::size_t N,char... c> constexpr std::uint64_t parse(int base)
+    {
+      return parse(base, {c...}, brigand::uint64_t<N>{});
+    }
+  }
+
+  namespace literal
+  {
+    // Enables xxx_c to be turned into usable integral constant int_<xxx>
+    template <char ...c>
+    constexpr brigand::uint64_t< boost::simd::detail::parse<sizeof...(c),c...>(1)> operator"" _c()
+    {
+      return {};
+    }
+  }
+} }
+
+#endif

--- a/include/boost/simd/litteral.hpp
+++ b/include/boost/simd/litteral.hpp
@@ -35,7 +35,7 @@ namespace boost { namespace simd
     // Intermediate trampoline so MSVC doesn't cry
     template<std::size_t N,char... c> constexpr std::uint64_t parse(int base)
     {
-      return parse(base, {c...}, brigand::uint64_t<N>{});
+      return parse<N>(base, {c...}, brigand::uint64_t<N>{});
     }
   }
 

--- a/include/boost/simd/pack.hpp
+++ b/include/boost/simd/pack.hpp
@@ -254,6 +254,20 @@ namespace boost { namespace simd
       return traits::at(*this, i);
     }
 
+    /// @overload
+    template<std::uint64_t Index>
+    BOOST_FORCEINLINE value_type operator[](std::integral_constant<std::uint64_t,Index> const&)
+    {
+      return ::boost::simd::extract<Index>(*this);
+    }
+
+    /// @overload
+    template<std::uint64_t Index>
+    BOOST_FORCEINLINE value_type operator[](std::integral_constant<std::uint64_t,Index> const&) const
+    {
+      return ::boost::simd::extract<Index>(*this);
+    }
+
     BOOST_FORCEINLINE value_type get(std::size_t i) const
     {
       return ::boost::simd::extract(*this, i);

--- a/test/function/simd/extract/static.arithmetic.cpp
+++ b/test/function/simd/extract/static.arithmetic.cpp
@@ -1,21 +1,22 @@
 //==================================================================================================
-/*!
-  @file
-
+/**
   Copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #include <boost/simd/function/extract.hpp>
 #include <boost/simd/detail/unroll.hpp>
+#include <boost/simd/litteral.hpp>
 #include <boost/simd/pack.hpp>
 #include <simd_test.hpp>
 #include <array>
 
 namespace bs = boost::simd;
 namespace bd = boost::dispatch;
+
+using namespace bs::literal;
 
 template <typename T, std::size_t N, typename Env, typename Idx>
 void unroll_step ( bs::pack<T,N> const& p, std::array<T,N> const& ref, Idx const&, Env& $)
@@ -51,4 +52,26 @@ STF_CASE_TPL("Check static extract on pack" , STF_NUMERIC_TYPES)
   test_st<T, N/2>($);
   test_st<T, N>($);
   test_st<T, N*2>($);
+}
+
+template <typename T, std::size_t N, typename Env>
+void test_lt(Env& $)
+{
+  std::array<T,N> ref;
+  for(std::size_t i = 0; i < N; ++i) ref[i] = T(i*2);
+  bs::pack<T,N> p(&ref[0], &ref[0]+N);
+
+          STF_EQUAL(bs::extract(p, 0_c), ref[0]);
+  if(N>1) STF_EQUAL(bs::extract(p, 1_c), ref[1]);
+  if(N>3) STF_EQUAL(bs::extract(p, 3_c), ref[3]);
+  if(N>7) STF_EQUAL(bs::extract(p, 7_c), ref[7]);
+}
+
+STF_CASE_TPL("Check extract on pack using literals" , STF_NUMERIC_TYPES)
+{
+  static const std::size_t N = boost::simd::pack<T>::static_size;
+
+  test_lt<T, N/2>($);
+  test_lt<T, N>($);
+  test_lt<T, N*2>($);
 }

--- a/test/function/simd/insert/static.arithmetic.cpp
+++ b/test/function/simd/insert/static.arithmetic.cpp
@@ -1,15 +1,14 @@
 //==================================================================================================
-/*!
-  @file
-
+/**
   Copyright 2016 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-*/
+**/
 //==================================================================================================
 #include <boost/simd/function/insert.hpp>
 #include <boost/simd/detail/unroll.hpp>
+#include <boost/simd/litteral.hpp>
 #include <boost/simd/pack.hpp>
 #include <simd_test.hpp>
 #include <array>
@@ -17,12 +16,14 @@
 namespace bs = boost::simd;
 namespace bd = boost::dispatch;
 
+using namespace bs::literal;
+
 template<typename A, typename P, typename... N>
 void f( brigand::list<N...> const&, A& a, P& p)
 {
   using T = typename P::value_type;
   BOOST_SIMD_LOCAL_UNROLL( a[N::value] = T(N::value+1) );
-  BOOST_SIMD_LOCAL_UNROLL( (bs::insert(p, N::value, T(N::value+1))) );
+  BOOST_SIMD_LOCAL_UNROLL( (bs::insert(p, N{}, T(N::value+1))) );
 }
 
 template <typename T, std::size_t N, typename Env>
@@ -34,7 +35,7 @@ void test_st(Env& $)
   f( brigand::range<std::size_t, 0, N>(),a,p);
 
   bs::pack<T, N> ref(&a[0], &a[0] + N);
-  STF_IEEE_EQUAL(ref, p);
+  STF_EQUAL(ref, p);
 }
 
 STF_CASE_TPL("Check static insert on pack" , STF_NUMERIC_TYPES)
@@ -44,4 +45,33 @@ STF_CASE_TPL("Check static insert on pack" , STF_NUMERIC_TYPES)
   test_st<T, N>($);
   test_st<T, N/2>($);
   test_st<T, N*2>($);
+}
+
+template <typename T, std::size_t N, typename Env>
+void test_lt(Env& $)
+{
+  bs::pack<T, N>  p;
+  std::array<T,N> a;
+
+  for(std::size_t i=0;i<N;++i)
+    a[i] = p[i] = T(0);
+
+  a[0] = T(1);
+  insert(p,0_c, 1);
+
+  if(N>1) { a[1] = T(2); insert(p,1_c, 2); }
+  if(N>3) { a[3] = T(4); insert(p,3_c, 4); }
+  if(N>7) { a[7] = T(8); insert(p,7_c, 8); }
+
+  bs::pack<T, N> ref(&a[0], &a[0] + N);
+  STF_EQUAL(ref, p);
+}
+
+STF_CASE_TPL("Check static insert on pack using literals" , STF_NUMERIC_TYPES)
+{
+  static const std::size_t N = boost::simd::pack<T>::static_size;
+
+  test_lt<T, N>($);
+  test_lt<T, N/2>($);
+  test_lt<T, N*2>($);
 }


### PR DESCRIPTION
Some functions requires parameters that may be a std::integral_constant. To simplify this API,
we now support user-defined litteral like 1_c to represent  std::integral_constant<int,1>.

Affected functions include:

- insert           :  insert(p, 1_c, 42);
- extract          :  auto x = extract(p, 1_c);
- pack::operator[] :  auto x = p[3_c];

Note that in the case of operator[], the access to the pack's element is  retuning a value instead of a reference.