### PR TITLE
Spurious warning with intel

### DIFF
--- a/include/boost/simd/arch/common/scalar/function/modf.hpp
+++ b/include/boost/simd/arch/common/scalar/function/modf.hpp
@@ -28,10 +28,10 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::arithmetic_<A0> >
                           )
   {
-    BOOST_FORCEINLINE void operator() ( A0 a0, A0 & frac,A0 & ent) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE void operator() ( A0 a0, A0 & rest,A0 & rounded) const BOOST_NOEXCEPT
     {
-      ent = simd::trunc(a0);
-      frac = a0 - ent;
+      rounded = simd::trunc(a0);
+      rest    = a0 - rounded;
     }
   };
   BOOST_DISPATCH_OVERLOAD ( modf_
@@ -70,11 +70,11 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::arithmetic_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &,  A0 a0, A0 & ent) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE A0 operator() (const std_tag &,  A0 a0, A0 & rounded) const BOOST_NOEXCEPT
     {
-      A0 frac;
-      frac = std::modf(a0,&ent);
-      return frac;
+      A0 rest;
+      rest = std::modf(a0,&rounded);
+      return rest;
     }
   };
 

--- a/include/boost/simd/arch/common/simd/function/modf.hpp
+++ b/include/boost/simd/arch/common/simd/function/modf.hpp
@@ -31,9 +31,9 @@ namespace boost { namespace simd { namespace ext
      using result = std::pair < A0, A0>;
      BOOST_FORCEINLINE result operator()(A0 const& a0) const
       {
-        A0 ent = bs::trunc(a0);
-        A0 frac = a0-ent;
-        return result(frac, ent);
+        A0 rounded = bs::trunc(a0);
+        A0 rest    = a0-rounded;
+        return result(rest, rounded);
       }
    };
 

--- a/test/function/scalar/modf.cpp
+++ b/test/function/scalar/modf.cpp
@@ -27,21 +27,21 @@ STF_CASE_TPL(" modf", STF_NUMERIC_TYPES)
              );
 
   {
-    T frac;
-    T ent;
+    T rest;
+    T rounded;
 
-    modf(T(1.5), frac, ent);
-    STF_EQUAL(ent, bs::trunc(T(1.5)));
-    STF_EQUAL(frac, T(.5));
+    modf(T(1.5), rest, rounded);
+    STF_EQUAL(rounded, bs::trunc(T(1.5)));
+    STF_EQUAL(rest, T(.5));
   }
 
   {
-    T frac;
-    T ent;
+    T rest;
+    T rounded;
 
-    frac = modf(T(1.5), ent);
-    STF_EQUAL(ent, bs::trunc(T(1.5)));
-    STF_EQUAL(frac, T(.5));
+    rest = modf(T(1.5), rounded);
+    STF_EQUAL(rounded, bs::trunc(T(1.5)));
+    STF_EQUAL(rest, T(.5));
   }
 
   {


### PR DESCRIPTION
Rename the couple ent/frac into  rounded/rest, since frac generate long, although not that justified, warnings with intel compiler.

Also, not sure 'ent' is meaningful in English ?