### PR TITLE
iterator test issue with centos65/icpc15

### DIFF
--- a/include/boost/simd/config.hpp
+++ b/include/boost/simd/config.hpp
@@ -14,6 +14,9 @@
 // Get version number
 #include <boost/simd/version.hpp>
 
+// Get the config already done for dispatch
+#include <boost/simd/detail/dispatch/config.hpp>
+
 // Setup the dispatch default architecture
 #if !defined(BOOST_DISPATCH_DEFAULT_SITE)
 #  include <boost/simd/arch/spec.hpp>

--- a/include/boost/simd/meta/is_iterator.hpp
+++ b/include/boost/simd/meta/is_iterator.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd
     {
       struct big{ void *p[2];};
       static_assert(sizeof(big) != sizeof(void*), 
-                    "This machine is to weird for us.");
+                    "This machine is too weird for us.");
       
       static big test(...); 
       template<class It> static typename It::iterator_category* test(It); // Iterator

--- a/include/boost/simd/meta/is_iterator.hpp
+++ b/include/boost/simd/meta/is_iterator.hpp
@@ -12,8 +12,8 @@
 #ifndef BOOST_SIMD_META_IS_ITERATOR_HPP_INCLUDED
 #define BOOST_SIMD_META_IS_ITERATOR_HPP_INCLUDED
 
-#include <boost/simd/detail/dispatch/detail/declval.hpp>
 #include <boost/simd/config.hpp>
+#include <boost/simd/detail/dispatch/detail/declval.hpp>
 #include <type_traits>
 
 namespace boost { namespace simd
@@ -21,6 +21,21 @@ namespace boost { namespace simd
   namespace bd = boost::dispatch;
   namespace detail
   {
+#if defined(BOOST_DISPATCH_USE_INCOMPLETE_STD)
+    // This is far from perfect, but we are in a far from perfect situation.
+    template <typename T> struct is_iterator_impl
+    {
+      struct big{ void *p[2];};
+      static_assert(sizeof(big) != sizeof(void*), 
+                    "This machine is to weird for us.");
+      
+      static big test(...); 
+      template<class It> static typename It::iterator_category* test(It); // Iterator
+      template<class It> static void * test(It *); // Pointer
+
+      static const bool value = sizeof(test(bd::detail::declval<T>())) != sizeof(big);
+    };
+#else
     template <typename T> struct is_iterator_impl
     {
       static std::false_type test(...);
@@ -37,6 +52,7 @@ namespace boost { namespace simd
                                             , std::true_type
                                             >::value;
     };
+#endif
   }
 
   /*!

--- a/test/architecture/CMakeLists.txt
+++ b/test/architecture/CMakeLists.txt
@@ -9,6 +9,7 @@
 set ( SOURCES
       tags.cpp
       limits.cpp
+      is_iterator.cpp
     )
 
 make_unit( "architecture" ${SOURCES})

--- a/test/architecture/is_iterator.cpp
+++ b/test/architecture/is_iterator.cpp
@@ -1,0 +1,24 @@
+//==================================================================================================
+/*
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+
+#include <vector>
+#include <boost/simd/meta/is_iterator.hpp>
+#include <simd_test.hpp>
+
+STF_CASE( "Check is_iterator support" )
+{
+  using boost::simd::is_iterator;
+  STF_EQUAL(is_iterator<int*>::value, true);
+  STF_EQUAL(is_iterator<int const*>::value, true);
+  STF_EQUAL(is_iterator<std::vector<int>::const_iterator>::value, true);
+  STF_EQUAL(is_iterator<std::vector<int>::iterator>::value, true);
+  STF_EQUAL(is_iterator<int>::value, false);
+  STF_EQUAL(is_iterator<std::vector<int>>::value, false);
+}
+


### PR DESCRIPTION
At least with intel15/gcc4.4.7, the iterator type traits seemss to be instantiated too soon, so the compilation fails before the code can be dismisssed by SFINAE (which is sad).