### PR TITLE
Update ns.bench (fix clang confusion)

### DIFF
--- a/bench/ns.bench.hpp
+++ b/bench/ns.bench.hpp
@@ -1290,9 +1290,6 @@ NS_BENCH_AUTO_DECLTYPE(f(container_at(std::get<N>(args), i)...))
 template <typename F, typename... Args>
 BOOST_FORCEINLINE auto call(F f, std::tuple<Args...> const& args, std::size_t i)
 NS_BENCH_AUTO_DECLTYPE(call(make_range_t<sizeof...(Args)>(), f, args, i))
-template <typename F>
-BOOST_FORCEINLINE auto call(F f, std::tuple<> const&, std::size_t)
-NS_BENCH_AUTO_DECLTYPE(f())
 template <typename Experiment, typename Enable = void>
 struct experiment_maybe_copy {
   using type = Experiment;


### PR DESCRIPTION
For some reasons clang was using the overload where the tuple is empty
when it was actually non-empty. Maybe it was evaluating its trailling
return type which was causing a compile-time error as it was trying to
call a function f with no arguments when argument were required.