### PR TITLE
If gcc lib is too old, pick integer_constant from boost instead of std.

### DIFF
--- a/bench/ns.bench.hpp
+++ b/bench/ns.bench.hpp
@@ -15,7 +15,8 @@ namespace ns { namespace bench {
  **/
 } }
 #include <boost/core/demangle.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
+
 namespace ns { namespace bench {
 template<typename T> inline std::string type_id()
 {
@@ -1357,7 +1358,7 @@ struct parameter_alignment
 {};
 template <typename T>
 struct parameter_alignment<T, typename std::enable_if<T::alignment == T::alignment>::type>
-: std::integral_constant<std::size_t, T::alignment>
+  : nsm::type_traits::integral_constant<std::size_t, T::alignment>
 {};
 template <typename G, typename T>
 struct make_parameters_container {

--- a/include/boost/simd/arch/common/detail/tags.hpp
+++ b/include/boost/simd/arch/common/detail/tags.hpp
@@ -14,8 +14,12 @@
 #ifndef BOOST_SIMD_ARCH_COMMON_DETAIL_TAGS_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_DETAIL_TAGS_HPP_INCLUDED
 
+#include <boost/simd/detail/nsm.hpp>
+
 namespace boost { namespace simd { namespace tag
 {
+  namespace tt = nsm::type_traits;
+
   struct exp_;
   struct exp2_;
   struct exp10_;
@@ -23,8 +27,8 @@ namespace boost { namespace simd { namespace tag
   struct log2_;
   struct log10_;
 
-  using not_simd_type = std::integral_constant<bool, false>;
-  using simd_type = std::integral_constant<bool, true>;
+  using not_simd_type = tt::integral_constant<bool, false>;
+  using simd_type = tt::integral_constant<bool, true>;
 
   struct restricted {};
   struct regular {};

--- a/include/boost/simd/arch/common/generic/function/all_reduce.hpp
+++ b/include/boost/simd/arch/common/generic/function/all_reduce.hpp
@@ -13,9 +13,12 @@
 #include <boost/simd/function/shuffle.hpp>
 #include <boost/simd/function/combine.hpp>
 #include <boost/simd/detail/dispatch/detail/declval.hpp>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace simd { namespace detail
 {
+  namespace tt = nsm::type_traits;
+
   //------------------------------------------------------------------------------------------------
   // This meta-permutation implements the butterfly pattern required for log-tree based reductions.
   //
@@ -29,7 +32,7 @@ namespace boost { namespace simd { namespace detail
   template<int Step> struct butterfly_perm
   {
     template<typename I, typename>
-    struct  apply : std::integral_constant<int,(I::value >= Step) ? I::value-Step : I::value+Step>
+    struct  apply : tt::integral_constant<int,(I::value >= Step) ? I::value-Step : I::value+Step>
     {};
   };
 

--- a/include/boost/simd/arch/common/generic/function/autoscan.hpp
+++ b/include/boost/simd/arch/common/generic/function/autoscan.hpp
@@ -13,10 +13,12 @@
 #include <boost/simd/function/combine.hpp>
 #include <boost/simd/function/shuffle.hpp>
 #include <boost/simd/detail/dispatch/detail/declval.hpp>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace simd { namespace detail
 {
   namespace bd = boost::dispatch;
+  namespace tt = nsm::type_traits;
 
   //------------------------------------------------------------------------------------------------
   // This meta-permutation implements the scan pattern required for scan-trees.
@@ -26,7 +28,7 @@ namespace boost { namespace simd { namespace detail
     {
       static const int relative_index = I::value / Step;
       static const int index = relative_index % 2 ? (relative_index*Step - 1) : -1;
-      using type = std::integral_constant<int,index>;
+      using type = tt::integral_constant<int,index>;
     };
   };
   //------------------------------------------------------------------------------------------------
@@ -36,7 +38,7 @@ namespace boost { namespace simd { namespace detail
     template<typename T, int I> struct apply
     {
       static const int relative_index = I / Step;
-      using type = std::integral_constant<T,relative_index % 2 ? T(0) : T(~0)>;
+      using type = tt::integral_constant<T,relative_index % 2 ? T(0) : T(~0)>;
     };
 
     template<typename V, typename... N>

--- a/include/boost/simd/arch/common/scalar/constant/constant_generator.hpp
+++ b/include/boost/simd/arch/common/scalar/constant/constant_generator.hpp
@@ -15,7 +15,7 @@
 #include <boost/simd/detail/dispatch/function/overload.hpp>
 #include <boost/simd/detail/dispatch/as.hpp>
 #include <boost/config.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 #ifdef BOOST_MSVC
 #pragma warning(push)
@@ -26,6 +26,7 @@
 namespace boost { namespace simd { namespace ext
 {
   namespace bd = boost::dispatch;
+  namespace tt = nsm::type_traits;
 
   BOOST_DISPATCH_OVERLOAD_FALLBACK( (typename X, typename V)
                                   , boost::dispatch::constant_value_<tag::constant_>
@@ -35,9 +36,9 @@ namespace boost { namespace simd { namespace ext
                                   )
   {
     template<typename T, T N>
-    static BOOST_FORCEINLINE T impl(std::integral_constant<T,N> const&) BOOST_NOEXCEPT
+    static BOOST_FORCEINLINE T impl(tt::integral_constant<T,N> const&) BOOST_NOEXCEPT
     {
-      return std::integral_constant<T,N>{};
+      return tt::integral_constant<T,N>{};
     }
 
     template<typename R, typename T, T N>

--- a/include/boost/simd/arch/common/simd/function/shuffle/broadcast.hpp
+++ b/include/boost/simd/arch/common/simd/function/shuffle/broadcast.hpp
@@ -18,11 +18,13 @@ namespace boost { namespace simd
 {
   namespace detail
   {
+    namespace tt = nsm::type_traits;
+
     // ---------------------------------------------------------------------------------------------
     // Check if pattern is [N ... N]
     template<int P, int... Ps>
     struct is_broadcast : nsm::all< nsm::integral_list<int,Ps...>
-                                      , nsm::equal_to<nsm::_1,std::integral_constant<int,P>>
+                                      , nsm::equal_to<nsm::_1,tt::integral_constant<int,P>>
                                       >
     {};
 

--- a/include/boost/simd/arch/common/simd/function/shuffle/deinterleave.hpp
+++ b/include/boost/simd/arch/common/simd/function/shuffle/deinterleave.hpp
@@ -26,6 +26,8 @@ namespace boost { namespace simd
 
   namespace detail
   {
+    namespace tt = nsm::type_traits;
+
     // ---------------------------------------------------------------------------------------------
     // generate pattern for deinterleaving shuffle
     template<int I, bool SZ, typename Range> struct deinter_;
@@ -33,7 +35,7 @@ namespace boost { namespace simd
     template<int I, bool SZ, typename... Ps>
     struct deinter_<I,SZ, nsm::list<Ps...>>
     {
-      using sz    = std::integral_constant<int,sizeof...(Ps)/2>;
+      using sz    = tt::integral_constant<int,sizeof...(Ps)/2>;
       using type  = detail::pattern_< ((SZ && Ps::value>=sz::value) ? -1 :  2*Ps::value+I)...>;
     };
 
@@ -45,7 +47,7 @@ namespace boost { namespace simd
     template<int... Ps> struct find_deinterleave
     {
       using ref = boost::simd::detail::pattern_<Ps...>;
-      using sz  = std::integral_constant<int,sizeof...(Ps)/2>;
+      using sz  = tt::integral_constant<int,sizeof...(Ps)/2>;
       using lo  = nsm::range<int,0,sz::value>;
       using hi  = nsm::range<int,sz::value,2*sz::value>;
       using fwd = nsm::append<lo,hi>;

--- a/include/boost/simd/arch/common/simd/function/shuffle/interleave.hpp
+++ b/include/boost/simd/arch/common/simd/function/shuffle/interleave.hpp
@@ -29,6 +29,8 @@ namespace boost { namespace simd
 
   namespace detail
   {
+    namespace tt = nsm::type_traits;
+
     // ---------------------------------------------------------------------------------------------
     // Generate various interleave_* based pattern for later comparison
     template<int C, int Base, bool Direct, bool HasZero, typename R>
@@ -41,10 +43,10 @@ namespace boost { namespace simd
     struct make_oepattern<C, Base, Direct, HasZero, nsm::list<N...>>
     {
       template<int I>
-      using a_value = std::integral_constant<int, Direct ? Base+I : (HasZero ? -1 : Base+I+C)>;
+      using a_value = tt::integral_constant<int, Direct ? Base+I : (HasZero ? -1 : Base+I+C)>;
 
       template<int I>
-      using b_value = std::integral_constant<int, Direct ? (HasZero ? -1 : Base+I+C-1) : Base+I-1>;
+      using b_value = tt::integral_constant<int, Direct ? (HasZero ? -1 : Base+I+C-1) : Base+I-1>;
 
       using type = boost::simd::detail::pattern_< ( N::value%2  ? b_value<N::value>::value
                                                                 : a_value<N::value>::value
@@ -56,7 +58,7 @@ namespace boost { namespace simd
     struct make_fspattern<C, Base, Direct, HasZero, nsm::list<N...>>
     {
       template<int I>
-      using f_value = std::integral_constant
+      using f_value = tt::integral_constant
                                           < int
                                           , Direct  ? ( (I%2) ? (HasZero ? -1 : (I%2)*C+I/2)
                                                               : (I%2)*C+I/2
@@ -67,7 +69,7 @@ namespace boost { namespace simd
                                           >;
 
       template<int I>
-      using s_value = std::integral_constant
+      using s_value = tt::integral_constant
                                       < int
                                       , Direct  ? ( (I%2) ? (HasZero ? -1 : ((I%2)*C+I/2)+C/2)
                                                           : ((I%2)*C+I/2)+C/2

--- a/include/boost/simd/arch/common/simd/function/shuffle/slide.hpp
+++ b/include/boost/simd/arch/common/simd/function/shuffle/slide.hpp
@@ -16,6 +16,8 @@
 
 namespace boost { namespace simd
 {
+  namespace tt = nsm::type_traits;
+
   // -----------------------------------------------------------------------------------------------
   // Repeat patterns hierarchy
   template<int Offset, typename P> struct slide_pattern : P
@@ -71,7 +73,7 @@ namespace boost { namespace simd
     // Locate proper sliding index
     template<int N, int... Ps> struct find_slide
     {
-      using checks = typename make_slides < std::integral_constant<int,sizeof...(Ps)>
+      using checks = typename make_slides < tt::integral_constant<int,sizeof...(Ps)>
                                           , nsm::range<int,-(N-1),N>
                                           >::type;
 
@@ -79,7 +81,7 @@ namespace boost { namespace simd
                                   , std::is_same<nsm::_1,nsm::integral_list<int,Ps...>>
                                   >;
 
-      using idx   = std::integral_constant<int, N-int(nsm::size<found>::value)>;
+      using idx   = tt::integral_constant<int, N-int(nsm::size<found>::value)>;
 
       using type = typename std::conditional< idx::value && (idx::value<N)
                                             , slide_pattern<idx::value,pattern_<Ps...>>

--- a/include/boost/simd/arch/common/simd/function/slide.hpp
+++ b/include/boost/simd/arch/common/simd/function/slide.hpp
@@ -22,6 +22,7 @@ namespace boost { namespace simd { namespace ext
 {
   namespace bd = boost::dispatch;
   namespace bs = boost::simd;
+  namespace tt = nsm::type_traits;
 
   //------------------------------------------------------------------------------------------------
   // unary slide uses binary slide with Zero
@@ -58,7 +59,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::constant_<bd::integer_<Offset>>
                           )
   {
-    using hcard = std::integral_constant<std::size_t,T::static_size/2>;
+    using hcard = tt::integral_constant<std::size_t,T::static_size/2>;
 
     // Slide by N gives whatever in non-aggregate storage
     template<typename K, typename H, typename... L0, typename... L1>

--- a/include/boost/simd/arch/common/simd/function/swapbytes.hpp
+++ b/include/boost/simd/arch/common/simd/function/swapbytes.hpp
@@ -16,15 +16,18 @@
 #include <boost/simd/function/shuffle.hpp>
 #include <boost/simd/function/bitwise_cast.hpp>
 #include <boost/simd/detail/dispatch/meta/as_integer.hpp>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace simd
 {
   namespace detail
   {
+    namespace tt = nsm::type_traits;
+    
     template<std::size_t N> struct swap_bytes_helper
     {
       template<typename I, typename C>
-      struct apply : std::integral_constant < std::size_t, N*(I::value/N)+N-1-I::value%N>
+      struct apply : tt::integral_constant < std::size_t, N*(I::value/N)+N-1-I::value%N>
       {};
     };
   }
@@ -35,6 +38,7 @@ namespace boost { namespace simd { namespace ext
 
   namespace bd = boost::dispatch;
   namespace bs = boost::simd;
+
   BOOST_DISPATCH_OVERLOAD_IF(swapbytes_
                             , (typename A0, typename X)
                             , (detail::is_native<X>)

--- a/include/boost/simd/arch/x86/avx/simd/function/broadcast.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/broadcast.hpp
@@ -18,13 +18,14 @@ namespace boost { namespace simd { namespace ext
 {
   namespace bd = ::boost::dispatch;
   namespace bs = ::boost::simd;
+  namespace tt = nsm::type_traits;
 
   template<typename A0, typename A1>
   struct bc_helper
   {
     using select_t  = nsm::bool_<(A1::value >= 0 && A1::value < A0::static_size)>;
-    using sel_t     = std::integral_constant<int, (A1::value >= A0::static_size/2) ? 1 : 0>;
-    using idx_t     = std::integral_constant<int, A1::value - sel_t::value*(A0::static_size/2)>;
+    using sel_t     = tt::integral_constant<int, (A1::value >= A0::static_size/2) ? 1 : 0>;
+    using idx_t     = tt::integral_constant<int, A1::value - sel_t::value*(A0::static_size/2)>;
     using type      = typename A0::template resize<A0::static_size/2>;
   };
 

--- a/include/boost/simd/arch/x86/avx/simd/function/shuffle/blend.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/shuffle/blend.hpp
@@ -13,11 +13,11 @@
 #include <boost/simd/detail/nsm.hpp>
 #include <boost/simd/function/bitwise_cast.hpp>
 #include <boost/simd/detail/dispatch/meta/as_floating.hpp>
-#include <type_traits>
 
 namespace boost { namespace simd
 {
   namespace bd = boost::dispatch;
+  namespace tt = nsm::type_traits;
 
   // -----------------------------------------------------------------------------------------------
   // Shuffle using blend patterns hierarchy
@@ -90,7 +90,7 @@ namespace boost { namespace simd
 
     template<int P0, int P1, int P2, int P3>
     struct  blend_mask<pattern_<P0,P1,P2,P3>>
-          : std::integral_constant< int
+          : tt::integral_constant< int
                                   , (P0==4 || P0==-1)    | (P1==5 || P1==-1)<<1
                                   | (P2==6 || P2==-1)<<2 | (P3==7 || P3==-1)<<3
                                   >
@@ -98,7 +98,7 @@ namespace boost { namespace simd
 
     template<int P0, int P1, int P2, int P3, int P4, int P5, int P6, int P7>
     struct  blend_mask<pattern_<P0,P1,P2,P3,P4,P5,P6,P7>>
-          : std::integral_constant< int
+          : tt::integral_constant< int
                                   , (P0==8  || P0==-1)    | (P1==9  || P1==-1)<<1
                                   | (P2==10 || P2==-1)<<2 | (P3==11 || P3==-1)<<3
                                   | (P4==12 || P4==-1)<<4 | (P5==13 || P5==-1)<<5
@@ -133,7 +133,7 @@ namespace boost { namespace simd
 
       template<typename T, typename P>
       static BOOST_FORCEINLINE T blend_ ( T const& a0, T const& a1, P const&
-                                        , std::integral_constant<std::size_t,4> const&
+                                        , tt::integral_constant<std::size_t,4> const&
                                         )
       {
         return _mm256_blend_pd(a0, a1, blend_mask<P>::value);
@@ -141,7 +141,7 @@ namespace boost { namespace simd
 
       template<typename T, typename P>
       static BOOST_FORCEINLINE T blend_ ( T const& a0, T const& a1, P const&
-                                        , std::integral_constant<std::size_t,8> const&
+                                        , tt::integral_constant<std::size_t,8> const&
                                         )
       {
         return _mm256_blend_ps(a0, a1, blend_mask<P>::value);

--- a/include/boost/simd/arch/x86/avx/simd/function/shuffle/perm.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/shuffle/perm.hpp
@@ -11,11 +11,11 @@
 
 #include <boost/simd/detail/shuffle.hpp>
 #include <boost/simd/detail/nsm.hpp>
-#include <type_traits>
 
 namespace boost { namespace simd
 {
   namespace bd = boost::dispatch;
+  namespace tt = nsm::type_traits;
 
   // -----------------------------------------------------------------------------------------------
   // Shuffle using blend patterns hierarchy
@@ -30,14 +30,14 @@ namespace boost { namespace simd
     // Check if a permutation can use blend_p*
     template<int... Ps> struct is_permute
     {
-      using sz = std::integral_constant<int,sizeof...(Ps)/2>;
+      using sz = tt::integral_constant<int,sizeof...(Ps)/2>;
       using l0 = nsm::range<int,0           ,   sz::value>;
       using h0 = nsm::range<int,sz::value   , 2*sz::value>;
       using l1 = nsm::range<int,2*sz::value , 3*sz::value>;
       using h1 = nsm::range<int,3*sz::value , 4*sz::value>;
 
       template<typename F, typename S, int Mask>
-      using i_t = nsm::pair< nsm::append<F,S>, std::integral_constant<int,Mask> >;
+      using i_t = nsm::pair< nsm::append<F,S>, tt::integral_constant<int,Mask> >;
 
       using lst = nsm::map< i_t<h0,l0,0x01>, i_t<l1,l0,0x02>, i_t<h1,l0,0x03>, i_t<h1,h0,0x13>
                               , i_t<l0,l1,0x20>, i_t<h0,l1,0x21>, i_t<h1,l1,0x23>, i_t<h0,h1,0x31>

--- a/include/boost/simd/arch/x86/avx/simd/function/shuffle/shuffle.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/shuffle/shuffle.hpp
@@ -13,11 +13,11 @@
 #include <boost/simd/detail/nsm.hpp>
 #include <boost/simd/function/bitwise_cast.hpp>
 #include <boost/simd/detail/dispatch/meta/as_floating.hpp>
-#include <type_traits>
 
 namespace boost { namespace simd
 {
   namespace bd = boost::dispatch;
+  namespace tt = nsm::type_traits;
 
   namespace detail
   {
@@ -79,11 +79,11 @@ namespace boost { namespace simd
     // ---------------------------------------------------------------------------------------------
     // AVX shuffling mask computation
     template<int P0,int P1, int P2, int P3>
-    struct avx_mask_pd : std::integral_constant<int, ((P3&1)<<3 | (P2&1)<<2 | (P1&1)<<1 | (P0&1))>
+    struct avx_mask_pd : tt::integral_constant<int, ((P3&1)<<3 | (P2&1)<<2 | (P1&1)<<1 | (P0&1))>
     {};
 
     template<int P0,int P1,int P2,int P3>
-    struct avx_mask_ps : std::integral_constant < int
+    struct avx_mask_ps : tt::integral_constant < int
                                                 , ((P3&3)<<6 | (P2&3)<<4 | (P1&3)<<2 | (P0&3))
                                                 >
     {};

--- a/include/boost/simd/arch/x86/avx/simd/function/slide.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/slide.hpp
@@ -13,11 +13,12 @@
 #include <boost/simd/detail/dispatch/hierarchy/exactly.hpp>
 #include <boost/simd/detail/dispatch/meta/as_floating.hpp>
 #include <boost/simd/function/genmask.hpp>
+#include <boost/simd/detail/nsm.hpp>
 
 #define BOOST_SIMD_UNARY_SLIDE(SZ,IDX)                                                              \
 BOOST_DISPATCH_OVERLOAD ( slide_, (typename T), bs::avx_                                            \
                         , bs::pack_< bd::type##SZ##_<T>, bs::avx_ >                                 \
-                        , bd::exactly_<std::integral_constant<int,IDX>>                             \
+                          , bd::exactly_<nsm::type_traits::integral_constant<int,IDX>> \
                         )                                                                           \
 /**/
 
@@ -25,7 +26,7 @@ BOOST_DISPATCH_OVERLOAD ( slide_, (typename T), bs::avx_                        
 BOOST_DISPATCH_OVERLOAD ( slide_, (typename T), bs::avx_                                            \
                         , bs::pack_< bd::type##SZ##_<T>, bs::avx_ >                                 \
                         , bs::pack_< bd::type##SZ##_<T>, bs::avx_ >                                 \
-                        , bd::exactly_<std::integral_constant<int,IDX>>                             \
+                          , bd::exactly_<nsm::type_traits::integral_constant<int,IDX>> \
                         )                                                                           \
 /**/
 
@@ -33,6 +34,7 @@ namespace boost { namespace simd { namespace ext
 {
   namespace bd = boost::dispatch;
   namespace bs = boost::simd;
+  namespace tt = nsm::type_traits;
 
   // -----------------------------------------------------------------------------------------------
   // [64 bits] Unary exact matches for all cardinal to minimize latency and # of registers used
@@ -40,7 +42,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_SIMD_UNARY_SLIDE(64,1)
   {
     BOOST_FORCEINLINE T operator()( T const& a0
-                                  , std::integral_constant<int,1> const&
+                                  , tt::integral_constant<int,1> const&
                                   ) const BOOST_NOEXCEPT
     {
       using f_t = bd::as_floating_t<T>;
@@ -52,7 +54,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_SIMD_UNARY_SLIDE(64,2)
   {
     BOOST_FORCEINLINE T operator()( T const& a0
-                                  , std::integral_constant<int,2> const&
+                                  , tt::integral_constant<int,2> const&
                                   ) const BOOST_NOEXCEPT
     {
       using f_t = bd::as_floating_t<T>;
@@ -64,7 +66,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_SIMD_UNARY_SLIDE(64,3)
   {
     BOOST_FORCEINLINE T operator()( T const& a0
-                                  , std::integral_constant<int,3> const&
+                                  , tt::integral_constant<int,3> const&
                                   ) const BOOST_NOEXCEPT
     {
       using f_t = bd::as_floating_t<T>;
@@ -84,7 +86,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_SIMD_BINARY_SLIDE(64,1)
   {
     BOOST_FORCEINLINE T operator()( T const& a0, T const& a1
-                                  , std::integral_constant<int,1> const&
+                                  , tt::integral_constant<int,1> const&
                                   ) const BOOST_NOEXCEPT
     {
       using f_t = bd::as_floating_t<T>;
@@ -103,7 +105,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_SIMD_BINARY_SLIDE(64,2)
   {
     BOOST_FORCEINLINE T operator()( T const& a0, T const& a1
-                                  , std::integral_constant<int,2> const&
+                                  , tt::integral_constant<int,2> const&
                                   ) const BOOST_NOEXCEPT
     {
       using f_t = bd::as_floating_t<T>;
@@ -119,7 +121,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_SIMD_BINARY_SLIDE(64,3)
   {
     BOOST_FORCEINLINE T operator()( T const& a0, T const& a1
-                                  , std::integral_constant<int,3> const&
+                                  , tt::integral_constant<int,3> const&
                                   ) const BOOST_NOEXCEPT
     {
       using f_t = bd::as_floating_t<T>;
@@ -140,7 +142,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_SIMD_UNARY_SLIDE(32,1)
   {
     BOOST_FORCEINLINE T operator()( T const& a0
-                                  , std::integral_constant<int,1> const&
+                                  , tt::integral_constant<int,1> const&
                                   ) const BOOST_NOEXCEPT
     {
       using f_t = bd::as_floating_t<T>;
@@ -159,7 +161,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_SIMD_UNARY_SLIDE(32,2)
   {
     BOOST_FORCEINLINE T operator()( T const& a0
-                                  , std::integral_constant<int,2> const&
+                                  , tt::integral_constant<int,2> const&
                                   ) const BOOST_NOEXCEPT
     {
       using f_t = bd::as_floating_t<T>;
@@ -171,7 +173,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_SIMD_UNARY_SLIDE(32,3)
   {
     BOOST_FORCEINLINE T operator()( T const& a0
-                                  , std::integral_constant<int,3> const&
+                                  , tt::integral_constant<int,3> const&
                                   ) const BOOST_NOEXCEPT
     {
       using f_t = bd::as_floating_t<T>;
@@ -190,7 +192,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_SIMD_UNARY_SLIDE(32,4)
   {
     BOOST_FORCEINLINE T operator()( T const& a0
-                                  , std::integral_constant<int,4> const&
+                                  , tt::integral_constant<int,4> const&
                                   ) const BOOST_NOEXCEPT
     {
       using f_t = bd::as_floating_t<T>;
@@ -202,7 +204,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_SIMD_UNARY_SLIDE(32,5)
   {
     BOOST_FORCEINLINE T operator()( T const& a0
-                                  , std::integral_constant<int,5> const&
+                                  , tt::integral_constant<int,5> const&
                                   ) const BOOST_NOEXCEPT
     {
       using f_t = bd::as_floating_t<T>;
@@ -221,7 +223,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_SIMD_UNARY_SLIDE(32,6)
   {
     BOOST_FORCEINLINE T operator()( T const& a0
-                                  , std::integral_constant<int,6> const&
+                                  , tt::integral_constant<int,6> const&
                                   ) const BOOST_NOEXCEPT
     {
       using f_t = bd::as_floating_t<T>;
@@ -233,7 +235,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_SIMD_UNARY_SLIDE(32,7)
   {
     BOOST_FORCEINLINE T operator()( T const& a0
-                                  , std::integral_constant<int,7> const&
+                                  , tt::integral_constant<int,7> const&
                                   ) const BOOST_NOEXCEPT
     {
       using f_t = bd::as_floating_t<T>;
@@ -254,7 +256,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_SIMD_BINARY_SLIDE(32,1)
   {
     BOOST_FORCEINLINE T operator()( T const& a0, T const& a1
-                                  , std::integral_constant<int,1> const&
+                                  , tt::integral_constant<int,1> const&
                                   ) const BOOST_NOEXCEPT
     {
       using f_t = bd::as_floating_t<T>;
@@ -276,7 +278,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_SIMD_BINARY_SLIDE(32,2)
   {
     BOOST_FORCEINLINE T operator()( T const& a0, T const& a1
-                                  , std::integral_constant<int,2> const&
+                                  , tt::integral_constant<int,2> const&
                                   ) const BOOST_NOEXCEPT
     {
       using f_t = bd::as_floating_t<T>;
@@ -290,7 +292,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_SIMD_BINARY_SLIDE(32,3)
   {
     BOOST_FORCEINLINE T operator()( T const& a0, T const& a1
-                                  , std::integral_constant<int,3> const&
+                                  , tt::integral_constant<int,3> const&
                                   ) const BOOST_NOEXCEPT
     {
       using f_t = bd::as_floating_t<T>;
@@ -310,7 +312,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_SIMD_BINARY_SLIDE(32,4)
   {
     BOOST_FORCEINLINE T operator()( T const& a0, T const& a1
-                                  , std::integral_constant<int,4> const&
+                                  , tt::integral_constant<int,4> const&
                                   ) const BOOST_NOEXCEPT
     {
       using f_t = bd::as_floating_t<T>;
@@ -321,7 +323,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_SIMD_BINARY_SLIDE(32,5)
   {
     BOOST_FORCEINLINE T operator()( T const& a0, T const& a1
-                                  , std::integral_constant<int,5> const&
+                                  , tt::integral_constant<int,5> const&
                                   ) const BOOST_NOEXCEPT
     {
       using f_t = bd::as_floating_t<T>;
@@ -342,7 +344,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_SIMD_BINARY_SLIDE(32,6)
   {
     BOOST_FORCEINLINE T operator()( T const& a0, T const& a1
-                                  , std::integral_constant<int,6> const&
+                                  , tt::integral_constant<int,6> const&
                                   ) const BOOST_NOEXCEPT
     {
       using f_t = bd::as_floating_t<T>;
@@ -355,7 +357,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_SIMD_BINARY_SLIDE(32,7)
   {
     BOOST_FORCEINLINE T operator()( T const& a0, T const& a1
-                                  , std::integral_constant<int,7> const&
+                                  , tt::integral_constant<int,7> const&
                                   ) const BOOST_NOEXCEPT
     {
       using f_t = bd::as_floating_t<T>;
@@ -383,7 +385,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::constant_<bd::integer_<Offset>>
                           )
   {
-    using hcard = std::integral_constant<int,(T::static_size/2)>;
+    using hcard = tt::integral_constant<int,(T::static_size/2)>;
 
     static BOOST_FORCEINLINE T unroll( T const& a0, T const& a1, std::true_type const& )
     {

--- a/include/boost/simd/arch/x86/sse1/simd/function/topology.hpp
+++ b/include/boost/simd/arch/x86/sse1/simd/function/topology.hpp
@@ -15,14 +15,15 @@
 #include <boost/simd/arch/common/simd/function/shuffle/repeat.hpp>
 #include <boost/simd/arch/common/simd/function/shuffle/slide.hpp>
 #include <boost/simd/detail/dispatch/meta/as_floating.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace simd { namespace detail
 {
+  namespace tt = nsm::type_traits;
   // -----------------------------------------------------------------------------------------------
   // Local masking utility
   template<int P0,int P1, int P2, int P3>
-  struct mask_ps : std::integral_constant<int, _MM_SHUFFLE(P3&3,P2&3,P1&3,P0&3)>
+  struct mask_ps : tt::integral_constant<int, _MM_SHUFFLE(P3&3,P2&3,P1&3,P0&3)>
   {};
 
   // -----------------------------------------------------------------------------------------------

--- a/include/boost/simd/arch/x86/sse2/simd/function/broadcast.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/broadcast.hpp
@@ -16,6 +16,7 @@ namespace boost { namespace simd { namespace ext
 {
   namespace bd = ::boost::dispatch;
   namespace bs = ::boost::simd;
+  namespace tt = nsm::type_traits;
 
   BOOST_DISPATCH_OVERLOAD ( broadcast_
                           , (typename A0, typename A1)
@@ -84,7 +85,7 @@ namespace boost { namespace simd { namespace ext
     {
       // This shuffle the 32 bits packet of the broadcast so
       // we end up with [ In In+1 In In+1 In In+1 In In+1 ]
-      using partial_t = std::integral_constant< int
+      using partial_t = tt::integral_constant< int
                                               ,_MM_SHUFFLE( A1::value / 2,A1::value / 2
                                                           , A1::value / 2,A1::value / 2
                                                           )
@@ -92,7 +93,7 @@ namespace boost { namespace simd { namespace ext
 
       // This select either In or In+1 as 16 bits value and give us
       // [In In In In In In In In] or [In+1 In+1 In+1 In+1 In+1 In+1 In+1 In+1]
-      using fix_t = std::integral_constant< int
+      using fix_t = tt::integral_constant< int
                                           , _MM_SHUFFLE ( A1::value % 2,A1::value % 2
                                                         , A1::value % 2,A1::value % 2
                                                         )

--- a/include/boost/simd/arch/x86/sse2/simd/function/slide.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/slide.hpp
@@ -11,11 +11,13 @@
 
 #include <boost/simd/function/bitwise_cast.hpp>
 #include <boost/simd/detail/overload.hpp>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace simd { namespace ext
 {
   namespace bd = boost::dispatch;
   namespace bs = boost::simd;
+  namespace tt = nsm::type_traits;
 
   BOOST_DISPATCH_OVERLOAD ( slide_
                           , (typename T, typename Offset)
@@ -25,12 +27,12 @@ namespace boost { namespace simd { namespace ext
                           )
   {
     using bits_t  = typename T::template rebind<std::uint8_t>::template resize<16>;
-    using bcnt    = std::integral_constant<std::size_t,16u/T::static_size>;
+    using bcnt    = tt::integral_constant<std::size_t,16u/T::static_size>;
 
     // slide with positive offset
     static BOOST_FORCEINLINE T side(T const& a0, std::true_type const&) BOOST_NOEXCEPT
     {
-      using imm = std::integral_constant<std::size_t,Offset::value*bcnt::value>;
+      using imm = tt::integral_constant<std::size_t,Offset::value*bcnt::value>;
       bits_t tmp = _mm_srli_si128(bitwise_cast<bits_t>(a0),imm::value);
       return bitwise_cast<T>(tmp);
     }
@@ -38,7 +40,7 @@ namespace boost { namespace simd { namespace ext
     // slide with negative offset
     static BOOST_FORCEINLINE T side( T const& a0, std::false_type const& ) BOOST_NOEXCEPT
     {
-      using imm = std::integral_constant<std::size_t,(-Offset::value)*bcnt::value>;
+      using imm = tt::integral_constant<std::size_t,(-Offset::value)*bcnt::value>;
       bits_t tmp = _mm_slli_si128(bitwise_cast<bits_t>(a0),imm::value);
       return bitwise_cast<T>(tmp);
     }
@@ -62,9 +64,9 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE T operator()(T const& a0, T const& a1, Offset const&) const BOOST_NOEXCEPT
     {
       // Compute relative offsets for shifted loads pair
-      using bcnt  = std::integral_constant<std::size_t,(16u/T::static_size)>;
-      using ls    = std::integral_constant<std::size_t,bcnt::value*Offset::value>;
-      using rs    = std::integral_constant<std::size_t,bcnt::value*(T::static_size-Offset::value)>;
+      using bcnt  = tt::integral_constant<std::size_t,(16u/T::static_size)>;
+      using ls    = tt::integral_constant<std::size_t,bcnt::value*Offset::value>;
+      using rs    = tt::integral_constant<std::size_t,bcnt::value*(T::static_size-Offset::value)>;
 
       // Shift everything in place
       return bitwise_cast<T>(bits_t( _mm_or_si128( _mm_srli_si128(bitwise_cast<bits_t>(a0),ls::value)

--- a/include/boost/simd/arch/x86/sse2/simd/function/topology.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/topology.hpp
@@ -9,7 +9,7 @@
 #ifndef BOOST_SIMD_ARCH_X86_SSE2_SIMD_FUNCTION_TOPOLOGY_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_X86_SSE2_SIMD_FUNCTION_TOPOLOGY_HPP_INCLUDED
 
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 #include <boost/simd/arch/x86/sse1/simd/function/topology.hpp>
 #include <boost/simd/detail/dispatch/meta/as_floating.hpp>
 #include <boost/simd/detail/dispatch/meta/as_integer.hpp>
@@ -17,11 +17,12 @@
 namespace boost { namespace simd { namespace detail
 {
   namespace bd = boost::dispatch;
+  namespace tt = nsm::type_traits;
 
   // -----------------------------------------------------------------------------------------------
   // Local masking utility
   template<int P0,int P1>
-  struct mask_pd : std::integral_constant<int, _MM_SHUFFLE2(P1&1,P0&1)>
+  struct mask_pd : tt::integral_constant<int, _MM_SHUFFLE2(P1&1,P0&1)>
   {};
 
   // -----------------------------------------------------------------------------------------------

--- a/include/boost/simd/arch/x86/ssse3/simd/function/slide.hpp
+++ b/include/boost/simd/arch/x86/ssse3/simd/function/slide.hpp
@@ -18,6 +18,7 @@ namespace boost { namespace simd { namespace ext
 {
   namespace bd = boost::dispatch;
   namespace bs = boost::simd;
+  namespace tt = nsm::type_traits;
 
   BOOST_DISPATCH_OVERLOAD ( slide_
                           , (typename T, typename Offset)
@@ -33,7 +34,7 @@ namespace boost { namespace simd { namespace ext
       using byte_t = typename T::template retype<std::uint8_t,16>;
 
       // Compute relative offsets
-      using bitcount = std::integral_constant < std::size_t
+      using bitcount = tt::integral_constant < std::size_t
                                               , sizeof(as_arithmetic_t<typename T::value_type>)
                                               * Offset::value
                                               >;

--- a/include/boost/simd/constant/definition/nbdigits.hpp
+++ b/include/boost/simd/constant/definition/nbdigits.hpp
@@ -23,6 +23,8 @@ namespace boost { namespace simd
 {
   namespace tag
   {
+    namespace tt = nsm::type_traits;
+    
     struct nbdigits_ : boost::dispatch::constant_value_<nbdigits_>
     {
       BOOST_DISPATCH_MAKE_CALLABLE(ext,nbdigits_,boost::dispatch::constant_value_<nbdigits_>);
@@ -30,13 +32,13 @@ namespace boost { namespace simd
       struct value_map
       {
         template<typename X>
-        static std::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
+        static tt::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
 
         template<typename X>
-        static std::integral_constant<std::int32_t,24> value(boost::dispatch::single_<X> const&);
+        static tt::integral_constant<std::int32_t,24> value(boost::dispatch::single_<X> const&);
 
         template<typename X>
-       static std::integral_constant<std::int64_t,53> value(boost::dispatch::double_<X> const&);
+       static tt::integral_constant<std::int64_t,53> value(boost::dispatch::double_<X> const&);
       };
     };
   }

--- a/include/boost/simd/constant/definition/nbexponentbits.hpp
+++ b/include/boost/simd/constant/definition/nbexponentbits.hpp
@@ -23,19 +23,21 @@ namespace boost { namespace simd
 {
   namespace tag
   {
+    namespace tt = nsm::type_traits;
+
     struct nbexponentbits_ : boost::dispatch::constant_value_<nbexponentbits_>
     {
       BOOST_DISPATCH_MAKE_CALLABLE(ext,nbexponentbits_,boost::dispatch::constant_value_<nbexponentbits_>);
       struct value_map
       {
         template<typename X>
-        static std::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
+        static tt::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
 
         template<typename X>
-        static std::integral_constant<std::int32_t,8> value(boost::dispatch::single_<X> const&);
+        static tt::integral_constant<std::int32_t,8> value(boost::dispatch::single_<X> const&);
 
         template<typename X>
-       static std::integral_constant<std::int64_t,11> value(boost::dispatch::double_<X> const&);
+       static tt::integral_constant<std::int64_t,11> value(boost::dispatch::double_<X> const&);
       };
     };
   }

--- a/include/boost/simd/constant/definition/nbmantissabits.hpp
+++ b/include/boost/simd/constant/definition/nbmantissabits.hpp
@@ -23,19 +23,21 @@ namespace boost { namespace simd
 {
   namespace tag
   {
+    namespace tt = nsm::type_traits;
+
     struct nbmantissabits_ : boost::dispatch::constant_value_<nbmantissabits_>
     {
       BOOST_DISPATCH_MAKE_CALLABLE(ext,nbmantissabits_,boost::dispatch::constant_value_<nbmantissabits_>);
       struct value_map
       {
         template<typename X>
-        static std::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
+        static tt::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
 
         template<typename X>
-        static std::integral_constant<std::int32_t,23> value(boost::dispatch::single_<X> const&);
+        static tt::integral_constant<std::int32_t,23> value(boost::dispatch::single_<X> const&);
 
         template<typename X>
-       static std::integral_constant<std::int64_t,52> value(boost::dispatch::double_<X> const&);
+       static tt::integral_constant<std::int64_t,52> value(boost::dispatch::double_<X> const&);
       };
     };
   }

--- a/include/boost/simd/constant/definition/signmask.hpp
+++ b/include/boost/simd/constant/definition/signmask.hpp
@@ -23,6 +23,8 @@ namespace boost { namespace simd
 {
   namespace tag
   {
+    namespace tt = nsm::type_traits;
+
     struct signmask_ : boost::dispatch::constant_value_<signmask_>
     {
       BOOST_DISPATCH_MAKE_CALLABLE(ext,signmask_,boost::dispatch::constant_value_<signmask_>);
@@ -30,28 +32,28 @@ namespace boost { namespace simd
       struct value_map
       {
         template<typename X>
-        static std::integral_constant<X,-127-1> value(boost::dispatch::int8_<X> const&);
+        static tt::integral_constant<X,-127-1> value(boost::dispatch::int8_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,-32767-1> value(boost::dispatch::int16_<X> const&);
+        static tt::integral_constant<X,-32767-1> value(boost::dispatch::int16_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,-2147483647-1> value(boost::dispatch::int32_<X> const&);
+        static tt::integral_constant<X,-2147483647-1> value(boost::dispatch::int32_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,-9223372036854775807LL-1> value(boost::dispatch::int64_<X> const&);
+        static tt::integral_constant<X,-9223372036854775807LL-1> value(boost::dispatch::int64_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,0x80U> value(boost::dispatch::uint8_<X> const&);
+        static tt::integral_constant<X,0x80U> value(boost::dispatch::uint8_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,0x8000U> value(boost::dispatch::uint16_<X> const&);
+        static tt::integral_constant<X,0x8000U> value(boost::dispatch::uint16_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,0x80000000UL> value(boost::dispatch::uint32_<X> const&);
+        static tt::integral_constant<X,0x80000000UL> value(boost::dispatch::uint32_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,0x8000000000000000ULL> value(boost::dispatch::uint64_<X> const&);
+        static tt::integral_constant<X,0x8000000000000000ULL> value(boost::dispatch::uint64_<X> const&);
 
         template<typename X>
         static nsm::single_<0x80000000UL> value(boost::dispatch::single_<X> const&);

--- a/include/boost/simd/constant/definition/sqrtvalmax.hpp
+++ b/include/boost/simd/constant/definition/sqrtvalmax.hpp
@@ -23,6 +23,8 @@ namespace boost { namespace simd
 {
   namespace tag
   {
+    namespace tt = nsm::type_traits;
+
     struct sqrtvalmax_ : boost::dispatch::constant_value_<sqrtvalmax_>
     {
       BOOST_DISPATCH_MAKE_CALLABLE(ext,sqrtvalmax_,boost::dispatch::constant_value_<sqrtvalmax_>);
@@ -34,27 +36,27 @@ namespace boost { namespace simd
         template<typename X>
         static nsm::double_<0x5fEFFFFFFFFFFFFFULL> value(boost::dispatch::double_<X> const&);
         template<typename X>
-        static std::integral_constant<X,15> value(boost::dispatch::uint8_<X> const&);
+        static tt::integral_constant<X,15> value(boost::dispatch::uint8_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,255> value(boost::dispatch::uint16_<X> const&);
+        static tt::integral_constant<X,255> value(boost::dispatch::uint16_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,65535> value(boost::dispatch::uint32_<X> const&);
+        static tt::integral_constant<X,65535> value(boost::dispatch::uint32_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,4294967296ULL> value(boost::dispatch::uint64_<X> const&);
+        static tt::integral_constant<X,4294967296ULL> value(boost::dispatch::uint64_<X> const&);
         template<typename X>
-        static std::integral_constant<X,11> value(boost::dispatch::int8_<X> const&);
+        static tt::integral_constant<X,11> value(boost::dispatch::int8_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,181> value(boost::dispatch::int16_<X> const&);
+        static tt::integral_constant<X,181> value(boost::dispatch::int16_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,46340> value(boost::dispatch::int32_<X> const&);
+        static tt::integral_constant<X,46340> value(boost::dispatch::int32_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,3037000499LL> value(boost::dispatch::int64_<X> const&);
+        static tt::integral_constant<X,3037000499LL> value(boost::dispatch::int64_<X> const&);
       };
     };
   }

--- a/include/boost/simd/constant/definition/valmax.hpp
+++ b/include/boost/simd/constant/definition/valmax.hpp
@@ -25,6 +25,8 @@ namespace boost { namespace simd
 {
   namespace tag
   {
+    namespace tt = nsm::type_traits;
+
     struct valmax_ : boost::dispatch::constant_value_<valmax_>
     {
       BOOST_DISPATCH_MAKE_CALLABLE(ext,valmax_,boost::dispatch::constant_value_<valmax_>);
@@ -32,19 +34,19 @@ namespace boost { namespace simd
       struct value_map
       {
         template<typename X>
-        static std::integral_constant<X,0x7F> value(boost::dispatch::int8_<X> const&);
+        static tt::integral_constant<X,0x7F> value(boost::dispatch::int8_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,0x7FFF> value(boost::dispatch::int16_<X> const&);
+        static tt::integral_constant<X,0x7FFF> value(boost::dispatch::int16_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,0x7FFFFFFF> value(boost::dispatch::int32_<X> const&);
+        static tt::integral_constant<X,0x7FFFFFFF> value(boost::dispatch::int32_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,0x7FFFFFFFFFFFFFFF> value(boost::dispatch::int64_<X> const&);
+        static tt::integral_constant<X,0x7FFFFFFFFFFFFFFF> value(boost::dispatch::int64_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,X(0xFFFFFFFFFFFFFFFFULL)> value(boost::dispatch::uint_<X> const&);
+        static tt::integral_constant<X,X(0xFFFFFFFFFFFFFFFFULL)> value(boost::dispatch::uint_<X> const&);
 
         template<typename X>
         static nsm::single_<0x7F7FFFFF> value(boost::dispatch::single_<X> const&);

--- a/include/boost/simd/constant/definition/valmin.hpp
+++ b/include/boost/simd/constant/definition/valmin.hpp
@@ -23,6 +23,8 @@ namespace boost { namespace simd
 {
   namespace tag
   {
+    namespace tt = nsm::type_traits;
+    
     struct valmin_ : boost::dispatch::constant_value_<valmin_>
     {
       BOOST_DISPATCH_MAKE_CALLABLE(ext,valmin_,boost::dispatch::constant_value_<valmin_>);
@@ -30,19 +32,19 @@ namespace boost { namespace simd
       struct value_map
       {
         template<typename X>
-        static std::integral_constant<X,-128> value(boost::dispatch::int8_<X> const&);
+        static tt::integral_constant<X,-128> value(boost::dispatch::int8_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,-32768> value(boost::dispatch::int16_<X> const&);
+        static tt::integral_constant<X,-32768> value(boost::dispatch::int16_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,-2147483647-1> value(boost::dispatch::int32_<X> const&);
+        static tt::integral_constant<X,-2147483647-1> value(boost::dispatch::int32_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,-9223372036854775807LL -1LL> value(boost::dispatch::int64_<X> const&);
+        static tt::integral_constant<X,-9223372036854775807LL -1LL> value(boost::dispatch::int64_<X> const&);
 
         template<typename X>
-        static std::integral_constant<X,X(0)> value(boost::dispatch::uint_<X> const&);
+        static tt::integral_constant<X,X(0)> value(boost::dispatch::uint_<X> const&);
 
         template<typename X>
         static nsm::single_<0xFF7FFFFF> value(boost::dispatch::single_<X> const&);

--- a/include/boost/simd/detail/constant/ldexpmask.hpp
+++ b/include/boost/simd/detail/constant/ldexpmask.hpp
@@ -39,6 +39,8 @@ namespace boost { namespace simd
 {
   namespace tag
   {
+    namespace tt = nsm::type_traits;
+    
     struct ldexpmask_ : boost::dispatch::constant_value_<ldexpmask_>
     {
       BOOST_DISPATCH_MAKE_CALLABLE(ext,ldexpmask_,boost::dispatch::constant_value_<ldexpmask_>);
@@ -46,13 +48,13 @@ namespace boost { namespace simd
       struct value_map
       {
         template<typename X>
-        static std::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
+        static tt::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
 
         template<typename X>
-        static std::integral_constant<std::int32_t,0x7F800000L> value(boost::dispatch::single_<X> const&);
+        static tt::integral_constant<std::int32_t,0x7F800000L> value(boost::dispatch::single_<X> const&);
 
         template<typename X>
-        static std::integral_constant<std::int64_t,0x7FF0000000000000LL> value(boost::dispatch::double_<X> const&);
+        static tt::integral_constant<std::int64_t,0x7FF0000000000000LL> value(boost::dispatch::double_<X> const&);
       };
     };
   }

--- a/include/boost/simd/detail/constant/limitexponent.hpp
+++ b/include/boost/simd/detail/constant/limitexponent.hpp
@@ -45,6 +45,8 @@ namespace boost { namespace simd
 {
   namespace tag
   {
+    namespace tt = nsm::type_traits;
+    
     struct limitexponent_ : boost::dispatch::constant_value_<limitexponent_>
     {
       BOOST_DISPATCH_MAKE_CALLABLE(ext,limitexponent_,boost::dispatch::constant_value_<limitexponent_>);
@@ -52,13 +54,13 @@ namespace boost { namespace simd
       struct value_map
       {
         template<typename X>
-        static std::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
+        static tt::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
 
         template<typename X>
-        static std::integral_constant<std::int32_t,128> value(boost::dispatch::single_<X> const&);
+        static tt::integral_constant<std::int32_t,128> value(boost::dispatch::single_<X> const&);
 
         template<typename X>
-        static std::integral_constant<std::int64_t,1024> value(boost::dispatch::double_<X> const&);
+        static tt::integral_constant<std::int64_t,1024> value(boost::dispatch::double_<X> const&);
       };
     };
   }

--- a/include/boost/simd/detail/constant/mask1frexp.hpp
+++ b/include/boost/simd/detail/constant/mask1frexp.hpp
@@ -45,6 +45,8 @@ namespace boost { namespace simd
 {
   namespace tag
   {
+    namespace tt = nsm::type_traits;
+    
     struct mask1frexp_ : boost::dispatch::constant_value_<mask1frexp_>
     {
       BOOST_DISPATCH_MAKE_CALLABLE(ext,mask1frexp_,boost::dispatch::constant_value_<mask1frexp_>);
@@ -52,13 +54,13 @@ namespace boost { namespace simd
       struct value_map
       {
         template<typename X>
-        static std::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
+        static tt::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
 
         template<typename X>
-        static std::integral_constant<std::int32_t,0x7F800000L> value(boost::dispatch::single_<X> const&);
+        static tt::integral_constant<std::int32_t,0x7F800000L> value(boost::dispatch::single_<X> const&);
 
         template<typename X>
-        static std::integral_constant<std::int64_t,0x7FF0000000000000LL> value(boost::dispatch::double_<X> const&);
+        static tt::integral_constant<std::int64_t,0x7FF0000000000000LL> value(boost::dispatch::double_<X> const&);
       };
     };
   }

--- a/include/boost/simd/detail/constant/mask2frexp.hpp
+++ b/include/boost/simd/detail/constant/mask2frexp.hpp
@@ -45,6 +45,8 @@ namespace boost { namespace simd
 {
   namespace tag
   {
+    namespace tt = nsm::type_traits;
+
     struct mask2frexp_ : boost::dispatch::constant_value_<mask2frexp_>
     {
       BOOST_DISPATCH_MAKE_CALLABLE(ext,mask2frexp_,boost::dispatch::constant_value_<mask2frexp_>);
@@ -52,13 +54,13 @@ namespace boost { namespace simd
       struct value_map
       {
         template<typename X>
-        static std::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
+        static tt::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
 
         template<typename X>
-        static std::integral_constant<std::int32_t,0x3f000000UL> value(boost::dispatch::single_<X> const&);
+        static tt::integral_constant<std::int32_t,0x3f000000UL> value(boost::dispatch::single_<X> const&);
 
         template<typename X>
-        static std::integral_constant<std::int64_t,0x3fe0000000000000ULL> value(boost::dispatch::double_<X> const&);
+        static tt::integral_constant<std::int64_t,0x3fe0000000000000ULL> value(boost::dispatch::double_<X> const&);
       };
     };
   }

--- a/include/boost/simd/detail/constant/maxexponent.hpp
+++ b/include/boost/simd/detail/constant/maxexponent.hpp
@@ -44,16 +44,18 @@
 namespace boost { namespace simd
 {
   namespace tag
-  {      struct value_map
+  { 
+    namespace tt = nsm::type_traits;
+     struct value_map
       {
         template<typename X>
-        static std::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
+        static tt::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
 
         template<typename X>
-        static std::integral_constant<std::int32_t,128> value(boost::dispatch::single_<X> const&);
+        static tt::integral_constant<std::int32_t,128> value(boost::dispatch::single_<X> const&);
 
         template<typename X>
-        static std::integral_constant<std::int64_t,1024> value(boost::dispatch::double_<X> const&);
+        static tt::integral_constant<std::int64_t,1024> value(boost::dispatch::double_<X> const&);
       };
     struct maxexponent_ : boost::dispatch::constant_value_<maxexponent_>
     {
@@ -61,13 +63,13 @@ namespace boost { namespace simd
       struct value_map
       {
         template<typename X>
-        static std::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
+        static tt::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
 
         template<typename X>
-        static std::integral_constant<std::int32_t,127> value(boost::dispatch::single_<X> const&);
+        static tt::integral_constant<std::int32_t,127> value(boost::dispatch::single_<X> const&);
 
         template<typename X>
-        static std::integral_constant<std::int64_t,1023> value(boost::dispatch::double_<X> const&);
+        static tt::integral_constant<std::int64_t,1023> value(boost::dispatch::double_<X> const&);
       };
     };
   }

--- a/include/boost/simd/detail/constant/maxexponentm1.hpp
+++ b/include/boost/simd/detail/constant/maxexponentm1.hpp
@@ -45,19 +45,20 @@ namespace boost { namespace simd
 {
   namespace tag
   {
+    namespace tt = nsm::type_traits;
     struct maxexponentm1_ : boost::dispatch::constant_value_<maxexponentm1_>
     {
       BOOST_DISPATCH_MAKE_CALLABLE(ext,maxexponentm1_,boost::dispatch::constant_value_<maxexponentm1_>);
       struct value_map
       {
         template<typename X>
-        static std::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
+        static tt::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
 
         template<typename X>
-        static std::integral_constant<std::int32_t,126> value(boost::dispatch::single_<X> const&);
+        static tt::integral_constant<std::int32_t,126> value(boost::dispatch::single_<X> const&);
 
         template<typename X>
-        static std::integral_constant<std::int64_t,1022> value(boost::dispatch::double_<X> const&);
+        static tt::integral_constant<std::int64_t,1022> value(boost::dispatch::double_<X> const&);
       };
     };
   }

--- a/include/boost/simd/detail/constant/maxleftshift.hpp
+++ b/include/boost/simd/detail/constant/maxleftshift.hpp
@@ -45,13 +45,15 @@ namespace boost { namespace simd
 {
   namespace tag
   {
+    namespace tt = nsm::type_traits;
+
     struct maxleftshift_ : boost::dispatch::constant_value_<maxleftshift_>
     {
       BOOST_DISPATCH_MAKE_CALLABLE(ext,maxleftshift_,boost::dispatch::constant_value_<maxleftshift_>);
       struct value_map
       {
         template<typename X>
-        static std::integral_constant<typename boost::dispatch::as_integer_t<X>,sizeof(X)*CHAR_BIT-1> value(boost::dispatch::arithmetic_<X> const&);
+        static tt::integral_constant<typename boost::dispatch::as_integer_t<X>,sizeof(X)*CHAR_BIT-1> value(boost::dispatch::arithmetic_<X> const&);
       };
     };
   }

--- a/include/boost/simd/detail/constant/minexponent.hpp
+++ b/include/boost/simd/detail/constant/minexponent.hpp
@@ -47,6 +47,8 @@ namespace boost { namespace simd
 {
   namespace tag
   {
+    namespace tt = nsm::type_traits;
+
     struct minexponent_ : boost::dispatch::constant_value_<minexponent_>
     {
       BOOST_DISPATCH_MAKE_CALLABLE(ext,minexponent_,boost::dispatch::constant_value_<minexponent_>);
@@ -54,13 +56,13 @@ namespace boost { namespace simd
       struct value_map
       {
         template<typename X>
-        static std::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
+        static tt::integral_constant<X,0> value(boost::dispatch::integer_<X> const&);
 
         template<typename X>
-        static std::integral_constant<std::int32_t,-126> value(boost::dispatch::single_<X> const&);
+        static tt::integral_constant<std::int32_t,-126> value(boost::dispatch::single_<X> const&);
 
         template<typename X>
-       static std::integral_constant<std::int64_t,-1022> value(boost::dispatch::double_<X> const&);
+       static tt::integral_constant<std::int64_t,-1022> value(boost::dispatch::double_<X> const&);
       };
     };
   }

--- a/include/boost/simd/detail/constant_traits.hpp
+++ b/include/boost/simd/detail/constant_traits.hpp
@@ -16,7 +16,7 @@
 #include <boost/simd/detail/dispatch/property_of.hpp>
 #include <boost/simd/detail/dispatch/hierarchy.hpp>
 #include <boost/config.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 #ifdef BOOST_MSVC
 #pragma warning(push)
@@ -31,7 +31,7 @@
 struct value_map                                                                                    \
 {                                                                                                   \
   template<typename X>                                                                              \
-  static std::integral_constant<X,X(INT)> value(boost::dispatch::integer_<X> const&);               \
+  static nsm::type_traits::integral_constant<X,X(INT)> value(boost::dispatch::integer_<X> const&); \
   template<typename X>                                                                              \
   static nsm::single_<FLOAT> value(boost::dispatch::single_<X> const&);                         \
   template<typename X>                                                                              \
@@ -41,6 +41,8 @@ struct value_map                                                                
 
 namespace boost { namespace simd { namespace detail
 {
+  namespace tt = nsm::type_traits;
+
   template<typename Tag, typename T>
   struct constant_traits
   {
@@ -61,7 +63,7 @@ namespace boost { namespace simd { namespace detail
   template<typename T, bits_t<T> N, bits_t<T> M = 0>
   struct  constantify
   {
-    using type = std::integral_constant<T,T(N)>;
+    using type = tt::integral_constant<T,T(N)>;
   };
 
   template<bits_t<double> V> struct constantify<double,V>

--- a/include/boost/simd/detail/dispatch/adapted/boost/array.hpp
+++ b/include/boost/simd/detail/dispatch/adapted/boost/array.hpp
@@ -17,11 +17,14 @@
 #include <boost/simd/detail/dispatch/meta/model_of.hpp>
 #include <boost/simd/detail/dispatch/adapted/hierarchy/array.hpp>
 #include <boost/simd/detail/dispatch/hierarchy_of.hpp>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace dispatch
 {
   namespace ext
   {
+    namespace tt = nsm::type_traits;
+
     template<typename T, std::size_t N> struct model_of<boost::array<T,N>>
     {
       template<typename X> struct apply { using type = boost::array<X,N>; };
@@ -36,7 +39,7 @@ namespace boost { namespace dispatch
     struct hierarchy_of<boost::array<T,N>,Origin>
     {
       using type = array_ < boost::dispatch::hierarchy_of_t<T,Origin>
-                          , std::integral_constant<std::size_t, N>
+                          , tt::integral_constant<std::size_t, N>
                           >;
     };
   }

--- a/include/boost/simd/detail/dispatch/adapted/boost/fusion.hpp
+++ b/include/boost/simd/detail/dispatch/adapted/boost/fusion.hpp
@@ -18,19 +18,21 @@
 #include <boost/simd/detail/dispatch/detail/hierarchy_of.hpp>
 #include <boost/simd/detail/dispatch/adapted/hierarchy/tuple.hpp>
 #include <boost/simd/detail/dispatch/meta/is_homogeneous.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace dispatch
 {
   namespace detail
   {
+    namespace tt = nsm::type_traits;
+
     template<typename T, typename Origin, bool IsHomo>
     struct hierarchy_of_tuple
     {
       using first = typename boost::fusion::result_of::value_at<T, boost::mpl::int_<0>>::type;
       using sz    = boost::fusion::result_of::size<T>;
       using type  = bag_< boost::dispatch::property_of_t<first,Origin>
-                        , std::integral_constant<std::size_t, sz::value>
+                        , tt::integral_constant<std::size_t, sz::value>
                         >;
     };
 
@@ -38,7 +40,7 @@ namespace boost { namespace dispatch
     struct hierarchy_of_tuple<T,Origin, false>
     {
       using sz   = boost::fusion::result_of::size<T>;
-      using type = tuple_<Origin, std::integral_constant<std::size_t, sz::value>>;
+      using type = tuple_<Origin, tt::integral_constant<std::size_t, sz::value>>;
     };
   }
 

--- a/include/boost/simd/detail/dispatch/adapted/std/array.hpp
+++ b/include/boost/simd/detail/dispatch/adapted/std/array.hpp
@@ -17,11 +17,13 @@
 #include <boost/simd/detail/dispatch/meta/model_of.hpp>
 #include <boost/simd/detail/dispatch/adapted/hierarchy/array.hpp>
 #include <boost/simd/detail/dispatch/hierarchy_of.hpp>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace dispatch
 {
   namespace ext
   {
+    namespace tt = nsm::type_traits;
     template<typename T, std::size_t N> struct model_of<std::array<T,N>>
     {
       template<typename X> struct apply { using type = std::array<X,N>; };
@@ -36,7 +38,7 @@ namespace boost { namespace dispatch
     struct hierarchy_of<std::array<T,N>,Origin>
     {
       using type = array_ < boost::dispatch::hierarchy_of_t<T,Origin>
-                          , std::integral_constant<std::size_t, N>
+                          , tt::integral_constant<std::size_t, N>
                           >;
     };
   }

--- a/include/boost/simd/detail/dispatch/adapted/std/integral_constant.hpp
+++ b/include/boost/simd/detail/dispatch/adapted/std/integral_constant.hpp
@@ -16,19 +16,20 @@
 #include <boost/simd/detail/dispatch/meta/model_of.hpp>
 #include <boost/simd/detail/dispatch/hierarchy_of.hpp>
 #include <boost/simd/detail/dispatch/adapted/hierarchy/integral_constant.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace dispatch
 {
+  namespace tt = nsm::type_traits;
   // model/value_of adaptation
   namespace ext
   {
-    template<typename T, T N> struct model_of<std::integral_constant<T,N>>
+    template<typename T, T N> struct model_of<tt::integral_constant<T,N>>
     {
-      template<typename X> struct apply { using type = std::integral_constant<X,X(N)>; };
+      template<typename X> struct apply { using type = tt::integral_constant<X,X(N)>; };
     };
 
-    template<typename T, T N> struct value_of<std::integral_constant<T,N>>
+    template<typename T, T N> struct value_of<tt::integral_constant<T,N>>
     {
       using type = T;
     };
@@ -38,7 +39,7 @@ namespace boost { namespace dispatch
   {
     // integral_constant<T,N> hierarchies as constant_< (u)int{8,16,32,64}<Origin> >
     template<typename T, T N, typename Origin>
-    struct hierarchy_of<std::integral_constant<T,N>,Origin>
+    struct hierarchy_of<tt::integral_constant<T,N>,Origin>
     {
       using type = constant_< boost::dispatch::property_of_t<T,Origin> >;
     };

--- a/include/boost/simd/detail/dispatch/adapted/std/tuple.hpp
+++ b/include/boost/simd/detail/dispatch/adapted/std/tuple.hpp
@@ -17,9 +17,11 @@
 #include <boost/simd/detail/dispatch/detail/hierarchy_of.hpp>
 #include <boost/simd/detail/dispatch/adapted/hierarchy/tuple.hpp>
 #include <boost/simd/detail/dispatch/meta/is_homogeneous.hpp>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace dispatch
 {
+  namespace tt = nsm::type_traits;
   namespace detail
   {
     template<typename T, typename Origin, bool IsHomo>
@@ -28,7 +30,7 @@ namespace boost { namespace dispatch
       using first = typename std::tuple_element<0,T>::type;
       using sz    = std::tuple_size<T>;
       using type = bag_ < boost::dispatch::property_of_t<first,Origin>
-                        , std::integral_constant<std::size_t, sz::value>
+                        , tt::integral_constant<std::size_t, sz::value>
                         >;
     };
 
@@ -36,7 +38,7 @@ namespace boost { namespace dispatch
     struct hierarchy_of_tuple<T,Origin, false>
     {
       using sz   = std::tuple_size<T>;
-      using type = tuple_<Origin, std::integral_constant<std::size_t, sz::value>>;
+      using type = tuple_<Origin, tt::integral_constant<std::size_t, sz::value>>;
     };
 
   }
@@ -52,7 +54,7 @@ namespace boost { namespace dispatch
     template<typename Origin>
     struct hierarchy_of<std::tuple<>,Origin>
     {
-      using type = tuple_<Origin, std::integral_constant<std::size_t,0u>>;
+      using type = tuple_<Origin, tt::integral_constant<std::size_t,0u>>;
     };
   }
 } }

--- a/include/boost/simd/detail/dispatch/config.hpp
+++ b/include/boost/simd/detail/dispatch/config.hpp
@@ -15,6 +15,7 @@
 #define BOOST_SIMD_DETAIL_DISPATCH_CONFIG_HPP_INCLUDED
 
 #include <boost/config.hpp>
+#include <boost/simd/detail/nsm.hpp>
 
 // TODO : PR to Boost.config
 #if defined(__GNUC__)
@@ -30,8 +31,7 @@
 #define BOOST_NO_RESTRICT_REFERENCES
 #endif
 
-// Detect stupid ICC/G++ combos
-#if defined(BOOST_INTEL_GCC_VERSION) && (BOOST_INTEL_GCC_VERSION < 40600)
+#if defined(NSM_ASSUME_INCOMPLETE_STD)
 #define BOOST_DISPATCH_USE_INCOMPLETE_STD
 #endif
 

--- a/include/boost/simd/detail/dispatch/meta/pointer_rank.hpp
+++ b/include/boost/simd/detail/dispatch/meta/pointer_rank.hpp
@@ -14,21 +14,23 @@
 #ifndef BOOST_SIMD_DETAIL_DISPATCH_META_POINTER_RANK_HPP_INCLUDED
 #define BOOST_SIMD_DETAIL_DISPATCH_META_POINTER_RANK_HPP_INCLUDED
 
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace dispatch
 {
-  template<typename T> struct pointer_rank : std::integral_constant<std::size_t,0> {};
+  namespace tt = nsm::type_traits;
+
+  template<typename T> struct pointer_rank : tt::integral_constant<std::size_t,0> {};
 
   template<typename T>
-  struct pointer_rank<T*>  : std::integral_constant<std::size_t,1+pointer_rank<T>::value>
+  struct pointer_rank<T*>  : tt::integral_constant<std::size_t,1+pointer_rank<T>::value>
   {};
 
   template<typename T>
-  struct pointer_rank<T* const>  : std::integral_constant<std::size_t,1+pointer_rank<T>::value>
+  struct pointer_rank<T* const>  : tt::integral_constant<std::size_t,1+pointer_rank<T>::value>
   {};
   template<typename T>
-  struct pointer_rank<T* volatile>  : std::integral_constant<std::size_t,1+pointer_rank<T>::value>
+  struct pointer_rank<T* volatile>  : tt::integral_constant<std::size_t,1+pointer_rank<T>::value>
   {};
 } }
 

--- a/include/boost/simd/detail/nsm.hpp
+++ b/include/boost/simd/detail/nsm.hpp
@@ -10,16 +10,32 @@
 #define NSM_HPP_INCLUDED
 
 #include <boost/config.hpp>
-#include <type_traits>
 #include <cstdint>
 #include <cstring>
 #include <utility>
+
+// Detect stupid ICC/G++ combos
+#if defined(BOOST_INTEL_GCC_VERSION) && (BOOST_INTEL_GCC_VERSION < 40600)
+#define NSM_ASSUME_INCOMPLETE_STD
+#endif
+
+#if defined(NSM_ASSUME_INCOMPLETE_STD)
+#include <boost/type_traits.hpp>
+namespace nsm { 
+  namespace type_traits = boost;
+}
+#else
+#include <type_traits>
+namespace nsm { 
+  namespace type_traits = std;
+}
+#endif
 
 namespace nsm
 {
   template <class... T> struct list {};
   template<typename T, T... Values>
-  using integral_list = nsm::list< std::integral_constant<T,Values>...>;
+  using integral_list = nsm::list< type_traits::integral_constant<T,Values>...>;
   using empty_sequence = nsm::list<>;
 
   template<typename T, typename R = void > struct has_type
@@ -28,7 +44,7 @@ namespace nsm
   };
 
   template <bool B>
-  using bool_ = std::integral_constant<bool, B>;
+  using bool_ = type_traits::integral_constant<bool, B>;
 
   template<typename T> struct type_ { using type = T; };
   template<typename T> using type_from = typename T::type;
@@ -401,7 +417,7 @@ namespace nsm
   using transform = typename detail::transform_selector<sizeof...(OpSeq2), Sequence1, OpSeq1, OpSeq2...>::type;
 
   template <typename T>
-  struct make_integral : std::integral_constant <typename T::value_type, T::value> {};
+  struct make_integral : type_traits::integral_constant <typename T::value_type, T::value> {};
 
   template <typename L>
   using as_integral_list = transform<L, make_integral<nsm::_1>>;
@@ -420,7 +436,7 @@ namespace nsm
   using wrap = typename detail::wrap_impl<A, B>::type;
 
   template<class... T>
-  using count = std::integral_constant<std::size_t, sizeof...(T)>;
+  using count = type_traits::integral_constant<std::size_t, sizeof...(T)>;
 
   template<class L> using size = wrap<L, count>;
 
@@ -869,25 +885,25 @@ namespace nsm
   }
 
   template <std::int8_t V>
-  using int8_t = std::integral_constant<std::int8_t, V>;
+  using int8_t = type_traits::integral_constant<std::int8_t, V>;
   template <std::uint8_t V>
-  using uint8_t = std::integral_constant<std::uint8_t, V>;
+  using uint8_t = type_traits::integral_constant<std::uint8_t, V>;
   template <std::int16_t V>
-  using int16_t = std::integral_constant<std::int16_t, V>;
+  using int16_t = type_traits::integral_constant<std::int16_t, V>;
   template <std::uint16_t V>
-  using uint16_t = std::integral_constant<std::uint16_t, V>;
+  using uint16_t = type_traits::integral_constant<std::uint16_t, V>;
   template <std::int32_t V>
-  using int32_t = std::integral_constant<std::int32_t, V>;
+  using int32_t = type_traits::integral_constant<std::int32_t, V>;
   template <std::uint32_t V>
-  using uint32_t = std::integral_constant<std::uint32_t, V>;
+  using uint32_t = type_traits::integral_constant<std::uint32_t, V>;
   template <std::int64_t V>
-  using int64_t = std::integral_constant<std::int64_t, V>;
+  using int64_t = type_traits::integral_constant<std::int64_t, V>;
   template <std::uint64_t V>
-  using uint64_t = std::integral_constant<std::uint64_t, V>;
+  using uint64_t = type_traits::integral_constant<std::uint64_t, V>;
   template<std::size_t V>
-  using size_t    = std::integral_constant<std::size_t, V>;
+  using size_t    = type_traits::integral_constant<std::size_t, V>;
   template<std::ptrdiff_t V>
-  using ptrdiff_t = std::integral_constant<std::ptrdiff_t, V>;
+  using ptrdiff_t = type_traits::integral_constant<std::ptrdiff_t, V>;
 }
 namespace nsm
 {
@@ -898,10 +914,10 @@ namespace nsm
     template<class T, T Start, T Int>
     struct int_plus
     {
-      using type = std::integral_constant<T, Start + Int>;
+      using type = type_traits::integral_constant<T, Start + Int>;
     };
     template<class T, class... Ts, T... Ints, T Start>
-    struct range_cat<T, list<Ts...>, list<std::integral_constant<T, Ints>...>, Start>
+    struct range_cat<T, list<Ts...>, list<type_traits::integral_constant<T, Ints>...>, Start>
     {
       using type = list<Ts..., typename int_plus<T, Start, Ints>::type...>;
     };
@@ -917,7 +933,7 @@ namespace nsm
     template<class T, T Start>
     struct range_impl<T, Start, 1>
     {
-      using type = list<std::integral_constant<T, Start>>;
+      using type = list<type_traits::integral_constant<T, Start>>;
     };
     template<class T, T Start>
     struct range_impl<T, Start, 0>
@@ -929,10 +945,10 @@ namespace nsm
     template<class T, T Start, T Int>
     struct int_minus
     {
-      using type = std::integral_constant<T, Int - Start>;
+      using type = type_traits::integral_constant<T, Int - Start>;
     };
     template<class T, class... Ts, T... Ints, T Start>
-    struct reverse_range_cat<T, list<Ts...>, list<std::integral_constant<T, Ints>...>, Start>
+    struct reverse_range_cat<T, list<Ts...>, list<type_traits::integral_constant<T, Ints>...>, Start>
     {
       using type = list<Ts..., typename int_minus<T, Start, Ints>::type...>;
     };
@@ -948,7 +964,7 @@ namespace nsm
     template<class T, T Start>
     struct reverse_range_impl<T, Start, 1>
     {
-      using type = list<std::integral_constant<T, Start>>;
+      using type = list<type_traits::integral_constant<T, Start>>;
     };
     template<class T, T Start>
     struct reverse_range_impl<T, Start, 0>
@@ -1014,19 +1030,19 @@ namespace nsm
   };
 
   template <typename A>
-  struct next : std::integral_constant < typename A::value_type, A::value + 1 > {};
+  struct next : type_traits::integral_constant < typename A::value_type, A::value + 1 > {};
 
   template <typename A>
-  struct prev : std::integral_constant < typename A::value_type, A::value - 1 > {};
+  struct prev : type_traits::integral_constant < typename A::value_type, A::value - 1 > {};
 
   template <typename A, typename B>
-  struct max : std::integral_constant < typename A::value_type
+  struct max : type_traits::integral_constant < typename A::value_type
                                       , (A::value < B::value) ? B::value : A::value
                                       >
   {};
 
   template <typename A, typename B>
-  struct min : std::integral_constant < typename A::value_type
+  struct min : type_traits::integral_constant < typename A::value_type
                                       , (A::value < B::value) ? A::value : B::value
                                       >
   {};
@@ -1096,16 +1112,16 @@ namespace nsm
   };
 
   template <typename A, typename B>
-  struct and_ : std::integral_constant <typename A::value_type, A::value && B::value > {};
+  struct and_ : type_traits::integral_constant <typename A::value_type, A::value && B::value > {};
 
   template <typename T>
-  struct not_ : std::integral_constant<typename T::value_type, !T::value> {};
+  struct not_ : type_traits::integral_constant<typename T::value_type, !T::value> {};
 
   template <typename A, typename B>
-  struct or_ : std::integral_constant < typename A::value_type, A::value || B::value > {};
+  struct or_ : type_traits::integral_constant < typename A::value_type, A::value || B::value > {};
 
   template <typename A, typename B>
-  struct xor_ : std::integral_constant<typename A::value_type, A::value != B::value> {};
+  struct xor_ : type_traits::integral_constant<typename A::value_type, A::value != B::value> {};
 
   template<class T>
   struct always
@@ -1114,7 +1130,7 @@ namespace nsm
   };
 
   template<typename T>
-  struct sizeof_ : std::integral_constant <std::size_t, sizeof(T)> {};
+  struct sizeof_ : type_traits::integral_constant <std::size_t, sizeof(T)> {};
 
   namespace detail
   {
@@ -1171,10 +1187,10 @@ namespace nsm
   using make_sequence = typename detail::make_sequence_impl<List, Start, N, Next, (N<=8)>::type;
 
   template<typename RealType, typename Type, Type Value>
-  struct real_ : std::integral_constant<Type,Value>
+  struct real_ : type_traits::integral_constant<Type,Value>
   {
     using value_type  = RealType;
-    using parent      = std::integral_constant<Type,Value>;
+    using parent      = type_traits::integral_constant<Type,Value>;
 
     BOOST_FORCEINLINE operator value_type() const
     {

--- a/include/boost/simd/detail/pack_info.hpp
+++ b/include/boost/simd/detail/pack_info.hpp
@@ -12,13 +12,15 @@
 #include <boost/simd/meta/cardinal_of.hpp>
 #include <boost/simd/detail/dispatch/meta/downgrade.hpp>
 #include <boost/simd/detail/dispatch/meta/upgrade.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace simd
 {
+  namespace tt = nsm::type_traits;
+
   // Overload for cardinal_of
   template<typename T, std::size_t N, typename ABI>
-  struct cardinal_of<pack<T,N,ABI>> : std::integral_constant<std::size_t,N>
+  struct cardinal_of<pack<T,N,ABI>> : tt::integral_constant<std::size_t,N>
   {};
 } }
 

--- a/include/boost/simd/detail/shuffle/default_matcher.hpp
+++ b/include/boost/simd/detail/shuffle/default_matcher.hpp
@@ -19,6 +19,8 @@
 
 namespace boost { namespace simd { namespace detail
 {
+  namespace tt = nsm::type_traits;
+
   // -----------------------------------------------------------------------------------------------
   // Half-permutation snatcher
   template<bool isUpper, int... Ps> struct half_
@@ -41,13 +43,13 @@ namespace boost { namespace simd { namespace detail
 
     // Unary helpers
     template<typename T, int N> BOOST_FORCEINLINE static typename T::value_type
-    fill_( const T& a0, std::integral_constant<int,N> const& )
+    fill_( const T& a0, tt::integral_constant<int,N> const& )
     {
       return boost::simd::extract<N>(a0);
     }
 
     template<typename T> BOOST_FORCEINLINE static typename T::value_type
-    fill_(const T&, std::integral_constant<int,-1> const&)
+    fill_(const T&, tt::integral_constant<int,-1> const&)
     {
       return typename T::value_type{0};
     }
@@ -71,14 +73,14 @@ namespace boost { namespace simd { namespace detail
 
     template<typename K, typename T, int... P>
     static BOOST_FORCEINLINE T process(T const& a0, pattern_<P...> const&, K const&)
-    { return T( fill_ (a0 , std::integral_constant<int,P>{} )... );
+    { return T( fill_ (a0 , tt::integral_constant<int,P>{} )... );
     }
 
     // Binary permutation handler
     template<typename T, int... P>
     static BOOST_FORCEINLINE T process(T const& a0, T const& a1, pattern_<P...> const&)
     {
-      return T( fill_ (a0 ,a1 , std::integral_constant<int,P>{}
+      return T( fill_ (a0 ,a1 , tt::integral_constant<int,P>{}
                               , nsm::bool_<(P<T::static_size)>{}
                       )...
               );
@@ -88,7 +90,7 @@ namespace boost { namespace simd { namespace detail
     template<typename T, int N>
     BOOST_FORCEINLINE static typename T::value_type
     fill_ ( const T& a0, const T&
-          , std::integral_constant<int,N> const&, std::true_type const&
+          , tt::integral_constant<int,N> const&, std::true_type const&
           )
     {
       return  boost::simd::extract<N>(a0);
@@ -97,7 +99,7 @@ namespace boost { namespace simd { namespace detail
     template<typename T>
     BOOST_FORCEINLINE static typename T::value_type
     fill_ ( const T&, const T&
-          , std::integral_constant<int,-1> const&, std::true_type const&
+          , tt::integral_constant<int,-1> const&, std::true_type const&
           )
     {
       return 0;
@@ -106,7 +108,7 @@ namespace boost { namespace simd { namespace detail
     template<typename T, int N>
     BOOST_FORCEINLINE static typename T::value_type
     fill_ (const T&, const T & a1
-          , std::integral_constant<int,N> const&, std::false_type const&
+          , tt::integral_constant<int,N> const&, std::false_type const&
           )
     {
       return  boost::simd::extract<N-T::static_size>(a1);

--- a/include/boost/simd/detail/shuffle/helpers.hpp
+++ b/include/boost/simd/detail/shuffle/helpers.hpp
@@ -15,6 +15,8 @@
 
 namespace boost { namespace simd { namespace detail
 {
+  namespace tt = nsm::type_traits;
+
   // -----------------------------------------------------------------------------------------------
   // Check if any -1 is in a pattern pack
   template<int... Ps>
@@ -27,7 +29,7 @@ namespace boost { namespace simd { namespace detail
 
   // -----------------------------------------------------------------------------------------------
   // Return a mask depending on a given pattern
-  template<typename T, int P> struct zeroing_mask: std::integral_constant<T,P==-1 ? T(0) : ~(T(0))>
+  template<typename T, int P> struct zeroing_mask: tt::integral_constant<T,P==-1 ? T(0) : ~(T(0))>
   {};
 
   // -----------------------------------------------------------------------------------------------
@@ -40,7 +42,7 @@ namespace boost { namespace simd { namespace detail
     using idx_a0 = nsm::integral_list<bool,  (Is <  int(sizeof...(Is)))...              >;
     using idx_a1 = nsm::integral_list<bool, ((Is >= int(sizeof...(Is))) || (Is==-1))... >;
 
-    using type = std::integral_constant < int
+    using type = tt::integral_constant < int
                                         , 0x01*nsm::all<idx_a0>::value
                                         + 0x02*nsm::all<idx_a1>::value
                                         >;
@@ -48,15 +50,15 @@ namespace boost { namespace simd { namespace detail
 
   template<typename Perm> using side_t = typename side<Perm>::type;
 
-  using a0_side   = std::integral_constant<int, 0x01>;
-  using a1_side   = std::integral_constant<int, 0x02>;
-  using zero_side = std::integral_constant<int, 0x03>;
-  using both_side = std::integral_constant<int, 0x00>;
+  using a0_side   = tt::integral_constant<int, 0x01>;
+  using a1_side   = tt::integral_constant<int, 0x02>;
+  using zero_side = tt::integral_constant<int, 0x03>;
+  using both_side = tt::integral_constant<int, 0x00>;
 
   // -----------------------------------------------------------------------------------------------
   // Slide a permutation by an offset
   template<int I, int Offset>
-  struct remap : std::integral_constant<int,I==-1 ? -1 : I+Offset>
+  struct remap : tt::integral_constant<int,I==-1 ? -1 : I+Offset>
   {};
 
   // -----------------------------------------------------------------------------------------------
@@ -64,7 +66,7 @@ namespace boost { namespace simd { namespace detail
   template<int Bits, int I, typename Ps, std::uint8_t Fix = 0xFF> struct val
   {
     using P    = nsm::at_c<Ps,I/Bits>;
-    using type = std::integral_constant < std::uint8_t
+    using type = tt::integral_constant < std::uint8_t
                                         , P::value == -1 ? Fix : (P::value*Bits + (I%Bits))
                                         >;
   };
@@ -91,7 +93,7 @@ namespace boost { namespace simd { namespace detail
   {
     using sz   = nsm::size<Ps>;
     using P    = nsm::at_c<Ps,I/Bits>;
-    using type = std::integral_constant < std::uint8_t
+    using type = tt::integral_constant < std::uint8_t
                                         , P::value==-1  ? 0xFF
                                                         : ( (P::value < sz::value)
                                                             ? (P::value*Bits + (I%Bits))
@@ -111,9 +113,9 @@ namespace boost { namespace simd { namespace detail
   // Computes a byte pattern from index pattern for binary shuffle - right side
   template<int Bits, int I, typename Ps> struct right_val
   {
-    using sz    = std::integral_constant<int,nsm::size<Ps>::value>;
+    using sz    = tt::integral_constant<int,nsm::size<Ps>::value>;
     using P     = nsm::at_c<Ps,I/Bits>;
-    using type  = std::integral_constant < std::uint8_t
+    using type  = tt::integral_constant < std::uint8_t
                                         , P::value==-1  ? 0xFF
                                                         : ( (P::value >= sz::value)
                                                             ? ((P::value-sz::value)*Bits + (I%Bits))

--- a/include/boost/simd/detail/shuffle/pattern.hpp
+++ b/include/boost/simd/detail/shuffle/pattern.hpp
@@ -23,12 +23,14 @@ namespace boost { namespace simd
 
   namespace detail
   {
+    namespace tt = nsm::type_traits;
+
     // -----------------------------------------------------------------------------------------------
     // normalized permutation pattern holder - also acts as its own hierarchy
     template<int... Ps> struct pattern_ : boost::dispatch::unspecified_<pattern_<Ps...>>
     {
       static const std::size_t static_size = sizeof...(Ps);
-      using size_type = std::integral_constant<std::size_t,static_size>;
+      using size_type = tt::integral_constant<std::size_t,static_size>;
       using parent = boost::dispatch::unspecified_<pattern_<Ps...>>;
     };
 

--- a/include/boost/simd/function/definition/aligned_load.hpp
+++ b/include/boost/simd/function/definition/aligned_load.hpp
@@ -12,6 +12,7 @@
 #define BOOST_SIMD_FUNCTION_DEFINITION_ALIGNED_LOAD_HPP_INCLUDED
 
 #include <boost/simd/config.hpp>
+#include <boost/simd/detail/nsm.hpp>
 #include <boost/simd/as.hpp>
 #include <boost/simd/detail/dispatch/function/make_callable.hpp>
 #include <boost/simd/detail/dispatch/hierarchy/functions.hpp>
@@ -19,6 +20,8 @@
 
 namespace boost { namespace simd
 {
+  namespace tt = nsm::type_traits;
+
   namespace tag
   {
     BOOST_DISPATCH_MAKE_TAG(ext, aligned_load_, boost::dispatch::abstract_<aligned_load_>);
@@ -44,7 +47,7 @@ namespace boost { namespace simd
   BOOST_FORCEINLINE T aligned_load(Pointer const& p, Opts&&... o)
   {
     return detail::aligned_load ( p, std::forward<Opts>(o)...
-                                , std::integral_constant<std::ptrdiff_t,Misalignment>()
+                                , tt::integral_constant<std::ptrdiff_t,Misalignment>()
                                 , boost::simd::as_<T>()
                                 );
   }

--- a/include/boost/simd/function/detail/slide.hpp
+++ b/include/boost/simd/function/detail/slide.hpp
@@ -11,10 +11,12 @@
 
 #include <boost/simd/config.hpp>
 #include <boost/simd/constant/zero.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace simd { namespace detail
 {
+  namespace tt = nsm::type_traits;
+
   template<typename T,int N, int Card, bool isFwd> struct slider;
 
   // We add a small trampoline so MSVC is happy with the cardinal_of call
@@ -26,10 +28,10 @@ namespace boost { namespace simd { namespace detail
   template<typename T,int N, int Card, bool isFwd> struct slider
   {
     static BOOST_FORCEINLINE auto call(T const& a0, T const& a1)
-    BOOST_NOEXCEPT_DECLTYPE_BODY(detail::slide(a0,a1,std::integral_constant<int, N>{}));
+    BOOST_NOEXCEPT_DECLTYPE_BODY(detail::slide(a0,a1,tt::integral_constant<int, N>{}));
 
     static BOOST_FORCEINLINE auto call(T const& a0)
-    BOOST_NOEXCEPT_DECLTYPE_BODY(detail::slide(a0,std::integral_constant<int, N>{}));
+    BOOST_NOEXCEPT_DECLTYPE_BODY(detail::slide(a0,tt::integral_constant<int, N>{}));
   };
 
   // Backward slide slides the swapped inputs by the complement of the offset except for
@@ -37,10 +39,10 @@ namespace boost { namespace simd { namespace detail
   template<typename T,int N, int Card> struct slider<T,N,Card,false>
   {
     //static BOOST_FORCEINLINE auto call(T const& a0, T const& a1)
-    //BOOST_NOEXCEPT_DECLTYPE_BODY(detail::slide(a1,a0,std::integral_constant<int, Card+N>{}));
+    //BOOST_NOEXCEPT_DECLTYPE_BODY(detail::slide(a1,a0,tt::integral_constant<int, Card+N>{}));
 
     static BOOST_FORCEINLINE auto call(T const& a0, std::false_type const&)
-    BOOST_NOEXCEPT_DECLTYPE_BODY(detail::slide(a0,std::integral_constant<int, N>{}));
+    BOOST_NOEXCEPT_DECLTYPE_BODY(detail::slide(a0,tt::integral_constant<int, N>{}));
 
     static BOOST_FORCEINLINE T call(T const&, std::true_type const&)
     { return Zero<T>(); }
@@ -49,7 +51,7 @@ namespace boost { namespace simd { namespace detail
     BOOST_NOEXCEPT_DECLTYPE_BODY( call(a0, nsm::bool_<(N==-Card)>{}) );
 
     static BOOST_FORCEINLINE auto call(T const& a0, T const& a1, std::false_type const&)
-    BOOST_NOEXCEPT_DECLTYPE_BODY(detail::slide(a1, a0, std::integral_constant<int, Card+N>{}));
+    BOOST_NOEXCEPT_DECLTYPE_BODY(detail::slide(a1, a0, tt::integral_constant<int, Card+N>{}));
 
     static BOOST_FORCEINLINE T call(T const&, T const& a1, std::true_type const&)
     { return a1; }

--- a/include/boost/simd/meta/cardinal_of.hpp
+++ b/include/boost/simd/meta/cardinal_of.hpp
@@ -15,10 +15,11 @@
 #include <boost/simd/config.hpp>
 #include <boost/core/ignore_unused.hpp>
 #include <boost/config.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace simd
 {
+  namespace tt = nsm::type_traits;
   /*!
     @ingroup group-api
 
@@ -49,7 +50,7 @@ namespace boost { namespace simd
   template<typename T>
   struct  cardinal_of
 #if !defined(DOXYGEN_ONLY)
-        : std::integral_constant<std::size_t,1ULL>
+        : tt::integral_constant<std::size_t,1ULL>
 #endif
   {};
 

--- a/include/boost/simd/meta/expected_cardinal.hpp
+++ b/include/boost/simd/meta/expected_cardinal.hpp
@@ -16,10 +16,12 @@
 
 #include <boost/simd/config.hpp>
 #include <boost/simd/arch/limits.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace simd
 {
+  namespace tt = nsm::type_traits;
+
   template<typename T> struct logical;
 
   /*!
@@ -34,12 +36,12 @@ namespace boost { namespace simd
   **/
   template<typename Type, typename Extension>
   struct  expected_cardinal
-        : std::integral_constant<std::size_t,limits<Extension>::bytes/sizeof(Type)>
+        : tt::integral_constant<std::size_t,limits<Extension>::bytes/sizeof(Type)>
   {};
 
   template<typename Type, typename Extension>
   struct  expected_cardinal<logical<Type>,Extension>
-        : std::integral_constant<std::size_t,limits<Extension>::bytes/sizeof(Type)>
+        : tt::integral_constant<std::size_t,limits<Extension>::bytes/sizeof(Type)>
   {};
 } }
 

--- a/include/boost/simd/meta/is_bitwise_logical.hpp
+++ b/include/boost/simd/meta/is_bitwise_logical.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_SIMD_META_IS_BITWISE_LOGICAL_HPP_INCLUDED
 #define BOOST_SIMD_META_IS_BITWISE_LOGICAL_HPP_INCLUDED
 
+#include <boost/simd/detail/nsm.hpp>
 #include <boost/simd/meta/as_logical.hpp>
 #include <boost/simd/meta/as_arithmetic.hpp>
 #include <boost/simd/config.hpp>
@@ -20,6 +21,7 @@
 namespace boost { namespace simd
 {
   namespace bd = boost::dispatch;
+  namespace tt = nsm::type_traits;
 
   /*!
     @ingroup  group-api
@@ -31,9 +33,9 @@ namespace boost { namespace simd
   **/
   template<typename T>
   struct  is_bitwise_logical
-        : std::integral_constant< bool
-                                , sizeof(as_arithmetic_t<T>) == sizeof(as_logical_t<T>)
-                                >
+        : tt::integral_constant< bool
+                               , sizeof(as_arithmetic_t<T>) == sizeof(as_logical_t<T>)
+                               >
   {};
 
   /*!

--- a/include/boost/simd/meta/is_iterator.hpp
+++ b/include/boost/simd/meta/is_iterator.hpp
@@ -13,12 +13,13 @@
 #define BOOST_SIMD_META_IS_ITERATOR_HPP_INCLUDED
 
 #include <boost/simd/config.hpp>
+#include <boost/simd/detail/nsm.hpp>
 #include <boost/simd/detail/dispatch/detail/declval.hpp>
-#include <type_traits>
 
 namespace boost { namespace simd
 {
   namespace bd = boost::dispatch;
+  namespace tt = nsm::type_traits;
   namespace detail
   {
 #if defined(BOOST_DISPATCH_USE_INCOMPLETE_STD)
@@ -64,7 +65,7 @@ namespace boost { namespace simd
     @tparam Type      Type to check
   **/
   template<typename T>
-  struct is_iterator : std::integral_constant<bool, detail::is_iterator_impl<T>::value>
+  struct is_iterator : tt::integral_constant<bool, detail::is_iterator_impl<T>::value>
   {};
 
   template<typename T>

--- a/include/boost/simd/pack.hpp
+++ b/include/boost/simd/pack.hpp
@@ -15,6 +15,7 @@
 #define BOOST_SIMD_PACK_HPP_INCLUDED
 
 #include <boost/simd/config.hpp>
+#include <boost/simd/detail/nsm.hpp>
 #include <boost/simd/detail/dispatch/detail/declval.hpp>
 #include <boost/simd/detail/pack_traits.hpp>
 #include <boost/simd/detail/storage_of.hpp>
@@ -51,6 +52,7 @@
 namespace boost { namespace simd
 {
   namespace bd = boost::dispatch;
+  namespace tt = nsm::type_traits;
 
   /*!
     @ingroup  group-api
@@ -259,14 +261,14 @@ namespace boost { namespace simd
 
     /// @overload
     template<std::uint64_t Index>
-    BOOST_FORCEINLINE value_type operator[](std::integral_constant<std::uint64_t,Index> const&)
+    BOOST_FORCEINLINE value_type operator[](tt::integral_constant<std::uint64_t,Index> const&)
     {
       return ::boost::simd::extract<Index>(*this);
     }
 
     /// @overload
     template<std::uint64_t Index>
-    BOOST_FORCEINLINE value_type operator[](std::integral_constant<std::uint64_t,Index> const&) const
+    BOOST_FORCEINLINE value_type operator[](tt::integral_constant<std::uint64_t,Index> const&) const
     {
       return ::boost::simd::extract<Index>(*this);
     }

--- a/test/api/meta/cardinal_of.cpp
+++ b/test/api/meta/cardinal_of.cpp
@@ -6,6 +6,7 @@
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 */
 //==================================================================================================
+#include <boost/simd/detail/nsm.hpp>
 #include <boost/simd/meta/cardinal_of.hpp>
 #include <boost/simd/pack.hpp>
 #include <simd_test.hpp>
@@ -42,7 +43,7 @@ STF_CASE_TPL( "Check cardinal_of for scalar types", STF_ALL_TYPES )
   STF_EQUAL( cardinal(T{}), 1ULL );
 }
 
-template<std::size_t N> using card_ = std::integral_constant<std::size_t,N>;
+template<std::size_t N> using card_ = nsm::type_traits::integral_constant<std::size_t,N>;
 
 STF_CASE_TPL( "Check cardinal_of for pack types"
             , (card_<1>)(card_<2>)(card_<4>)

--- a/test/doc/swar/shuffle.perm.cpp
+++ b/test/doc/swar/shuffle.perm.cpp
@@ -7,13 +7,14 @@
 */
 //==================================================================================================
 //! [shuffle-perm]
+#include <boost/simd/detail/nsm.hpp>
 #include <boost/simd/pack.hpp>
 #include <boost/simd/function/shuffle.hpp>
 #include <iostream>
 
 struct last_
 {
-  template<typename I, typename C> struct apply : std::integral_constant<int, C::value-1> {};
+  template<typename I, typename C> struct apply : nsm::type_traits::integral_constant<int, C::value-1> {};
 };
 
 constexpr int reverse(int i, int c)

--- a/test/function/scalar/shuffle.cpp
+++ b/test/function/scalar/shuffle.cpp
@@ -6,6 +6,7 @@
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 **/
 //==================================================================================================
+#include <boost/simd/detail/nsm.hpp>
 #include <boost/simd/function/scalar/shuffle.hpp>
 #include <scalar_test.hpp>
 
@@ -27,7 +28,7 @@ STF_CASE_TPL("Check binary shuffle behavior with direct permutation", STF_NUMERI
 template<int N> struct grab_
 {
   template<typename I, typename C>
-  struct apply : std::integral_constant<int, N>
+  struct apply : nsm::type_traits::integral_constant<int, N>
   {};
 };
 

--- a/test/function/simd/shuffle/cardinal.1.cpp
+++ b/test/function/simd/shuffle/cardinal.1.cpp
@@ -6,6 +6,7 @@
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 **/
 //==================================================================================================
+#include <boost/simd/detail/nsm.hpp>
 #include <boost/simd/function/shuffle.hpp>
 #include <boost/simd/pack.hpp>
 #include <simd_test.hpp>
@@ -29,7 +30,7 @@ STF_CASE_TPL("Check binary shuffle behavior with direct permutation", STF_NUMERI
 
 template<int N> struct grab_
 {
-  template<typename I, typename C> struct apply : std::integral_constant<int, N> {};
+  template<typename I, typename C> struct apply : nsm::type_traits::integral_constant<int, N> {};
 };
 
 STF_CASE_TPL("Check unary shuffle behavior with direct meta-permutation", STF_NUMERIC_TYPES)


### PR DESCRIPTION
Needed, mostly, because the gcc4.4.7 integer_constant does not provide the require conversion operator.
boost's version does.

Along with #380, push the success rate of unit up to 41%:
41% tests passed, 717 tests failed out of 1216
