### PR TITLE
more restrictive scalar-to-pack operator instantiations

### DIFF
--- a/include/boost/simd/detail/pack_operators.hpp
+++ b/include/boost/simd/detail/pack_operators.hpp
@@ -41,12 +41,14 @@ namespace boost { namespace simd
 {
 #define BOOST_SIMD_PACK_DEFINE_BINOP(type_, op, f)                                                 \
   template <typename T, std::size_t N, typename U> BOOST_FORCEINLINE                               \
-  typename std::enable_if<is_not_pack_t<U>::value, pack<type_, N>>::type                           \
+  typename std::enable_if<is_not_pack_t<U>::value && std::is_convertible<U, T>::value,             \
+                          pack<type_, N>>::type                                                    \
   op(pack<T, N> const& p0, U const& s1) BOOST_NOEXCEPT_IF_EXPR(f(p0, s1))                          \
   { return f(p0, s1); }                                                                            \
                                                                                                    \
   template <typename T, std::size_t N, typename U> BOOST_FORCEINLINE                               \
-  typename std::enable_if<is_not_pack_t<U>::value, pack<type_, N>>::type                           \
+  typename std::enable_if<is_not_pack_t<U>::value && std::is_convertible<U, T>::value,             \
+                          pack<type_, N>>::type                                                    \
   op(U const& s0, pack<T, N> const& p1) BOOST_NOEXCEPT_IF_EXPR(f(s0, p1))                          \
   { return f(s0, p1); }                                                                            \
                                                                                                    \


### PR DESCRIPTION
I ran into a problem where I had a 3d vector math template library instantiated with ```boost::simd::pack``` types having operators which collided with boost::simd::pack operators. Specifically, the ```mymath::vec_t<>``` types I define have operator+, operator-, etc. defined, which when ```mymath::vec_t<>``` is instantiated with a ```boost::simd::pack<float>```, I get ambiguous operator calls. Take the following example: consider ```mymath::vec_t<float, 3>``` to be the common "vec3f" type folks in graphics use to represent an {x, y, z}. When I instantiated ```mymath::vec_t<boost::simd::pack<float>, 3>```, all operators on that vec_t type should be the same because ```boost::simd::pack<>``` comes with the necessary operators for that to work. However...

boost.simd defines operations where a scalar is a valid input to binary operators, which makes sense ONLY if the scalar is _actually_ a scalar. It's current definition triggers the enabling of binary operators for ALL non-pack types, which then also considers my ```math::vec_t<boost::simd::pack<float>, 3>```...which doesn't make sense to instantiate.

With the following change, boost.simd is able to instantiate operators on boost::simd::pack<> types without colliding with any types which define operators over aggregates of boost::simd::packs, fixing the problem for me. I don't know the ramifications of everything in boost.simd with this change, as my use of the library is fairly limited thus far, but I figured I'd communicate the change to y'all.

I guess the suggestion is to use anything more restrictive than ```is_not_pack_t<U>``` for enabling binary operators with scalars. In my mind, you could also use ```std::is_scalar```, but I know you guys are smart and probably have a better idea of what to do!