### PR TITLE
Pick (true|false)_type in the same namespace as integral_constant

### DIFF
--- a/bench/ns.bench.hpp
+++ b/bench/ns.bench.hpp
@@ -1468,7 +1468,7 @@ namespace ns { namespace bench { namespace generators {
 template <typename U, typename IS = typename std::is_scalar<U>::type>
 struct rand {};
 template <typename T>
-struct rand<T, std::true_type>
+struct rand<T, nsm::type_traits::true_type>
 {
   template <typename U>
   rand( U pmin = static_cast<U>(std::numeric_limits<T>::min())
@@ -1505,7 +1505,7 @@ struct rand<T, std::true_type>
   T min_, max_;
 };
 template <typename T>
-struct rand<T, std::false_type>
+struct rand<T, nsm::type_traits::false_type>
 {
   using value_type = typename T::value_type;
   template <typename U>

--- a/exhaustive/exhaustive.hpp
+++ b/exhaustive/exhaustive.hpp
@@ -35,7 +35,7 @@
 #include <boost/simd/detail/dispatch/meta/scalar_of.hpp>
 #include <boost/config.hpp>
 #include <boost/core/demangle.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 
 namespace bd = boost::dispatch;

--- a/include/boost/simd/arch/common/generic/function/aligned_load.hpp
+++ b/include/boost/simd/arch/common/generic/function/aligned_load.hpp
@@ -64,7 +64,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_DISPATCH_OVERLOAD ( aligned_load_
                           , (typename Target, typename Pointer, typename Offset)
                           , bd::cpu_
-                          , bd::masked_pointer_<bd::unspecified_<Pointer>,std::false_type>
+                          , bd::masked_pointer_<bd::unspecified_<Pointer>,tt::false_type>
                           , bd::scalar_<bd::integer_<Offset>>
                           , bd::target_<bd::unspecified_<Target>>
                           )
@@ -80,7 +80,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_DISPATCH_OVERLOAD ( aligned_load_
                           , (typename Target, typename Pointer, typename Offset)
                           , bd::cpu_
-                          , bd::masked_pointer_<bd::unspecified_<Pointer>,std::true_type>
+                          , bd::masked_pointer_<bd::unspecified_<Pointer>,tt::true_type>
                           , bd::scalar_<bd::integer_<Offset>>
                           , bd::target_<bd::unspecified_<Target>>
                           )

--- a/include/boost/simd/arch/common/generic/function/bitwise_cast.hpp
+++ b/include/boost/simd/arch/common/generic/function/bitwise_cast.hpp
@@ -17,7 +17,7 @@
 #include <boost/simd/function/slice.hpp>
 #include <boost/simd/logical.hpp>
 #include <cstring>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 
 namespace boost { namespace simd { namespace ext
@@ -42,7 +42,7 @@ namespace boost { namespace simd { namespace ext
       return do_(a0, typename std::is_same<A0, result_t>::type());
     }
 
-    BOOST_FORCEINLINE result_t do_(A0 const& a0, std::false_type const& ) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE result_t do_(A0 const& a0, tt::false_type const& ) const BOOST_NOEXCEPT
     {
       return do_(a0, typename A0::storage_kind{});
     }
@@ -63,7 +63,7 @@ namespace boost { namespace simd { namespace ext
       return that;
     }
 
-    BOOST_FORCEINLINE result_t do_(A0 const& a0, std::true_type const& ) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE result_t do_(A0 const& a0, tt::true_type const& ) const BOOST_NOEXCEPT
     {
       return a0;
     }

--- a/include/boost/simd/arch/common/generic/function/saturate.hpp
+++ b/include/boost/simd/arch/common/generic/function/saturate.hpp
@@ -44,7 +44,7 @@ namespace boost { namespace simd { namespace ext
     }
 
     BOOST_FORCEINLINE A0 impl( A0 const& a0
-                                        , const std::true_type &) const BOOST_NOEXCEPT
+                                        , const tt::true_type &) const BOOST_NOEXCEPT
     {
       using starget_t = bd::scalar_of_t<typename T::type>;
       const A0 vma = splat<A0>(Valmax<starget_t>());
@@ -52,7 +52,7 @@ namespace boost { namespace simd { namespace ext
       return if_else(is_inf(a0), a0, min(vma, max(vmi, a0)));
     }
     BOOST_FORCEINLINE A0 impl( A0 const& a0
-                                             , const std::false_type &) const BOOST_NOEXCEPT
+                                             , const tt::false_type &) const BOOST_NOEXCEPT
     {
       return a0;
     }
@@ -92,12 +92,12 @@ namespace boost { namespace simd { namespace ext
                    );
     }
     static BOOST_FORCEINLINE A0 impl( A0 const& a0
-                                        , const std::true_type &) BOOST_NOEXCEPT
+                                        , const tt::true_type &) BOOST_NOEXCEPT
     {
       return a0;
     }
     static BOOST_FORCEINLINE A0 impl( A0 const& a0
-                                        , const std::false_type &) BOOST_NOEXCEPT
+                                        , const tt::false_type &) BOOST_NOEXCEPT
     {
       using starget_t = bd::scalar_of_t<typename T::type>;
       const A0 vma = splat<A0>(Valmax<starget_t>());
@@ -123,12 +123,12 @@ namespace boost { namespace simd { namespace ext
                    );
     }
     static BOOST_FORCEINLINE A0 impl( A0 const& a0
-                                        , const std::true_type &) BOOST_NOEXCEPT
+                                        , const tt::true_type &) BOOST_NOEXCEPT
     {
       return max(Zero<A0>(), a0);
     }
     static BOOST_FORCEINLINE A0 impl( A0 const& a0
-                                        , const std::false_type &) BOOST_NOEXCEPT
+                                        , const tt::false_type &) BOOST_NOEXCEPT
     {
       using starget_t = bd::scalar_of_t<typename T::type>;
       const A0 vma = splat<A0>(Valmax<starget_t>());
@@ -169,12 +169,12 @@ namespace boost { namespace simd { namespace ext
                    );
     }
     static BOOST_FORCEINLINE A0 impl( A0 const& a0
-                                        , const std::true_type &) BOOST_NOEXCEPT
+                                        , const tt::true_type &) BOOST_NOEXCEPT
     {
       return a0;
     }
     static BOOST_FORCEINLINE A0 impl( A0 const& a0
-                                        , const std::false_type &) BOOST_NOEXCEPT
+                                        , const tt::false_type &) BOOST_NOEXCEPT
     {
       using starget_t = bd::scalar_of_t<typename T::type>;
       const A0 vma = splat<A0>(Valmax<starget_t>());

--- a/include/boost/simd/arch/common/scalar/constant/constant_value.hpp
+++ b/include/boost/simd/arch/common/scalar/constant/constant_value.hpp
@@ -16,7 +16,6 @@
 #include <boost/simd/detail/dispatch/function/overload.hpp>
 #include <boost/simd/detail/dispatch/as.hpp>
 #include <boost/config.hpp>
-#include <type_traits>
 
 #ifdef BOOST_MSVC
 #pragma warning(push)

--- a/include/boost/simd/arch/common/scalar/function/bitwise_and.hpp
+++ b/include/boost/simd/arch/common/scalar/function/bitwise_and.hpp
@@ -19,7 +19,6 @@
 #include <boost/simd/detail/dispatch/hierarchy.hpp>
 #include <boost/simd/detail/dispatch/meta/as_integer.hpp>
 #include <boost/config.hpp>
-#include <type_traits>
 
 namespace boost { namespace simd { namespace ext
 {

--- a/include/boost/simd/arch/common/scalar/function/bitwise_notand.hpp
+++ b/include/boost/simd/arch/common/scalar/function/bitwise_notand.hpp
@@ -18,7 +18,7 @@
 #include <boost/simd/detail/dispatch/function/overload.hpp>
 #include <boost/simd/detail/dispatch/meta/as_integer.hpp>
 #include <boost/config.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace simd { namespace ext
 {

--- a/include/boost/simd/arch/common/scalar/function/bitwise_or.hpp
+++ b/include/boost/simd/arch/common/scalar/function/bitwise_or.hpp
@@ -18,7 +18,6 @@
 #include <boost/simd/detail/dispatch/hierarchy.hpp>
 #include <boost/simd/detail/dispatch/meta/as_integer.hpp>
 #include <boost/config.hpp>
-#include <type_traits>
 
 namespace boost { namespace simd { namespace ext
 {

--- a/include/boost/simd/arch/common/scalar/function/bitwise_ornot.hpp
+++ b/include/boost/simd/arch/common/scalar/function/bitwise_ornot.hpp
@@ -18,7 +18,7 @@
 #include <boost/simd/detail/dispatch/function/overload.hpp>
 #include <boost/simd/detail/dispatch/meta/as_integer.hpp>
 #include <boost/config.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace simd { namespace ext
 {

--- a/include/boost/simd/arch/common/scalar/function/bitwise_xor.hpp
+++ b/include/boost/simd/arch/common/scalar/function/bitwise_xor.hpp
@@ -18,7 +18,6 @@
 #include <boost/simd/detail/dispatch/hierarchy.hpp>
 #include <boost/simd/detail/dispatch/meta/as_integer.hpp>
 #include <boost/config.hpp>
-#include <type_traits>
 
 namespace boost { namespace simd { namespace ext
 {

--- a/include/boost/simd/arch/common/scalar/function/ilog2.hpp
+++ b/include/boost/simd/arch/common/scalar/function/ilog2.hpp
@@ -48,7 +48,7 @@ namespace boost { namespace simd { namespace ext
       return impl(a0, typename nsm::bool_<sizeof(A0) <= 4>::type());
     }
 
-    static BOOST_FORCEINLINE A0 impl( A0  a0,  std::true_type const &) BOOST_NOEXCEPT
+    static BOOST_FORCEINLINE A0 impl( A0  a0,  tt::true_type const &) BOOST_NOEXCEPT
     {
       unsigned long index;
       BOOST_VERIFY(::_BitScanReverse(&index, a0));
@@ -56,14 +56,14 @@ namespace boost { namespace simd { namespace ext
     }
 
     #if defined(_WIN64)
-    static BOOST_FORCEINLINE A0 impl(A0 a0, std::false_type const &) BOOST_NOEXCEPT
+    static BOOST_FORCEINLINE A0 impl(A0 a0, tt::false_type const &) BOOST_NOEXCEPT
     {
       unsigned long index;
       BOOST_VERIFY(::_BitScanReverse64(&index, a0));
       return static_cast<A0>(index);
     }
     #else
-    static BOOST_FORCEINLINE A0 impl(A0 a0, std::false_type const &) BOOST_NOEXCEPT
+    static BOOST_FORCEINLINE A0 impl(A0 a0, tt::false_type const &) BOOST_NOEXCEPT
     {
       return static_cast<A0>(sizeof(A0)*8-boost::simd::clz(a0)-1);
     }

--- a/include/boost/simd/arch/common/scalar/function/minus_s.hpp
+++ b/include/boost/simd/arch/common/scalar/function/minus_s.hpp
@@ -53,7 +53,7 @@ namespace boost { namespace simd { namespace ext
     }
 
     static BOOST_FORCEINLINE A0 impl( A0 a0, A0 a1
-                                    , const std::false_type &) BOOST_NOEXCEPT
+                                    , const tt::false_type &) BOOST_NOEXCEPT
     {
       using u_t = bd::upgrade_t<A0>;
       using s_t = bd::as_signed_t<u_t>;
@@ -62,7 +62,7 @@ namespace boost { namespace simd { namespace ext
 
 
     static BOOST_FORCEINLINE A0 impl( A0 a0, A0 a1
-                                    , const std::true_type &) BOOST_NOEXCEPT
+                                    , const tt::true_type &) BOOST_NOEXCEPT
     {
       using un_t = bd::as_unsigned_t<A0>;
 

--- a/include/boost/simd/arch/common/scalar/function/plus_s.hpp
+++ b/include/boost/simd/arch/common/scalar/function/plus_s.hpp
@@ -23,7 +23,6 @@
 #include <boost/simd/detail/dispatch/meta/as_unsigned.hpp>
 #include <boost/simd/detail/dispatch/meta/upgrade.hpp>
 #include <boost/config.hpp>
-#include <type_traits>
 
 namespace boost { namespace simd { namespace ext
 {
@@ -58,14 +57,14 @@ namespace boost { namespace simd { namespace ext
     }
 
     static BOOST_FORCEINLINE A0 impl( A0 a0, A0 a1
-                                    , const std::false_type &) BOOST_NOEXCEPT
+                                    , const tt::false_type &) BOOST_NOEXCEPT
     {
       using utype = bd::upgrade_t<A0>;
       return static_cast<A0>(saturate<A0>(utype(a0)+utype(a1)));
     }
 
     static BOOST_FORCEINLINE A0 impl( A0  a0, A0  a1
-                                    , const std::true_type &) BOOST_NOEXCEPT
+                                    , const tt::true_type &) BOOST_NOEXCEPT
     {
       using utype = bd::as_unsigned_t<A0>;
 
@@ -93,13 +92,13 @@ namespace boost { namespace simd { namespace ext
     }
 
     static BOOST_FORCEINLINE A0 impl( A0 a0, A0 a1
-                                      , const std::false_type &) BOOST_NOEXCEPT
+                                      , const tt::false_type &) BOOST_NOEXCEPT
     {
       typedef typename bd::upgrade<A0>::type utype;
       return static_cast<A0>(boost::simd::min(utype(boost::simd::Valmax<A0>()), utype(a0+a1)));
     }
     static BOOST_FORCEINLINE A0 impl( A0 a0, A0 a1
-                                      , const std::true_type &) BOOST_NOEXCEPT
+                                      , const tt::true_type &) BOOST_NOEXCEPT
     {
       A0 res = a0 + a1;
       res |= -(res < a0);

--- a/include/boost/simd/arch/common/scalar/function/saturate.hpp
+++ b/include/boost/simd/arch/common/scalar/function/saturate.hpp
@@ -44,7 +44,7 @@ namespace boost { namespace simd { namespace ext
     }
 
     BOOST_FORCEINLINE A0 impl( A0 a0
-                                        , const std::true_type &) const BOOST_NOEXCEPT
+                                        , const tt::true_type &) const BOOST_NOEXCEPT
     {
       using starget_t = bd::scalar_of_t<typename T::type>;
       const A0 vma = splat<A0>(Valmax<starget_t>());
@@ -52,7 +52,7 @@ namespace boost { namespace simd { namespace ext
       return (is_inf(a0)? a0: min(vma, max(vmi, a0)));
     }
     BOOST_FORCEINLINE A0 impl( A0 a0
-                                             , const std::false_type &) const BOOST_NOEXCEPT
+                                             , const tt::false_type &) const BOOST_NOEXCEPT
     {
       return a0;
     }
@@ -92,12 +92,12 @@ namespace boost { namespace simd { namespace ext
                    );
     }
     static BOOST_FORCEINLINE A0 impl( A0 a0
-                                        , const std::true_type &) BOOST_NOEXCEPT
+                                        , const tt::true_type &) BOOST_NOEXCEPT
     {
       return a0;
     }
     static BOOST_FORCEINLINE A0 impl( A0 a0
-                                        , const std::false_type &) BOOST_NOEXCEPT
+                                        , const tt::false_type &) BOOST_NOEXCEPT
     {
       using starget_t = bd::scalar_of_t<typename T::type>;
       const A0 vma = splat<A0>(Valmax<starget_t>());
@@ -123,12 +123,12 @@ namespace boost { namespace simd { namespace ext
                    );
     }
     static BOOST_FORCEINLINE A0 impl( A0 a0
-                                        , const std::true_type &) BOOST_NOEXCEPT
+                                        , const tt::true_type &) BOOST_NOEXCEPT
     {
       return max(Zero<A0>(), a0);
     }
     static BOOST_FORCEINLINE A0 impl( A0 a0
-                                        , const std::false_type &) BOOST_NOEXCEPT
+                                        , const tt::false_type &) BOOST_NOEXCEPT
     {
       using starget_t = bd::scalar_of_t<typename T::type>;
       const A0 vma = splat<A0>(Valmax<starget_t>());
@@ -169,12 +169,12 @@ namespace boost { namespace simd { namespace ext
                    );
     }
     static BOOST_FORCEINLINE A0 impl( A0 a0
-                                        , const std::true_type &) BOOST_NOEXCEPT
+                                        , const tt::true_type &) BOOST_NOEXCEPT
     {
       return a0;
     }
     static BOOST_FORCEINLINE A0 impl( A0 a0
-                                        , const std::false_type &) BOOST_NOEXCEPT
+                                        , const tt::false_type &) BOOST_NOEXCEPT
     {
       using starget_t = bd::scalar_of_t<typename T::type>;
       const A0 vma = splat<A0>(Valmax<starget_t>());

--- a/include/boost/simd/arch/common/simd/constant/constant_generator.hpp
+++ b/include/boost/simd/arch/common/simd/constant/constant_generator.hpp
@@ -17,7 +17,7 @@
 #include <boost/simd/detail/dispatch/function/overload.hpp>
 #include <boost/simd/detail/dispatch/as.hpp>
 #include <boost/config.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace simd { namespace ext
 {

--- a/include/boost/simd/arch/common/simd/constant/constant_value.hpp
+++ b/include/boost/simd/arch/common/simd/constant/constant_value.hpp
@@ -17,7 +17,7 @@
 #include <boost/simd/detail/dispatch/function/overload.hpp>
 #include <boost/simd/detail/dispatch/as.hpp>
 #include <boost/config.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace simd { namespace ext
 {

--- a/include/boost/simd/arch/common/simd/function/aligned_load/misaligned.hpp
+++ b/include/boost/simd/arch/common/simd/function/aligned_load/misaligned.hpp
@@ -55,7 +55,7 @@ namespace boost { namespace simd { namespace ext
 
     // Aggregate case: fill in the storage by calling load twice
     template<typename... N> static BOOST_FORCEINLINE
-    target_t do_( Pointer p, Misalignment const&, std::true_type const&
+    target_t do_( Pointer p, Misalignment const&, tt::true_type const&
                 , aggregate_storage const&, nsm::list<N...> const&
                 ) BOOST_NOEXCEPT
     {
@@ -66,7 +66,7 @@ namespace boost { namespace simd { namespace ext
     }
 
     template<typename... N> static BOOST_FORCEINLINE
-    target_t do_( Pointer p, Misalignment const&, std::false_type const&
+    target_t do_( Pointer p, Misalignment const&, tt::false_type const&
                 , aggregate_storage const&, nsm::list<N...> const&
                 ) BOOST_NOEXCEPT
     {
@@ -78,7 +78,7 @@ namespace boost { namespace simd { namespace ext
 
     // Other case: Fill a pack piecewise
     template<typename K, typename... N> static BOOST_FORCEINLINE
-    target_t do_( Pointer p, Misalignment const&, std::true_type const&
+    target_t do_( Pointer p, Misalignment const&, tt::true_type const&
                 , K const&, nsm::list<N...> const&
                 ) BOOST_NOEXCEPT
     {
@@ -86,7 +86,7 @@ namespace boost { namespace simd { namespace ext
     }
 
     template<typename K, typename... N> static BOOST_FORCEINLINE
-    target_t do_( Pointer p, Misalignment const&, std::false_type const&
+    target_t do_( Pointer p, Misalignment const&, tt::false_type const&
                 , K const&, nsm::list<N...> const&
                 ) BOOST_NOEXCEPT
     {

--- a/include/boost/simd/arch/common/simd/function/bitwise_andnot.hpp
+++ b/include/boost/simd/arch/common/simd/function/bitwise_andnot.hpp
@@ -18,7 +18,6 @@
 #include <boost/simd/function/complement.hpp>
 #include <boost/simd/detail/nsm.hpp>
 #include <boost/simd/detail/dispatch/function/overload.hpp>
-#include <type_traits>
 
 namespace boost { namespace simd { namespace ext
 {

--- a/include/boost/simd/arch/common/simd/function/bitwise_cast.hpp
+++ b/include/boost/simd/arch/common/simd/function/bitwise_cast.hpp
@@ -14,7 +14,7 @@
 #include <boost/simd/meta/as_arithmetic.hpp>
 #include <boost/simd/detail/traits.hpp>
 #include <boost/simd/logical.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace simd { namespace ext
 {
@@ -83,14 +83,14 @@ namespace boost { namespace simd { namespace ext
       return do_(a0, typename std::is_same<A0, result_t>::type());
     }
 
-    BOOST_FORCEINLINE result_t do_(A0 const& a0, std::false_type ) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE result_t do_(A0 const& a0, tt::false_type ) const BOOST_NOEXCEPT
     {
       using a_t = bs::as_arithmetic_t<A0>;
       using r_t = bs::as_arithmetic_t<result_t>;
       return bitwise_cast<r_t>(bitwise_cast<a_t>(a0)).storage() ;
     }
 
-    BOOST_FORCEINLINE result_t do_(A0 const& a0, std::true_type const& ) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE result_t do_(A0 const& a0, tt::true_type const& ) const BOOST_NOEXCEPT
     {
       return a0;
     }

--- a/include/boost/simd/arch/common/simd/function/genmask.hpp
+++ b/include/boost/simd/arch/common/simd/function/genmask.hpp
@@ -35,12 +35,12 @@ namespace boost { namespace simd { namespace ext
       return do_(a0, typename is_bitwise_logical<A0>::type{});
     }
 
-    BOOST_FORCEINLINE result_t do_( A0 const& a0, std::true_type const& ) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE result_t do_( A0 const& a0, tt::true_type const& ) const BOOST_NOEXCEPT
     {
       return bitwise_cast<result_t>(a0);
     }
 
-    BOOST_FORCEINLINE result_t do_( A0 const& a0, std::false_type const& ) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE result_t do_( A0 const& a0, tt::false_type const& ) const BOOST_NOEXCEPT
     {
       return if_else(a0, Allbits<result_t>(), result_t(0));
     }

--- a/include/boost/simd/arch/common/simd/function/genmaskc.hpp
+++ b/include/boost/simd/arch/common/simd/function/genmaskc.hpp
@@ -62,12 +62,12 @@ namespace boost { namespace simd { namespace ext
       return do_(a0, typename is_bitwise_logical<A0>::type{});
     }
 
-    BOOST_FORCEINLINE result_t do_( A0 const& a0, std::true_type const& ) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE result_t do_( A0 const& a0, tt::true_type const& ) const BOOST_NOEXCEPT
     {
       return complement(bitwise_cast<result_t>(a0));
     }
 
-    BOOST_FORCEINLINE result_t do_( A0 const& a0, std::false_type const& ) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE result_t do_( A0 const& a0, tt::false_type const& ) const BOOST_NOEXCEPT
     {
       return if_else(a0, result_t(0), Allbits<result_t>());
     }

--- a/include/boost/simd/arch/common/simd/function/if_allbits_else.hpp
+++ b/include/boost/simd/arch/common/simd/function/if_allbits_else.hpp
@@ -34,12 +34,12 @@ namespace boost { namespace simd { namespace ext
       return do_(a0,a1,typename bs::is_bitwise_logical<A0>::type{});
     }
 
-    BOOST_FORCEINLINE A1 do_(A0 const& a0, A1 const& a1, std::true_type const&) const
+    BOOST_FORCEINLINE A1 do_(A0 const& a0, A1 const& a1, tt::true_type const&) const
     {
       return bitwise_or(a1, genmask(a0));
     }
 
-    BOOST_FORCEINLINE A1 do_(A0 const& a0, A1 const& a1, std::false_type const&) const
+    BOOST_FORCEINLINE A1 do_(A0 const& a0, A1 const& a1, tt::false_type const&) const
     {
       return if_else(a0, Allbits<A1>(), a1);
     }

--- a/include/boost/simd/arch/common/simd/function/if_dec.hpp
+++ b/include/boost/simd/arch/common/simd/function/if_dec.hpp
@@ -35,12 +35,12 @@ namespace boost { namespace simd { namespace ext
       return do_(a0,a1,is_bitwise_logical_t<A0>{});
     }
 
-    BOOST_FORCEINLINE A1 do_(const A0& a0, const A1& a1, std::true_type const&) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE A1 do_(const A0& a0, const A1& a1, tt::true_type const&) const BOOST_NOEXCEPT
     {
       return a1 + bitwise_cast<A1>(genmask(a0));
     }
 
-    BOOST_FORCEINLINE A1 do_(const A0& a0, const A1& a1, std::false_type const&) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE A1 do_(const A0& a0, const A1& a1, tt::false_type const&) const BOOST_NOEXCEPT
     {
       return if_minus(a0, a1, One<A1>());
     }

--- a/include/boost/simd/arch/common/simd/function/if_else_allbits.hpp
+++ b/include/boost/simd/arch/common/simd/function/if_else_allbits.hpp
@@ -34,12 +34,12 @@ namespace boost { namespace simd { namespace ext
       return do_(a0,a1,typename bs::is_bitwise_logical<A0>::type{});
     }
 
-    BOOST_FORCEINLINE A1 do_(A0 const& a0, A1 const& a1, std::true_type const&) const
+    BOOST_FORCEINLINE A1 do_(A0 const& a0, A1 const& a1, tt::true_type const&) const
     {
       return bitwise_ornot(a1, genmask(a0));
     }
 
-    BOOST_FORCEINLINE A1 do_(A0 const& a0, A1 const& a1, std::false_type const&) const
+    BOOST_FORCEINLINE A1 do_(A0 const& a0, A1 const& a1, tt::false_type const&) const
     {
       return if_else(a0, a1, Allbits<A1>());
     }

--- a/include/boost/simd/arch/common/simd/function/if_else_zero.hpp
+++ b/include/boost/simd/arch/common/simd/function/if_else_zero.hpp
@@ -34,12 +34,12 @@ namespace boost { namespace simd { namespace ext
       return do_(a0,a1,typename bs::is_bitwise_logical<A0>::type{});
     }
 
-    BOOST_FORCEINLINE A1 do_(A0 const& a0, A1 const& a1, std::true_type const&) const
+    BOOST_FORCEINLINE A1 do_(A0 const& a0, A1 const& a1, tt::true_type const&) const
     {
       return bitwise_and(a1, genmask(a0));
     }
 
-    BOOST_FORCEINLINE A1 do_(A0 const& a0, A1 const& a1, std::false_type const&) const
+    BOOST_FORCEINLINE A1 do_(A0 const& a0, A1 const& a1, tt::false_type const&) const
     {
       return if_else(a0, a1, A1(0));
     }

--- a/include/boost/simd/arch/common/simd/function/if_inc.hpp
+++ b/include/boost/simd/arch/common/simd/function/if_inc.hpp
@@ -35,12 +35,12 @@ namespace boost { namespace simd { namespace ext
       return do_(a0,a1,is_bitwise_logical_t<A0>{});
     }
 
-    BOOST_FORCEINLINE A1 do_(const A0& a0, const A1& a1, std::true_type const&) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE A1 do_(const A0& a0, const A1& a1, tt::true_type const&) const BOOST_NOEXCEPT
     {
       return a1 - bitwise_cast<A1>(genmask(a0));
     }
 
-    BOOST_FORCEINLINE A1 do_(const A0& a0, const A1& a1, std::false_type const&) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE A1 do_(const A0& a0, const A1& a1, tt::false_type const&) const BOOST_NOEXCEPT
     {
       return if_plus(a0, a1, One<A1>());
     }

--- a/include/boost/simd/arch/common/simd/function/if_zero_else.hpp
+++ b/include/boost/simd/arch/common/simd/function/if_zero_else.hpp
@@ -32,12 +32,12 @@ namespace boost { namespace simd { namespace ext
       return do_(a0,a1,typename bs::is_bitwise_logical<A0>::type{});
     }
 
-    BOOST_FORCEINLINE A1 do_(A0 const& a0, A1 const& a1, std::true_type const&) const
+    BOOST_FORCEINLINE A1 do_(A0 const& a0, A1 const& a1, tt::true_type const&) const
     {
       return bitwise_andnot(a1, genmask(a0));
     }
 
-    BOOST_FORCEINLINE A1 do_(A0 const& a0, A1 const& a1, std::false_type const&) const
+    BOOST_FORCEINLINE A1 do_(A0 const& a0, A1 const& a1, tt::false_type const&) const
     {
       return if_else(a0, A1(0), a1);
     }

--- a/include/boost/simd/arch/common/simd/function/ifnot_dec.hpp
+++ b/include/boost/simd/arch/common/simd/function/ifnot_dec.hpp
@@ -30,12 +30,12 @@ namespace boost { namespace simd { namespace ext
       return do_(a0,a1,is_bitwise_logical_t<A0>{});
     }
 
-    BOOST_FORCEINLINE A1 do_(const A0& a0, const A1& a1, std::true_type const&) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE A1 do_(const A0& a0, const A1& a1, tt::true_type const&) const BOOST_NOEXCEPT
     {
       return a1 + bitwise_cast<A1>(genmaskc(a0));
     }
 
-    BOOST_FORCEINLINE A1 do_(const A0& a0, const A1& a1, std::false_type const&) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE A1 do_(const A0& a0, const A1& a1, tt::false_type const&) const BOOST_NOEXCEPT
     {
       return ifnot_minus(a0, a1, One<A1>());
     }

--- a/include/boost/simd/arch/common/simd/function/ifnot_inc.hpp
+++ b/include/boost/simd/arch/common/simd/function/ifnot_inc.hpp
@@ -33,12 +33,12 @@ namespace boost { namespace simd { namespace ext
       return do_(a0,a1,is_bitwise_logical_t<A0>{});
     }
 
-    BOOST_FORCEINLINE A1 do_(const A0& a0, const A1& a1, std::true_type const&) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE A1 do_(const A0& a0, const A1& a1, tt::true_type const&) const BOOST_NOEXCEPT
     {
       return a1 - bitwise_cast<A1>(genmaskc(a0));
     }
 
-    BOOST_FORCEINLINE A1 do_(const A0& a0, const A1& a1, std::false_type const&) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE A1 do_(const A0& a0, const A1& a1, tt::false_type const&) const BOOST_NOEXCEPT
     {
       return ifnot_plus(a0, a1, One<A1>());
     }

--- a/include/boost/simd/arch/common/simd/function/interleave_even.hpp
+++ b/include/boost/simd/arch/common/simd/function/interleave_even.hpp
@@ -32,14 +32,14 @@ namespace boost { namespace simd { namespace ext
 
     template<typename N, typename V>
     static BOOST_FORCEINLINE
-    typename V::value_type value(V const& x, V const&, std::true_type const&)
+    typename V::value_type value(V const& x, V const&, tt::true_type const&)
     {
       return bs::extract<2*(N::value/2)>(x);
     }
 
     template<typename N, typename V>
     static BOOST_FORCEINLINE
-    typename V::value_type value(V const&, V const& y, std::false_type const&)
+    typename V::value_type value(V const&, V const& y, tt::false_type const&)
     {
       return bs::extract<2*(N::value/2)>(y);
     }

--- a/include/boost/simd/arch/common/simd/function/interleave_first.hpp
+++ b/include/boost/simd/arch/common/simd/function/interleave_first.hpp
@@ -30,14 +30,14 @@ namespace boost { namespace simd { namespace ext
   {
     template<typename N, typename V>
     static BOOST_FORCEINLINE
-    typename V::value_type value(V const& x, V const&, std::true_type const&)
+    typename V::value_type value(V const& x, V const&, tt::true_type const&)
     {
       return bs::extract<N::value/2>(x);
     }
 
     template<typename N, typename V>
     static BOOST_FORCEINLINE
-    typename V::value_type value(V const&, V const& y, std::false_type const&)
+    typename V::value_type value(V const&, V const& y, tt::false_type const&)
     {
       return bs::extract<N::value/2>(y);
     }

--- a/include/boost/simd/arch/common/simd/function/interleave_odd.hpp
+++ b/include/boost/simd/arch/common/simd/function/interleave_odd.hpp
@@ -32,14 +32,14 @@ namespace boost { namespace simd { namespace ext
 
     template<typename N, typename V>
     static BOOST_FORCEINLINE
-    typename V::value_type value(V const& x, V const&, std::true_type const&)
+    typename V::value_type value(V const& x, V const&, tt::true_type const&)
     {
       return bs::extract<2*(N::value/2)+1>(x);
     }
 
     template<typename N, typename V>
     static BOOST_FORCEINLINE
-    typename V::value_type value(V const&, V const& y, std::false_type const&)
+    typename V::value_type value(V const&, V const& y, tt::false_type const&)
     {
       return bs::extract<2*(N::value/2)+1>(y);
     }

--- a/include/boost/simd/arch/common/simd/function/interleave_second.hpp
+++ b/include/boost/simd/arch/common/simd/function/interleave_second.hpp
@@ -30,14 +30,14 @@ namespace boost { namespace simd { namespace ext
   {
     template<typename N, typename V>
     static BOOST_FORCEINLINE
-    typename V::value_type value(V const& x, V const&, std::true_type const&)
+    typename V::value_type value(V const& x, V const&, tt::true_type const&)
     {
       return bs::extract<V::static_size/2 + N::value/2>(x);
     }
 
     template<typename N, typename V>
     static BOOST_FORCEINLINE
-    typename V::value_type value(V const&, V const& y, std::false_type const&)
+    typename V::value_type value(V const&, V const& y, tt::false_type const&)
     {
       return bs::extract<V::static_size/2 + N::value/2>(y);
     }

--- a/include/boost/simd/arch/common/simd/function/mask2logical.hpp
+++ b/include/boost/simd/arch/common/simd/function/mask2logical.hpp
@@ -36,12 +36,12 @@ namespace boost { namespace simd { namespace ext
       return do_(a0, typename is_bitwise_logical<A0>::type{});
     }
 
-    BOOST_FORCEINLINE result_t do_(const A0& a0, std::true_type const&) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE result_t do_(const A0& a0, tt::true_type const&) const BOOST_NOEXCEPT
     {
       return bitwise_cast<result_t>(a0);
     }
 
-    BOOST_FORCEINLINE result_t do_(const A0& a0, std::false_type const&) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE result_t do_(const A0& a0, tt::false_type const&) const BOOST_NOEXCEPT
     {
       return a0 != 0;
     }

--- a/include/boost/simd/arch/common/simd/function/shuffle/broadcast.hpp
+++ b/include/boost/simd/arch/common/simd/function/shuffle/broadcast.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd
                                       >
     {};
 
-    template<int P0> struct is_broadcast<P0> : std::false_type {};
+    template<int P0> struct is_broadcast<P0> : tt::false_type {};
   }
 
   // -----------------------------------------------------------------------------------------------

--- a/include/boost/simd/arch/common/simd/function/shuffle/deinterleave.hpp
+++ b/include/boost/simd/arch/common/simd/function/shuffle/deinterleave.hpp
@@ -84,8 +84,8 @@ namespace boost { namespace simd
       using mode = typename find_deinterleave<Ps...>::type;
     };
 
-    template<int P0>         struct is_deinterleave<P0>    : std::false_type {};
-    template<int P0, int P1> struct is_deinterleave<P0,P1> : std::false_type {};
+    template<int P0>         struct is_deinterleave<P0>    : tt::false_type {};
+    template<int P0, int P1> struct is_deinterleave<P0,P1> : tt::false_type {};
   }
 
   // -----------------------------------------------------------------------------------------------

--- a/include/boost/simd/arch/common/simd/function/shuffle/interleave.hpp
+++ b/include/boost/simd/arch/common/simd/function/shuffle/interleave.hpp
@@ -145,8 +145,8 @@ namespace boost { namespace simd
     };
 
     // Do not step on other hierarchies
-    template<int P0>          struct is_interleave<P0>    : std::false_type {};
-    template<int P0, int P1>  struct is_interleave<P0,P1> : std::false_type {};
+    template<int P0>          struct is_interleave<P0>    : tt::false_type {};
+    template<int P0, int P1>  struct is_interleave<P0,P1> : tt::false_type {};
   }
 
   // -----------------------------------------------------------------------------------------------

--- a/include/boost/simd/arch/common/simd/function/shuffle/repeat.hpp
+++ b/include/boost/simd/arch/common/simd/function/shuffle/repeat.hpp
@@ -31,12 +31,12 @@ namespace boost { namespace simd
     {};
 
     // -1 disqualifies already
-    template<int P1, int... Ps> struct  is_repeat<-1,P1,Ps...> : std::false_type {};
+    template<int P1, int... Ps> struct  is_repeat<-1,P1,Ps...> : tt::false_type {};
 
     // Don' overlap with other hierarchies
-    template<int P0>          struct is_repeat<P0>    : std::false_type {};
-    template<int P0, int P1>  struct is_repeat<P0,P1> : std::false_type {};
-    template<int P1>          struct is_repeat<-1,P1> : std::false_type {};
+    template<int P0>          struct is_repeat<P0>    : tt::false_type {};
+    template<int P0, int P1>  struct is_repeat<P0,P1> : tt::false_type {};
+    template<int P1>          struct is_repeat<-1,P1> : tt::false_type {};
   }
 
   // -----------------------------------------------------------------------------------------------

--- a/include/boost/simd/arch/common/simd/function/shuffle/reverse.hpp
+++ b/include/boost/simd/arch/common/simd/function/shuffle/reverse.hpp
@@ -29,7 +29,7 @@ namespace boost { namespace simd
                                 >;
     };
 
-    template<int P0> struct is_reverse<P0> : std::false_type {};
+    template<int P0> struct is_reverse<P0> : tt::false_type {};
   }
 
   // -----------------------------------------------------------------------------------------------

--- a/include/boost/simd/arch/common/simd/function/shuffle/slide.hpp
+++ b/include/boost/simd/arch/common/simd/function/shuffle/slide.hpp
@@ -101,7 +101,7 @@ namespace boost { namespace simd
     };
 
     // Don' overlap with other hierarchies
-    template<int N, int P0> struct is_slide<N,P0>     : std::false_type {};
+    template<int N, int P0> struct is_slide<N,P0>     : tt::false_type {};
   }
 
   // -----------------------------------------------------------------------------------------------

--- a/include/boost/simd/arch/common/simd/function/slide.hpp
+++ b/include/boost/simd/arch/common/simd/function/slide.hpp
@@ -33,12 +33,12 @@ namespace boost { namespace simd { namespace ext
                           , bd::constant_<bd::integer_<Offset>>
                           )
   {
-    static BOOST_FORCEINLINE T do_(T const& a0, std::true_type const&) BOOST_NOEXCEPT
+    static BOOST_FORCEINLINE T do_(T const& a0, tt::true_type const&) BOOST_NOEXCEPT
     {
       return slide<Offset::value>(a0,Zero<T>());
     }
 
-    static BOOST_FORCEINLINE T do_(T const& a0, std::false_type const&) BOOST_NOEXCEPT
+    static BOOST_FORCEINLINE T do_(T const& a0, tt::false_type const&) BOOST_NOEXCEPT
     {
       return slide<Offset::value+T::static_size>(Zero<T>(),a0);
     }
@@ -75,7 +75,7 @@ namespace boost { namespace simd { namespace ext
     // Slide by N is optimized for aggregate storage
     template<typename... L0, typename... L1>
     static BOOST_FORCEINLINE T unroll ( T const& a0, T const& a1, aggregate_storage const&
-                                      , std::true_type const&
+                                      , tt::true_type const&
                                       , nsm::list<L0...> const&, nsm::list<L1...> const&
                                       )
     {
@@ -86,7 +86,7 @@ namespace boost { namespace simd { namespace ext
 
     template<typename... L0, typename... L1>
     static BOOST_FORCEINLINE T unroll ( T const& a0, T const& a1, aggregate_storage const&
-                                      , std::false_type const&
+                                      , tt::false_type const&
                                       , nsm::list<L0...> const&, nsm::list<L1...> const&
                                       )
     {

--- a/include/boost/simd/arch/x86/avx/simd/function/aligned_load.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/aligned_load.hpp
@@ -106,12 +106,12 @@ namespace boost { namespace simd { namespace ext
       return do_(p, nsm::bool_<unalignment != 0>());
     }
 
-    BOOST_FORCEINLINE target do_( Pointer p, std::true_type const& ) const
+    BOOST_FORCEINLINE target do_( Pointer p, tt::true_type const& ) const
     {
       return load<target>(p);
     }
 
-    BOOST_FORCEINLINE target do_( Pointer p, std::false_type const& ) const
+    BOOST_FORCEINLINE target do_( Pointer p, tt::false_type const& ) const
     {
       return aligned_load<target>(p);
     }
@@ -122,7 +122,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_DISPATCH_OVERLOAD ( aligned_load_
                           , (typename Target, typename Pointer)
                           , bs::avx_
-                          , bd::masked_pointer_<bd::scalar_<bd::single_<Pointer>>,std::true_type>
+                          , bd::masked_pointer_<bd::scalar_<bd::single_<Pointer>>,tt::true_type>
                           , bd::target_<bs::pack_<bd::single_<Target>,bs::avx_>>
                           )
   {
@@ -141,7 +141,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_DISPATCH_OVERLOAD ( aligned_load_
                           , (typename Target, typename Pointer)
                           , bs::avx_
-                          , bd::masked_pointer_<bd::scalar_<bd::single_<Pointer>>,std::false_type>
+                          , bd::masked_pointer_<bd::scalar_<bd::single_<Pointer>>,tt::false_type>
                           , bd::target_<bs::pack_<bd::single_<Target>,bs::avx_>>
                           )
   {
@@ -165,7 +165,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_DISPATCH_OVERLOAD ( aligned_load_
                           , (typename Target, typename Pointer)
                           , bs::avx_
-                          , bd::masked_pointer_<bd::scalar_<bd::double_<Pointer>>,std::true_type>
+                          , bd::masked_pointer_<bd::scalar_<bd::double_<Pointer>>,tt::true_type>
                           , bd::target_<bs::pack_<bd::double_<Target>,bs::avx_>>
                           )
   {
@@ -184,7 +184,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_DISPATCH_OVERLOAD ( aligned_load_
                           , (typename Target, typename Pointer)
                           , bs::avx_
-                          , bd::masked_pointer_<bd::scalar_<bd::double_<Pointer>>,std::false_type>
+                          , bd::masked_pointer_<bd::scalar_<bd::double_<Pointer>>,tt::false_type>
                           , bd::target_<bs::pack_<bd::double_<Target>,bs::avx_>>
                           )
   {

--- a/include/boost/simd/arch/x86/avx/simd/function/shuffle/blend.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/shuffle/blend.hpp
@@ -72,17 +72,17 @@ namespace boost { namespace simd
 
     // ---------------------------------------------------------------------------------------------
     // Prevent ambiguity with other hierarchy
-    template<> struct is_blend<-1,-1,-1,-1> : std::false_type {};
-    template<> struct is_blend< 0, 1, 2, 3> : std::false_type {};
-    template<> struct is_blend< 4, 5, 6, 7> : std::false_type {};
-    template<> struct is_blend< 0,-1, 2,-1> : std::false_type {};
-    template<> struct is_blend<-1, 1,-1, 3> : std::false_type {};
+    template<> struct is_blend<-1,-1,-1,-1> : tt::false_type {};
+    template<> struct is_blend< 0, 1, 2, 3> : tt::false_type {};
+    template<> struct is_blend< 4, 5, 6, 7> : tt::false_type {};
+    template<> struct is_blend< 0,-1, 2,-1> : tt::false_type {};
+    template<> struct is_blend<-1, 1,-1, 3> : tt::false_type {};
 
-    template<> struct is_blend<-1,-1,-1,-1,-1,-1,-1,-1> : std::false_type {};
-    template<> struct is_blend< 0, 1, 2, 3, 4, 5, 6, 7> : std::false_type {};
-    template<> struct is_blend< 8, 9,10,11,12,13,14,15> : std::false_type {};
-    template<> struct is_blend< 0,-1, 2,-1, 4,-1, 6,-1> : std::false_type {};
-    template<> struct is_blend<-1, 1,-1, 3,-1, 5,-1, 7> : std::false_type {};
+    template<> struct is_blend<-1,-1,-1,-1,-1,-1,-1,-1> : tt::false_type {};
+    template<> struct is_blend< 0, 1, 2, 3, 4, 5, 6, 7> : tt::false_type {};
+    template<> struct is_blend< 8, 9,10,11,12,13,14,15> : tt::false_type {};
+    template<> struct is_blend< 0,-1, 2,-1, 4,-1, 6,-1> : tt::false_type {};
+    template<> struct is_blend<-1, 1,-1, 3,-1, 5,-1, 7> : tt::false_type {};
 
     // ---------------------------------------------------------------------------------------------
     // Compute the blend mask to use

--- a/include/boost/simd/arch/x86/avx/simd/function/shuffle/perm.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/shuffle/perm.hpp
@@ -47,8 +47,8 @@ namespace boost { namespace simd
       using type = nsm::bool_<!std::is_same<mode, nsm::no_such_type_>::value>;
     };
 
-    template<int P0>         struct is_permute<P0>    : std::false_type {};
-    template<int P0, int P1> struct is_permute<P0,P1> : std::false_type {};
+    template<int P0>         struct is_permute<P0>    : tt::false_type {};
+    template<int P0, int P1> struct is_permute<P0,P1> : tt::false_type {};
 
     // ---------------------------------------------------------------------------------------------
     // AVX permute patterns

--- a/include/boost/simd/arch/x86/avx/simd/function/shuffle/shuffle.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/shuffle/shuffle.hpp
@@ -109,17 +109,17 @@ namespace boost { namespace simd
 
       // Masked binary shuffling
       template<typename T,int... Ps> static BOOST_FORCEINLINE
-      T shuff_(const T& a0, const T & a1, pattern_<Ps...> const& p, std::true_type const&)
+      T shuff_(const T& a0, const T & a1, pattern_<Ps...> const& p, tt::true_type const&)
       {
         using s_t  = typename T::value_type;
         using ui_t = boost::dispatch::as_integer_t<s_t,unsigned>;
-        return  shuff_(a0,a1,p,std::false_type{})
+        return  shuff_(a0,a1,p,tt::false_type{})
               & T ( bitwise_cast<s_t>(zeroing_mask<ui_t,Ps>::value)... );
       }
 
       // Regular binary shuffling
       template<typename T,int... Ps> static BOOST_FORCEINLINE
-      T shuff_(const T& a0, const T & a1, pattern_<Ps...> const&, std::false_type const&)
+      T shuff_(const T& a0, const T & a1, pattern_<Ps...> const&, tt::false_type const&)
       {
         return shuff_(a0, a1, typename avx_topology<Ps...>::type{});
       }

--- a/include/boost/simd/arch/x86/avx/simd/function/shuffle/sse.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/shuffle/sse.hpp
@@ -11,7 +11,7 @@
 
 #include <boost/simd/detail/shuffle.hpp>
 #include <boost/simd/detail/dispatch/meta/as_floating.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace simd { namespace detail
 {
@@ -43,7 +43,7 @@ namespace boost { namespace simd { namespace detail
 
     template<typename T,int P0, int P1>
     static BOOST_FORCEINLINE T do_( T const& a0, pattern_<P0,P1> const&
-                                  , std::true_type const&, std::false_type const&
+                                  , tt::true_type const&, tt::false_type const&
                                   )
     {
       bd::as_floating_t<T> tmp =  _mm_permute_pd( bitwise_cast<bd::as_floating_t<T>>(a0)
@@ -65,7 +65,7 @@ namespace boost { namespace simd { namespace detail
 
     template<typename T, int P0, int P1, int P2, int P3>
     static BOOST_FORCEINLINE T do_( T const& a0, pattern_<P0,P1,P2,P3> const&
-                                  , std::true_type const&, std::false_type const&
+                                  , tt::true_type const&, tt::false_type const&
                                   )
     {
       bd::as_floating_t<T> tmp = _mm_permute_ps( bitwise_cast<bd::as_floating_t<T>>(a0)

--- a/include/boost/simd/arch/x86/avx/simd/function/slide.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/slide.hpp
@@ -387,7 +387,7 @@ namespace boost { namespace simd { namespace ext
   {
     using hcard = tt::integral_constant<int,(T::static_size/2)>;
 
-    static BOOST_FORCEINLINE T unroll( T const& a0, T const& a1, std::true_type const& )
+    static BOOST_FORCEINLINE T unroll( T const& a0, T const& a1, tt::true_type const& )
     {
       auto s0 = slice(a0);
       auto l1 = slice_low(a1);
@@ -396,7 +396,7 @@ namespace boost { namespace simd { namespace ext
                     );
     }
 
-    static BOOST_FORCEINLINE T unroll( T const& a0, T const& a1, std::false_type const& )
+    static BOOST_FORCEINLINE T unroll( T const& a0, T const& a1, tt::false_type const& )
     {
       auto s1 = slice(a1);
       auto h0 = slice_high(a0);

--- a/include/boost/simd/arch/x86/avx2/simd/function/aligned_load.hpp
+++ b/include/boost/simd/arch/x86/avx2/simd/function/aligned_load.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_DISPATCH_OVERLOAD ( aligned_load_
                           , (typename Target, typename Pointer)
                           , bs::avx2_
-                          , bd::masked_pointer_<bd::scalar_<bd::ints32_<Pointer>>,std::true_type>
+                          , bd::masked_pointer_<bd::scalar_<bd::ints32_<Pointer>>,tt::true_type>
                           , bd::target_<bs::pack_<bd::ints32_<Target>,bs::avx_>>
                           )
   {
@@ -48,7 +48,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_DISPATCH_OVERLOAD ( aligned_load_
                           , (typename Target, typename Pointer)
                           , bs::avx2_
-                          , bd::masked_pointer_<bd::scalar_<bd::ints32_<Pointer>>,std::false_type>
+                          , bd::masked_pointer_<bd::scalar_<bd::ints32_<Pointer>>,tt::false_type>
                           , bd::target_<bs::pack_<bd::ints32_<Target>,bs::avx_>>
                           )
   {
@@ -74,7 +74,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_DISPATCH_OVERLOAD ( aligned_load_
                           , (typename Target, typename Pointer)
                           , bs::avx2_
-                          , bd::masked_pointer_<bd::scalar_<bd::ints64_<Pointer>>,std::true_type>
+                          , bd::masked_pointer_<bd::scalar_<bd::ints64_<Pointer>>,tt::true_type>
                           , bd::target_<bs::pack_<bd::ints64_<Target>,bs::avx_>>
                           )
   {
@@ -96,7 +96,7 @@ namespace boost { namespace simd { namespace ext
   BOOST_DISPATCH_OVERLOAD ( aligned_load_
                           , (typename Target, typename Pointer)
                           , bs::avx2_
-                          , bd::masked_pointer_<bd::scalar_<bd::ints64_<Pointer>>,std::false_type>
+                          , bd::masked_pointer_<bd::scalar_<bd::ints64_<Pointer>>,tt::false_type>
                           , bd::target_<bs::pack_<bd::ints64_<Target>,bs::avx_>>
                           )
   {

--- a/include/boost/simd/arch/x86/sse1/simd/function/aligned_load.hpp
+++ b/include/boost/simd/arch/x86/sse1/simd/function/aligned_load.hpp
@@ -69,14 +69,14 @@ namespace boost { namespace simd { namespace ext
       return do_(p, nsm::bool_<unalignment != 0>());
     }
 
-    BOOST_FORCEINLINE target do_( Pointer p, std::true_type const& ) const
+    BOOST_FORCEINLINE target do_( Pointer p, tt::true_type const& ) const
     {
       return slide<unalignment> ( aligned_load<target>( p-unalignment )
                                 , aligned_load<target>( p-unalignment+card )
                                 );
     }
 
-    BOOST_FORCEINLINE target do_( Pointer p, std::false_type const& ) const
+    BOOST_FORCEINLINE target do_( Pointer p, tt::false_type const& ) const
     {
       return aligned_load<target>(p);
     }

--- a/include/boost/simd/arch/x86/sse1/simd/function/topology.hpp
+++ b/include/boost/simd/arch/x86/sse1/simd/function/topology.hpp
@@ -156,17 +156,17 @@ namespace boost { namespace simd { namespace detail
 
     // Regular unary shuffling
     template<typename T,int... Ps> static BOOST_FORCEINLINE
-    T do_(const T& a0, pattern_<Ps...> const&, std::false_type const&)
+    T do_(const T& a0, pattern_<Ps...> const&, tt::false_type const&)
     {
       return _mm_shuffle_ps(a0,a0, mask_ps<Ps...>::value);
     }
 
     // Masked unary shuffling
     template<typename T,int... Ps> static BOOST_FORCEINLINE
-    T do_(const T & a0, pattern_<Ps...> const& p, std::true_type const&)
+    T do_(const T & a0, pattern_<Ps...> const& p, tt::true_type const&)
     {
       using s_t = typename T::value_type;
-      return  do_(a0,p,std::false_type{})
+      return  do_(a0,p,tt::false_type{})
             & T( bitwise_cast<s_t>(zeroing_mask<std::uint32_t,Ps>::value)...);
     }
 
@@ -179,16 +179,16 @@ namespace boost { namespace simd { namespace detail
 
     // Masked binary shuffling
     template<typename T, int... Ps> static BOOST_FORCEINLINE
-    T do_(const T& a0, const T & a1, pattern_<Ps...> const& p, std::true_type const&)
+    T do_(const T& a0, const T & a1, pattern_<Ps...> const& p, tt::true_type const&)
     {
       using s_t = typename T::value_type;
-      return  do_(a0,a1,p,std::false_type{})
+      return  do_(a0,a1,p,tt::false_type{})
             & T( bitwise_cast<s_t>(zeroing_mask<std::uint32_t,Ps>::value)...);
     }
 
     // Regular binary shuffling
     template<typename T, int... Ps> static BOOST_FORCEINLINE
-    T do_(const T& a0, const T & a1, pattern_<Ps...> const&, std::false_type const&)
+    T do_(const T& a0, const T & a1, pattern_<Ps...> const&, tt::false_type const&)
     {
       return do_(a0, a1, typename sse_topology<4,Ps...>::type{});
     }

--- a/include/boost/simd/arch/x86/sse2/pack_traits.hpp
+++ b/include/boost/simd/arch/x86/sse2/pack_traits.hpp
@@ -17,7 +17,7 @@
 #include <boost/config.hpp>
 #include <boost/simd/arch/x86/sse1/pack_traits.hpp>
 #include <boost/simd/detail/pack_traits.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 #if defined __GNUC__ && __GNUC__>=6
 #pragma GCC diagnostic push

--- a/include/boost/simd/arch/x86/sse2/simd/function/slide.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/slide.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace simd { namespace ext
     using bcnt    = tt::integral_constant<std::size_t,16u/T::static_size>;
 
     // slide with positive offset
-    static BOOST_FORCEINLINE T side(T const& a0, std::true_type const&) BOOST_NOEXCEPT
+    static BOOST_FORCEINLINE T side(T const& a0, tt::true_type const&) BOOST_NOEXCEPT
     {
       using imm = tt::integral_constant<std::size_t,Offset::value*bcnt::value>;
       bits_t tmp = _mm_srli_si128(bitwise_cast<bits_t>(a0),imm::value);
@@ -38,7 +38,7 @@ namespace boost { namespace simd { namespace ext
     }
 
     // slide with negative offset
-    static BOOST_FORCEINLINE T side( T const& a0, std::false_type const& ) BOOST_NOEXCEPT
+    static BOOST_FORCEINLINE T side( T const& a0, tt::false_type const& ) BOOST_NOEXCEPT
     {
       using imm = tt::integral_constant<std::size_t,(-Offset::value)*bcnt::value>;
       bits_t tmp = _mm_slli_si128(bitwise_cast<bits_t>(a0),imm::value);

--- a/include/boost/simd/arch/x86/sse2/simd/function/topology.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/topology.hpp
@@ -53,14 +53,14 @@ namespace boost { namespace simd { namespace detail
 
     // Regular unary shuffling - ints32
     template<typename T,int P0,int P1,int P2,int P3> static BOOST_FORCEINLINE
-    T do_(const T& a0, pattern_<P0,P1,P2,P3> const&, std::false_type const&)
+    T do_(const T& a0, pattern_<P0,P1,P2,P3> const&, tt::false_type const&)
     {
       return _mm_shuffle_epi32(a0, (mask_ps<P0,P1,P2,P3>::value));
     }
 
     // Regular unary shuffling -  type64
     template<typename T,int P0,int P1> static BOOST_FORCEINLINE
-    T do_(const T& a0, pattern_<P0,P1> const&, std::false_type const&)
+    T do_(const T& a0, pattern_<P0,P1> const&, tt::false_type const&)
     {
       using f_t = bd::as_floating_t<T>;
       auto const v = bitwise_cast<f_t>(a0);
@@ -69,11 +69,11 @@ namespace boost { namespace simd { namespace detail
 
     // Masked unary shuffling
     template<typename T,int... Ps> static BOOST_FORCEINLINE
-    T do_(const T & a0, pattern_<Ps...> const& p, std::true_type const&)
+    T do_(const T & a0, pattern_<Ps...> const& p, tt::true_type const&)
     {
       using s_t = typename T::value_type;
       using i_t = bd::as_integer_t<s_t,unsigned>;
-      return  do_(a0,p,std::false_type{})
+      return  do_(a0,p,tt::false_type{})
             & T ( bitwise_cast<s_t>(zeroing_mask<i_t,Ps>::value)... );
     }
 
@@ -96,10 +96,10 @@ namespace boost { namespace simd { namespace detail
 
     // Masked binary shuffling
     template<typename T,int P0,int P1> static BOOST_FORCEINLINE
-    T do_(const T& a0, const T & a1, pattern_<P0,P1> const& p, std::true_type const&)
+    T do_(const T& a0, const T & a1, pattern_<P0,P1> const& p, tt::true_type const&)
     {
       using s_t = typename T::value_type;
-      return  do_(a0,a1,p,std::false_type{})
+      return  do_(a0,a1,p,tt::false_type{})
             & T ( bitwise_cast<s_t>(zeroing_mask<std::uint64_t,P0>::value)
                 , bitwise_cast<s_t>(zeroing_mask<std::uint64_t,P1>::value)
                 );
@@ -107,7 +107,7 @@ namespace boost { namespace simd { namespace detail
 
     // Regular binary shuffling
     template<typename T,int P0,int P1> static BOOST_FORCEINLINE
-    T do_(const T& a0, const T & a1, pattern_<P0,P1> const&, std::false_type const&)
+    T do_(const T& a0, const T & a1, pattern_<P0,P1> const&, tt::false_type const&)
     {
       return do_(a0, a1, typename sse_topology<2,P0,P1>::type{});
     }

--- a/include/boost/simd/arch/x86/sse2/supports.hpp
+++ b/include/boost/simd/arch/x86/sse2/supports.hpp
@@ -14,19 +14,20 @@
 namespace boost { namespace simd { namespace detail
 {
   namespace bd = boost::dispatch;
+  namespace tt = nsm::type_traits;
 
   // Some compilers don't provide _mm_set1_epi64x
   template<typename T> struct support_mm_set1_epi64x
   {
     template<typename U>
     static auto test( int ) -> decltype ( _mm_set1_epi64x(bd::detail::declval<U>())
-                                        , std::true_type()
+                                        , tt::true_type()
                                         );
 
     template<typename>
-    static auto test( ... ) -> std::false_type;
+    static auto test( ... ) -> tt::false_type;
 
-    typedef std::is_same<decltype(test<T>(0)),std::true_type> type;
+    typedef std::is_same<decltype(test<T>(0)),tt::true_type> type;
   };
 
   // Some compilers don't provide _mm_set_epi64x
@@ -34,13 +35,13 @@ namespace boost { namespace simd { namespace detail
   {
     template<typename U>
     static auto test( int ) -> decltype ( _mm_set_epi64x(bd::detail::declval<U>(),bd::detail::declval<U>())
-                                        , std::true_type()
+                                        , tt::true_type()
                                         );
 
     template<typename>
-    static auto test( ... ) -> std::false_type;
+    static auto test( ... ) -> tt::false_type;
 
-    typedef std::is_same<decltype(test<T>(0)),std::true_type> type;
+    typedef std::is_same<decltype(test<T>(0)),tt::true_type> type;
   };
 } } }
 

--- a/include/boost/simd/arch/x86/ssse3/simd/function/topology.hpp
+++ b/include/boost/simd/arch/x86/ssse3/simd/function/topology.hpp
@@ -9,7 +9,7 @@
 #ifndef BOOST_SIMD_ARCH_X86_SSSE3_SIMD_FUNCTION_TOPOLOGY_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_X86_SSSE3_SIMD_FUNCTION_TOPOLOGY_HPP_INCLUDED
 
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 #include <boost/simd/detail/shuffle.hpp>
 #include <boost/simd/arch/x86/sse1/simd/function/topology.hpp>
 

--- a/include/boost/simd/detail/aliasing.hpp
+++ b/include/boost/simd/detail/aliasing.hpp
@@ -12,7 +12,7 @@
 #define BOOST_SIMD_DETAIL_ALIASING_HPP_INCLUDED
 
 #include <boost/config.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 #ifndef BOOST_SIMD_NO_STRICT_ALIASING
 

--- a/include/boost/simd/detail/assert_utils.hpp
+++ b/include/boost/simd/detail/assert_utils.hpp
@@ -42,7 +42,7 @@ namespace boost { namespace simd
   }
 
   template<typename A0, typename A1>
-  BOOST_FORCEINLINE bool assert_good_shift( A1 const& t, std::true_type const&)
+  BOOST_FORCEINLINE bool assert_good_shift( A1 const& t, tt::true_type const&)
   {
     for(std::size_t i = 0; i != cardinal_of<A0>::value; ++i)
     {
@@ -58,7 +58,7 @@ namespace boost { namespace simd
   }
 
   template<typename A0, typename A1>
-  BOOST_FORCEINLINE bool assert_good_shift( A1 const& t, std::false_type const&)
+  BOOST_FORCEINLINE bool assert_good_shift( A1 const& t, tt::false_type const&)
   {
     for(std::size_t i = 0; i != cardinal_of<A0>::value; ++i)
     {

--- a/include/boost/simd/detail/diagnostic.hpp
+++ b/include/boost/simd/detail/diagnostic.hpp
@@ -13,7 +13,7 @@
 
 #include <ostream>
 #include <iostream>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 #include <boost/simd/detail/dispatch/detail/declval.hpp>
 
 #if defined(BOOST_SIMD_ENABLE_DIAG)
@@ -34,13 +34,13 @@ class diagnostic
   {
     template <typename U>
     static auto test( int ) -> decltype( std::cout << bd::detail::declval<U>()
-                                       , std::true_type()
+                                       , tt::true_type()
                                        );
 
     template<typename>
-    static auto test( ... ) -> std::false_type;
+    static auto test( ... ) -> tt::false_type;
 
-    using type = typename std::is_same<decltype(test<T>(0)), std::true_type>::type;
+    using type = typename std::is_same<decltype(test<T>(0)), tt::true_type>::type;
   };
 
   template <typename T, typename R>

--- a/include/boost/simd/detail/dispatch/adapted/hierarchy/tuple.hpp
+++ b/include/boost/simd/detail/dispatch/adapted/hierarchy/tuple.hpp
@@ -17,7 +17,6 @@
 #include <boost/simd/detail/dispatch/hierarchy/unspecified.hpp>
 #include <boost/fusion/include/as_vector.hpp>
 #include <boost/simd/detail/nsm.hpp>
-#include <type_traits>
 
 namespace boost { namespace dispatch
 {

--- a/include/boost/simd/detail/dispatch/detail/hierarchy_of.hpp
+++ b/include/boost/simd/detail/dispatch/detail/hierarchy_of.hpp
@@ -16,7 +16,7 @@
 
 #include <boost/simd/detail/dispatch/hierarchy/scalar.hpp>
 #include <boost/simd/detail/dispatch/property_of.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace dispatch { namespace ext
 {

--- a/include/boost/simd/detail/dispatch/detail/is_iterator.hpp
+++ b/include/boost/simd/detail/dispatch/detail/is_iterator.hpp
@@ -16,11 +16,11 @@
 
 namespace boost { namespace dispatch { namespace detail
 {
-  template<typename T, typename EnableIf = void > struct is_iterator : std::false_type {};
+  template<typename T, typename EnableIf = void > struct is_iterator : tt::false_type {};
 
   template<typename T>
   struct is_iterator<T, typename boost::enable_if_has_type<typename T::iterator_category>::type>
-       : std::true_type
+       : tt::true_type
   {};
 } } }
 

--- a/include/boost/simd/detail/dispatch/detail/is_pointer.hpp
+++ b/include/boost/simd/detail/dispatch/detail/is_pointer.hpp
@@ -10,7 +10,6 @@
 #ifndef BOOST_SIMD_DETAIL_DISPATCH_DETAIL_IS_POINTER_HPP_INCLUDED
 #define BOOST_SIMD_DETAIL_DISPATCH_DETAIL_IS_POINTER_HPP_INCLUDED
 
-#include <type_traits>
 #include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace dispatch { namespace detail

--- a/include/boost/simd/detail/dispatch/detail/property_of.hpp
+++ b/include/boost/simd/detail/dispatch/detail/property_of.hpp
@@ -20,7 +20,7 @@
 #include <boost/simd/detail/dispatch/hierarchy/ieee_types.hpp>
 #include <boost/simd/detail/dispatch/hierarchy/void.hpp>
 #include <boost/simd/detail/dispatch/hierarchy/bool.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 #include <climits>
 
 namespace boost { namespace dispatch { namespace ext

--- a/include/boost/simd/detail/dispatch/detail/scalar_of.hpp
+++ b/include/boost/simd/detail/dispatch/detail/scalar_of.hpp
@@ -15,7 +15,7 @@
 #define BOOST_SIMD_DETAIL_DISPATCH_DETAIL_SCALAR_OF_HPP_INCLUDED
 
 #include <boost/simd/detail/dispatch/meta/value_of.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace dispatch
 {

--- a/include/boost/simd/detail/dispatch/detail/updowngrade.hpp
+++ b/include/boost/simd/detail/dispatch/detail/updowngrade.hpp
@@ -20,7 +20,6 @@
 #include <boost/simd/detail/dispatch/meta/make_integer.hpp>
 #include <boost/simd/detail/dispatch/meta/apply_sign.hpp>
 #include <boost/simd/detail/nsm.hpp>
-#include <type_traits>
 
 namespace boost { namespace dispatch { namespace detail
 {

--- a/include/boost/simd/detail/dispatch/detail/value_of.hpp
+++ b/include/boost/simd/detail/dispatch/detail/value_of.hpp
@@ -14,7 +14,7 @@
 #ifndef BOOST_SIMD_DETAIL_DISPATCH_DETAIL_VALUE_OF_HPP_INCLUDED
 #define BOOST_SIMD_DETAIL_DISPATCH_DETAIL_VALUE_OF_HPP_INCLUDED
 
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace dispatch
 {

--- a/include/boost/simd/detail/dispatch/function/overload.hpp
+++ b/include/boost/simd/detail/dispatch/function/overload.hpp
@@ -18,7 +18,7 @@
 #include <boost/preprocessor/tuple/rem.hpp>
 #include <boost/preprocessor/punctuation/remove_parens.hpp>
 #include <boost/config.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 /*!
   @ingroup group-function

--- a/include/boost/simd/detail/dispatch/hierarchy/signed_types.hpp
+++ b/include/boost/simd/detail/dispatch/hierarchy/signed_types.hpp
@@ -17,7 +17,6 @@
 #include <boost/simd/detail/dispatch/hierarchy/integer.hpp>
 #include <boost/simd/detail/dispatch/meta/behave_as.hpp>
 #include <boost/simd/detail/nsm.hpp>
-#include <type_traits>
 
 namespace boost { namespace dispatch
 {

--- a/include/boost/simd/detail/dispatch/hierarchy/sized_types.hpp
+++ b/include/boost/simd/detail/dispatch/hierarchy/sized_types.hpp
@@ -19,7 +19,7 @@
 #include <boost/simd/detail/dispatch/hierarchy/signed_types.hpp>
 #include <boost/simd/detail/dispatch/meta/sign_of.hpp>
 #include <boost/simd/detail/dispatch/meta/behave_as.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 #include <climits>
 #include <cstddef>
 

--- a/include/boost/simd/detail/dispatch/hierarchy_of.hpp
+++ b/include/boost/simd/detail/dispatch/hierarchy_of.hpp
@@ -15,7 +15,7 @@
 #define BOOST_SIMD_DETAIL_DISPATCH_HIERARCHY_OF_HPP_INCLUDED
 
 #include <boost/simd/detail/dispatch/detail/hierarchy_of.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace dispatch
 {

--- a/include/boost/simd/detail/dispatch/meta/as_floating.hpp
+++ b/include/boost/simd/detail/dispatch/meta/as_floating.hpp
@@ -17,7 +17,7 @@
 #include <boost/simd/detail/dispatch/meta/factory_of.hpp>
 #include <boost/simd/detail/dispatch/meta/primitive_of.hpp>
 #include <boost/simd/detail/dispatch/meta/make_floating.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace dispatch
 {

--- a/include/boost/simd/detail/dispatch/meta/as_integer.hpp
+++ b/include/boost/simd/detail/dispatch/meta/as_integer.hpp
@@ -18,7 +18,7 @@
 #include <boost/simd/detail/dispatch/meta/factory_of.hpp>
 #include <boost/simd/detail/dispatch/meta/primitive_of.hpp>
 #include <boost/simd/detail/dispatch/meta/make_integer.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace dispatch
 {

--- a/include/boost/simd/detail/dispatch/meta/as_signed.hpp
+++ b/include/boost/simd/detail/dispatch/meta/as_signed.hpp
@@ -17,7 +17,7 @@
 #include <boost/simd/detail/dispatch/meta/factory_of.hpp>
 #include <boost/simd/detail/dispatch/meta/primitive_of.hpp>
 #include <boost/simd/detail/dispatch/meta/is_natural.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace dispatch
 {

--- a/include/boost/simd/detail/dispatch/meta/as_unsigned.hpp
+++ b/include/boost/simd/detail/dispatch/meta/as_unsigned.hpp
@@ -17,7 +17,7 @@
 #include <boost/simd/detail/dispatch/meta/factory_of.hpp>
 #include <boost/simd/detail/dispatch/meta/primitive_of.hpp>
 #include <boost/simd/detail/dispatch/meta/is_natural.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace dispatch
 {

--- a/include/boost/simd/detail/dispatch/meta/is_homogeneous.hpp
+++ b/include/boost/simd/detail/dispatch/meta/is_homogeneous.hpp
@@ -18,7 +18,6 @@
 #include <boost/fusion/include/as_vector.hpp>
 #include <boost/fusion/include/size.hpp>
 #include <boost/simd/detail/nsm.hpp>
-#include <type_traits>
 #include <tuple>
 
 namespace boost { namespace dispatch
@@ -40,7 +39,7 @@ namespace boost { namespace dispatch
       template<typename T, bool Status> struct impl
       {
         // Empty sequence are not homogeneous
-        using type = std::false_type;
+        using type = tt::false_type;
       };
 
       template<typename T>
@@ -60,13 +59,13 @@ namespace boost { namespace dispatch
     // Special case for std::tuple<>
     template<> struct is_homogeneous_<std::tuple<>>
     {
-      using type = std::false_type;
+      using type = tt::false_type;
     };
 
     // Special case for std::tuple<T>
     template<typename T> struct is_homogeneous_<std::tuple<T>>
     {
-      using type = std::true_type;
+      using type = tt::true_type;
     };
 
     // Special case for std::tuple

--- a/include/boost/simd/detail/dispatch/meta/is_natural.hpp
+++ b/include/boost/simd/detail/dispatch/meta/is_natural.hpp
@@ -15,7 +15,6 @@
 #define BOOST_SIMD_DETAIL_DISPATCH_META_IS_NATURAL_HPP_INCLUDED
 
 #include <boost/simd/detail/nsm.hpp>
-#include <type_traits>
 
 namespace boost { namespace dispatch
 {

--- a/include/boost/simd/detail/dispatch/meta/parent_of.hpp
+++ b/include/boost/simd/detail/dispatch/meta/parent_of.hpp
@@ -15,7 +15,7 @@
 #define BOOST_SIMD_DETAIL_DISPATCH_META_PARENT_OF_HPP_INCLUDED
 
 #include <boost/utility/enable_if.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace dispatch
 {

--- a/include/boost/simd/detail/dispatch/meta/sign_of.hpp
+++ b/include/boost/simd/detail/dispatch/meta/sign_of.hpp
@@ -15,7 +15,7 @@
 #define BOOST_SIMD_DETAIL_DISPATCH_META_SIGN_OF_HPP_INCLUDED
 
 #include <boost/simd/detail/dispatch/meta/primitive_of.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace dispatch
 {

--- a/include/boost/simd/detail/dispatch/meta/transfer_qualifiers.hpp
+++ b/include/boost/simd/detail/dispatch/meta/transfer_qualifiers.hpp
@@ -14,7 +14,7 @@
 #ifndef BOOST_SIMD_DETAIL_DISPATCH_META_TRANSFER_QUALIFIERS_HPP_INCLUDED
 #define BOOST_SIMD_DETAIL_DISPATCH_META_TRANSFER_QUALIFIERS_HPP_INCLUDED
 
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace dispatch
 {

--- a/include/boost/simd/detail/dispatch/models.hpp
+++ b/include/boost/simd/detail/dispatch/models.hpp
@@ -16,21 +16,22 @@
 
 #include <boost/simd/detail/dispatch/hierarchy_of.hpp>
 #include <boost/simd/detail/nsm.hpp>
-#include <type_traits>
 
 namespace boost { namespace dispatch
 {
   namespace detail
   {
+    namespace tt = nsm::type_traits;
+
     template<typename T, typename Hierarchy> struct models
     {
       template<typename U> using hierarchy_t  = nsm::apply<Hierarchy,U>;
 
-      template<typename U> static std::true_type  test( hierarchy_t<U> );
-      template<typename  > static std::false_type test( ... );
+      template<typename U> static tt::true_type  test( hierarchy_t<U> );
+      template<typename  > static tt::false_type test( ... );
 
       using type = typename std::is_same< decltype(test<T>(boost::dispatch::hierarchy_of_t<T>{}))
-                                        , std::true_type
+                                        , tt::true_type
                                         >::type;
     };
   }

--- a/include/boost/simd/detail/dispatch/property_of.hpp
+++ b/include/boost/simd/detail/dispatch/property_of.hpp
@@ -16,7 +16,7 @@
 
 #include <boost/simd/detail/dispatch/meta/scalar_of.hpp>
 #include <boost/simd/detail/dispatch/detail/property_of.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace dispatch
 {

--- a/include/boost/simd/detail/nsm.hpp
+++ b/include/boost/simd/detail/nsm.hpp
@@ -182,10 +182,10 @@ namespace nsm
     {
       struct dummy {};
       template <typename C, typename P>
-      static auto test(P * p) -> decltype(C::at(*p), std::true_type());
+      static auto test(P * p) -> decltype(C::at(*p), type_traits::true_type());
       template <typename, typename>
-      static std::false_type test(...);
-      static const bool value = std::is_same<std::true_type, decltype(test<T, dummy>(nullptr))>::value;
+      static type_traits::false_type test(...);
+      static const bool value = std::is_same<type_traits::true_type, decltype(test<T, dummy>(nullptr))>::value;
     };
 
     template <class L, typename Index, bool>
@@ -236,11 +236,11 @@ namespace nsm
   using _state    = _1;
   using _element = _2;
 
-  template<typename T> struct is_placeholder : std::false_type {};
+  template<typename T> struct is_placeholder : type_traits::false_type {};
   template<std::size_t I>
-  struct is_placeholder< nsm::args<I>> : std::true_type {};
+  struct is_placeholder< nsm::args<I>> : type_traits::true_type {};
 
-  template<typename... T> struct has_placeholders : std::false_type {};
+  template<typename... T> struct has_placeholders : type_traits::false_type {};
   template<typename T> struct has_placeholders<T> : is_placeholder<T> {};
 
   template<template<class...>class T,typename... Ts>
@@ -248,7 +248,7 @@ namespace nsm
 
   template<typename F, typename... T> struct bind;
   template<typename F, typename... T>
-  struct has_placeholders<bind<F,T...>> : std::false_type {};
+  struct has_placeholders<bind<F,T...>> : type_traits::false_type {};
 
   template <bool...> struct checks_ {};
   template<typename T, typename U, typename... Ts>
@@ -987,7 +987,7 @@ namespace nsm
   };
   template<class T>
   struct has_placeholders<protect<T>>
-  : std::false_type
+  : type_traits::false_type
   {};
 
   template<typename C, typename T, typename F>

--- a/include/boost/simd/detail/pack_proxy.hpp
+++ b/include/boost/simd/detail/pack_proxy.hpp
@@ -17,7 +17,7 @@
 #include <boost/simd/detail/dispatch/meta/value_of.hpp>
 #include <boost/simd/detail/dispatch/hierarchy_of.hpp>
 #include <boost/config.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 #include <iostream>
 
 namespace boost { namespace simd { namespace detail

--- a/include/boost/simd/detail/shuffle/default_matcher.hpp
+++ b/include/boost/simd/detail/shuffle/default_matcher.hpp
@@ -90,7 +90,7 @@ namespace boost { namespace simd { namespace detail
     template<typename T, int N>
     BOOST_FORCEINLINE static typename T::value_type
     fill_ ( const T& a0, const T&
-          , tt::integral_constant<int,N> const&, std::true_type const&
+          , tt::integral_constant<int,N> const&, tt::true_type const&
           )
     {
       return  boost::simd::extract<N>(a0);
@@ -99,7 +99,7 @@ namespace boost { namespace simd { namespace detail
     template<typename T>
     BOOST_FORCEINLINE static typename T::value_type
     fill_ ( const T&, const T&
-          , tt::integral_constant<int,-1> const&, std::true_type const&
+          , tt::integral_constant<int,-1> const&, tt::true_type const&
           )
     {
       return 0;
@@ -108,7 +108,7 @@ namespace boost { namespace simd { namespace detail
     template<typename T, int N>
     BOOST_FORCEINLINE static typename T::value_type
     fill_ (const T&, const T & a1
-          , tt::integral_constant<int,N> const&, std::false_type const&
+          , tt::integral_constant<int,N> const&, tt::false_type const&
           )
     {
       return  boost::simd::extract<N-T::static_size>(a1);

--- a/include/boost/simd/detail/storage_of.hpp
+++ b/include/boost/simd/detail/storage_of.hpp
@@ -15,7 +15,6 @@
 #include <boost/simd/detail/as_simd.hpp>
 #include <boost/simd/meta/expected_cardinal.hpp>
 #include <boost/simd/detail/nsm.hpp>
-#include <type_traits>
 #include <array>
 
 #if defined __GNUC__ && __GNUC__>=6

--- a/include/boost/simd/detail/traits.hpp
+++ b/include/boost/simd/detail/traits.hpp
@@ -13,7 +13,7 @@
 
 #include <boost/simd/arch/common/tags.hpp>
 #include <boost/config.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 
 namespace boost { namespace simd { namespace detail
 {

--- a/include/boost/simd/function/detail/slide.hpp
+++ b/include/boost/simd/function/detail/slide.hpp
@@ -41,19 +41,19 @@ namespace boost { namespace simd { namespace detail
     //static BOOST_FORCEINLINE auto call(T const& a0, T const& a1)
     //BOOST_NOEXCEPT_DECLTYPE_BODY(detail::slide(a1,a0,tt::integral_constant<int, Card+N>{}));
 
-    static BOOST_FORCEINLINE auto call(T const& a0, std::false_type const&)
+    static BOOST_FORCEINLINE auto call(T const& a0, tt::false_type const&)
     BOOST_NOEXCEPT_DECLTYPE_BODY(detail::slide(a0,tt::integral_constant<int, N>{}));
 
-    static BOOST_FORCEINLINE T call(T const&, std::true_type const&)
+    static BOOST_FORCEINLINE T call(T const&, tt::true_type const&)
     { return Zero<T>(); }
 
     static BOOST_FORCEINLINE auto call(T const& a0)
     BOOST_NOEXCEPT_DECLTYPE_BODY( call(a0, nsm::bool_<(N==-Card)>{}) );
 
-    static BOOST_FORCEINLINE auto call(T const& a0, T const& a1, std::false_type const&)
+    static BOOST_FORCEINLINE auto call(T const& a0, T const& a1, tt::false_type const&)
     BOOST_NOEXCEPT_DECLTYPE_BODY(detail::slide(a1, a0, tt::integral_constant<int, Card+N>{}));
 
-    static BOOST_FORCEINLINE T call(T const&, T const& a1, std::true_type const&)
+    static BOOST_FORCEINLINE T call(T const&, T const& a1, tt::true_type const&)
     { return a1; }
 
     static BOOST_FORCEINLINE auto call(T const& a0, T const& a1)

--- a/include/boost/simd/meta/is_bitwise_logical.hpp
+++ b/include/boost/simd/meta/is_bitwise_logical.hpp
@@ -16,7 +16,6 @@
 #include <boost/simd/meta/as_logical.hpp>
 #include <boost/simd/meta/as_arithmetic.hpp>
 #include <boost/simd/config.hpp>
-#include <type_traits>
 
 namespace boost { namespace simd
 {

--- a/include/boost/simd/meta/is_iterator.hpp
+++ b/include/boost/simd/meta/is_iterator.hpp
@@ -39,7 +39,7 @@ namespace boost { namespace simd
 #else
     template <typename T> struct is_iterator_impl
     {
-      static std::false_type test(...);
+      static tt::false_type test(...);
 
       template <  typename U
                 , typename=typename std::iterator_traits<U>::difference_type
@@ -47,10 +47,10 @@ namespace boost { namespace simd
                 , typename=typename std::iterator_traits<U>::reference
                 , typename=typename std::iterator_traits<U>::value_type
                 , typename=typename std::iterator_traits<U>::iterator_category
-                > static std::true_type test(U&&);
+                > static tt::true_type test(U&&);
 
       static const bool value = std::is_same< decltype(test(bd::detail::declval<T>()))
-                                            , std::true_type
+                                            , tt::true_type
                                             >::value;
     };
 #endif

--- a/include/boost/simd/meta/is_pointing_to.hpp
+++ b/include/boost/simd/meta/is_pointing_to.hpp
@@ -10,7 +10,7 @@
 #define BOOST_SIMD_META_IS_POINTING_TO_HPP_INCLUDED
 
 #include <boost/pointee.hpp>
-#include <type_traits>
+#include <boost/simd/detail/nsm.hpp>
 #include <iterator>
 
 namespace boost { namespace simd

--- a/test/api/helper/mask.cpp
+++ b/test/api/helper/mask.cpp
@@ -9,10 +9,12 @@
 #include <boost/simd/mask.hpp>
 #include <boost/simd/detail/dispatch/hierarchy_of.hpp>
 #include <boost/pointee.hpp>
+#include <boost/simd/detail/nsm.hpp>
 #include <simd_test.hpp>
 
 using namespace boost::simd;
 using namespace boost::dispatch;
+using namespace nsm;
 
 STF_CASE( "Check masked pointer interface" )
 {
@@ -48,18 +50,18 @@ STF_CASE( "hierarchy_of of masked pointer")
   using zero_c_masked_ptr_t = decltype(m4);
 
   STF_TYPE_IS ( hierarchy_of_t<masked_ptr_t>
-              , (masked_pointer_<hierarchy_of_t<float,masked_ptr_t>, std::false_type>)
+              , (masked_pointer_<hierarchy_of_t<float,masked_ptr_t>, type_traits::false_type>)
               );
 
   STF_TYPE_IS ( hierarchy_of_t<zero_masked_ptr_t>
-              , (masked_pointer_<hierarchy_of_t<float,zero_masked_ptr_t>, std::true_type>)
+              , (masked_pointer_<hierarchy_of_t<float,zero_masked_ptr_t>, type_traits::true_type>)
               );
 
   STF_TYPE_IS ( hierarchy_of_t<c_masked_ptr_t>
-              , (masked_pointer_<hierarchy_of_t<char const,c_masked_ptr_t>, std::false_type>)
+              , (masked_pointer_<hierarchy_of_t<char const,c_masked_ptr_t>, type_traits::false_type>)
               );
 
   STF_TYPE_IS ( hierarchy_of_t<zero_c_masked_ptr_t>
-              , (masked_pointer_<hierarchy_of_t<char const,zero_c_masked_ptr_t>, std::true_type>)
+              , (masked_pointer_<hierarchy_of_t<char const,zero_c_masked_ptr_t>, type_traits::true_type>)
               );
 }

--- a/test/function/simd/bitwise_cast.cpp
+++ b/test/function/simd/bitwise_cast.cpp
@@ -14,9 +14,11 @@
 #include <boost/simd/pack.hpp>
 #include <simd_test.hpp>
 
+namespace bs = boost::simd;
+namespace tt = nsm::type_traits;
+
 STF_CASE( "Check bitwise_cast between integer types" )
 {
-  namespace bs = boost::simd;
   static const std::size_t N = bs::pack<uint16_t>::static_size;
 
   {
@@ -71,7 +73,7 @@ STF_CASE( "Check bitwise_cast between integer & real types" )
   }
 }
 
-template<typename T, typename Env> void logical_test(Env& $, std::true_type const&)
+template<typename T, typename Env> void logical_test(Env& $, tt::true_type const&)
 {
   namespace bs = boost::simd;
   static const std::size_t N = bs::pack<T>::static_size;
@@ -98,7 +100,7 @@ template<typename T, typename Env> void logical_test(Env& $, std::true_type cons
   }
 }
 
-template<typename T, typename Env> void logical_test(Env& $, std::false_type const&)
+template<typename T, typename Env> void logical_test(Env& $, tt::false_type const&)
 {
   STF_PASS("Logical type are not bitwise compatible on this architecture.");
 }
@@ -108,7 +110,7 @@ STF_CASE_TPL( "Check bitwise_cast between arithmetic & logical types", STF_NUMER
   logical_test<T>($, typename boost::simd::is_bitwise_logical<T>::type{});
 }
 
-template<typename Env> void logical_diff_test(Env& $, std::true_type const&)
+template<typename Env> void logical_diff_test(Env& $, tt::true_type const&)
 {
   namespace bs = boost::simd;
   static const std::size_t N = bs::pack<float>::static_size;
@@ -144,7 +146,7 @@ template<typename Env> void logical_diff_test(Env& $, std::true_type const&)
   }
 }
 
-template<typename Env> void logical_diff_test(Env& $, std::false_type const&)
+template<typename Env> void logical_diff_test(Env& $, tt::false_type const&)
 {
   STF_PASS("Logical types are not bitwise compatible on this architecture.");
 }

--- a/test/function/simd/deinterleave.cpp
+++ b/test/function/simd/deinterleave.cpp
@@ -11,13 +11,14 @@
 #include <simd_test.hpp>
 
 namespace bs = boost::simd;
+namespace tt = nsm::type_traits;
 
 template <typename T, int N, typename Env>
-void test(Env&, std::false_type const&)
+void test(Env&, tt::false_type const&)
 {}
 
 template <typename T, int N, typename Env>
-void test(Env& $, std::true_type const& = {})
+void test(Env& $, tt::true_type const& = {})
 {
   using p_t = bs::pack<T, N>;
 

--- a/test/function/simd/deinterleave_first.cpp
+++ b/test/function/simd/deinterleave_first.cpp
@@ -11,13 +11,14 @@
 #include <simd_test.hpp>
 
 namespace bs = boost::simd;
+namespace tt = nsm::type_traits;
 
 template <typename T, int N, typename Env>
-void test(Env&, std::false_type const&)
+void test(Env&, tt::false_type const&)
 {}
 
 template <typename T, int N, typename Env>
-void test(Env& $, std::true_type const& = {})
+void test(Env& $, tt::true_type const& = {})
 {
   using p_t = bs::pack<T, N>;
 

--- a/test/function/simd/deinterleave_second.cpp
+++ b/test/function/simd/deinterleave_second.cpp
@@ -11,13 +11,14 @@
 #include <simd_test.hpp>
 
 namespace bs = boost::simd;
+namespace tt = nsm::type_traits;
 
 template <typename T, int N, typename Env>
-void test(Env&, std::false_type const&)
+void test(Env&, tt::false_type const&)
 {}
 
 template <typename T, int N, typename Env>
-void test(Env& $, std::true_type const& = {})
+void test(Env& $, tt::true_type const& = {})
 {
   using p_t = bs::pack<T, N>;
 

--- a/test/function/simd/group.cpp
+++ b/test/function/simd/group.cpp
@@ -14,13 +14,14 @@
 
 namespace bs = boost::simd;
 namespace bd = boost::dispatch;
+namespace tt = nsm::type_traits;
 
 template<typename T, std::size_t N, typename Env>
-void test( Env&, std::false_type const& )
+void test( Env&, tt::false_type const& )
 {}
 
 template<typename T, std::size_t N, typename Env>
-void test( Env& $, std::true_type const& )
+void test( Env& $, tt::true_type const& )
 {
   using p_t = bs::pack<T, N>;
   using g_t = bd::downgrade_t<p_t>;

--- a/test/function/simd/groups.cpp
+++ b/test/function/simd/groups.cpp
@@ -15,13 +15,14 @@
 
 namespace bs = boost::simd;
 namespace bd = boost::dispatch;
+namespace tt = nsm::type_traits;
 
 template<typename T, std::size_t N, typename Env>
-void test( Env&, std::false_type const& )
+void test( Env&, tt::false_type const& )
 {}
 
 template<typename T, std::size_t N, typename Env>
-void test( Env& $, std::true_type const& )
+void test( Env& $, tt::true_type const& )
 {
   using p_t = bs::pack<T, N>;
   using g_t = bd::downgrade_t<p_t>;

--- a/test/function/simd/interleave.cpp
+++ b/test/function/simd/interleave.cpp
@@ -12,13 +12,14 @@
 #include <simd_test.hpp>
 
 namespace bs = boost::simd;
+namespace tt = nsm::type_traits;
 
 template <typename T, int N, typename Env>
-void test(Env&, std::false_type const&)
+void test(Env&, tt::false_type const&)
 {}
 
 template <typename T, int N, typename Env>
-void test(Env& $, std::true_type const& = {})
+void test(Env& $, tt::true_type const& = {})
 {
   using p_t = bs::pack<T, N>;
 

--- a/test/function/simd/interleave_even.cpp
+++ b/test/function/simd/interleave_even.cpp
@@ -11,12 +11,14 @@
 #include <simd_test.hpp>
 
 namespace bs = boost::simd;
+namespace tt = nsm::type_traits;
+
 template <typename T, int N, typename Env>
-void test(Env&, std::false_type const&)
+void test(Env&, tt::false_type const&)
 {}
 
 template <typename T, int N, typename Env>
-void test(Env& $, std::true_type const& = {})
+void test(Env& $, tt::true_type const& = {})
 {
   using p_t = bs::pack<T, N>;
 

--- a/test/function/simd/interleave_first.cpp
+++ b/test/function/simd/interleave_first.cpp
@@ -11,13 +11,14 @@
 #include <simd_test.hpp>
 
 namespace bs = boost::simd;
+namespace tt = nsm::type_traits;
 
 template <typename T, int N, typename Env>
-void test(Env&, std::false_type const&)
+void test(Env&, tt::false_type const&)
 {}
 
 template <typename T, int N, typename Env>
-void test(Env& $, std::true_type const& = {})
+void test(Env& $, tt::true_type const& = {})
 {
   using p_t = bs::pack<T, N>;
 

--- a/test/function/simd/interleave_odd.cpp
+++ b/test/function/simd/interleave_odd.cpp
@@ -11,13 +11,14 @@
 #include <simd_test.hpp>
 
 namespace bs = boost::simd;
+namespace tt = nsm::type_traits;
 
 template <typename T, int N, typename Env>
-void test(Env&, std::false_type const&)
+void test(Env&, tt::false_type const&)
 {}
 
 template <typename T, int N, typename Env>
-void test(Env& $, std::true_type const& = {})
+void test(Env& $, tt::true_type const& = {})
 {
   using p_t = bs::pack<T, N>;
 

--- a/test/function/simd/interleave_second.cpp
+++ b/test/function/simd/interleave_second.cpp
@@ -11,13 +11,14 @@
 #include <simd_test.hpp>
 
 namespace bs = boost::simd;
+namespace tt = nsm::type_traits;
 
 template <typename T, int N, typename Env>
-void test(Env&, std::false_type const&)
+void test(Env&, tt::false_type const&)
 {}
 
 template <typename T, int N, typename Env>
-void test(Env& $, std::true_type const& = {})
+void test(Env& $, tt::true_type const& = {})
 {
   using p_t = bs::pack<T, N>;
 

--- a/test/function/simd/split/arithmetic.high.cpp
+++ b/test/function/simd/split/arithmetic.high.cpp
@@ -12,13 +12,14 @@
 
 namespace bs = boost::simd;
 namespace bd = boost::dispatch;
+namespace tt = nsm::type_traits;
 
 template<typename T, std::size_t N, typename Env>
-void test( Env&, std::false_type const& )
+void test( Env&, tt::false_type const& )
 {}
 
 template<typename T, std::size_t N, typename Env>
-void test( Env& $, std::true_type const& )
+void test( Env& $, tt::true_type const& )
 {
   using type = bd::upgrade_t<T>;
 

--- a/test/function/simd/split/arithmetic.low.cpp
+++ b/test/function/simd/split/arithmetic.low.cpp
@@ -12,13 +12,14 @@
 
 namespace bs = boost::simd;
 namespace bd = boost::dispatch;
+namespace tt = nsm::type_traits;
 
 template<typename T, std::size_t N, typename Env>
-void test( Env&, std::false_type const& )
+void test( Env&, tt::false_type const& )
 {}
 
 template<typename T, std::size_t N, typename Env>
-void test( Env& $, std::true_type const& )
+void test( Env& $, tt::true_type const& )
 {
   using type = bd::upgrade_t<T>;
 

--- a/test/function/simd/split/arithmetic.pair.cpp
+++ b/test/function/simd/split/arithmetic.pair.cpp
@@ -12,13 +12,14 @@
 
 namespace bs = boost::simd;
 namespace bd = boost::dispatch;
+namespace tt = nsm::type_traits;
 
 template<typename T, std::size_t N, typename Env>
-void test( Env&, std::false_type const& )
+void test( Env&, tt::false_type const& )
 {}
 
 template<typename T, std::size_t N, typename Env>
-void test( Env& $, std::true_type const& )
+void test( Env& $, tt::true_type const& )
 {
   using type = bd::upgrade_t<T>;
 

--- a/test/function/simd/split/logical.high.cpp
+++ b/test/function/simd/split/logical.high.cpp
@@ -13,13 +13,14 @@
 
 namespace bs = boost::simd;
 namespace bd = boost::dispatch;
+namespace tt = nsm::type_traits;
 
 template<typename T, std::size_t N, typename Env>
-void test( Env&, std::false_type const& )
+void test( Env&, tt::false_type const& )
 {}
 
 template<typename T, std::size_t N, typename Env>
-void test( Env& $, std::true_type const& )
+void test( Env& $, tt::true_type const& )
 {
   using type = bd::upgrade_t<bs::logical<T>>;
 

--- a/test/function/simd/split/logical.low.cpp
+++ b/test/function/simd/split/logical.low.cpp
@@ -13,13 +13,14 @@
 
 namespace bs = boost::simd;
 namespace bd = boost::dispatch;
+namespace tt = nsm::type_traits;
 
 template<typename T, std::size_t N, typename Env>
-void test( Env&, std::false_type const& )
+void test( Env&, tt::false_type const& )
 {}
 
 template<typename T, std::size_t N, typename Env>
-void test( Env& $, std::true_type const& )
+void test( Env& $, tt::true_type const& )
 {
   using type = bd::upgrade_t<bs::logical<T>>;
 

--- a/test/function/simd/split/logical.pair.cpp
+++ b/test/function/simd/split/logical.pair.cpp
@@ -13,13 +13,14 @@
 
 namespace bs = boost::simd;
 namespace bd = boost::dispatch;
+namespace tt = nsm::type_traits;
 
 template<typename T, std::size_t N, typename Env>
-void test( Env&, std::false_type const& )
+void test( Env&, tt::false_type const& )
 {}
 
 template<typename T, std::size_t N, typename Env>
-void test( Env& $, std::true_type const& )
+void test( Env& $, tt::true_type const& )
 {
   using type = bd::upgrade_t<bs::logical<T>>;
 

--- a/test/function/simd/split_multiplies.cpp
+++ b/test/function/simd/split_multiplies.cpp
@@ -12,13 +12,14 @@
 
 namespace bs = boost::simd;
 namespace bd = boost::dispatch;
+namespace tt = nsm::type_traits;
 
 template<typename T, std::size_t N, typename Env>
-void test( Env&, std::false_type const& )
+void test( Env&, tt::false_type const& )
 {}
 
 template<typename T, std::size_t N, typename Env>
-void test( Env& $, std::true_type const& )
+void test( Env& $, tt::true_type const& )
 {
   using type = bd::upgrade_t<T>;
 

--- a/test/stf.hpp
+++ b/test/stf.hpp
@@ -22,7 +22,7 @@
 # include <boost/range.hpp>
 
 namespace stf {
- namespace type_traits = boot;
+ namespace type_traits = boost;
  namespace detail {
   using boost::declval;
   using nullptr_t = decltype(nullptr);

--- a/test/stf.hpp
+++ b/test/stf.hpp
@@ -22,10 +22,7 @@
 # include <boost/range.hpp>
 
 namespace stf {
-  namespace rg {
-    using boost::begin;
-    using boost::end;
-  }
+ namespace type_traits = boot;
  namespace detail {
   using boost::declval;
   using nullptr_t = decltype(nullptr);
@@ -45,17 +42,14 @@ namespace stf {
 #else
 # include <utility>
 # include <iterator>
-namespace stf { 
-  namespace rg {
-    using std::begin;
-    using std::end;
-  }
-  namespace detail {
+namespace stf {
+ namespace type_traits = std;
+ namespace detail {
   using std::declval;
   using nullptr_t = std::nullptr_t;
   using std::shuffle;
 #endif
-  }
+ }
 }
 
 namespace stf
@@ -376,11 +370,11 @@ namespace stf { namespace detail
     static auto test( int ) -> decltype ( declval<U>().begin()
                                         , declval<U>().end()
                                         , declval<U>().size()
-                                        , std::true_type()
+                                        , type_traits::true_type()
                                         );
     template<typename>
-    static auto test( ... ) -> std::false_type;
-    typedef std::is_same<decltype(test<T>(0)),std::true_type> type;
+    static auto test( ... ) -> type_traits::false_type;
+    typedef std::is_same<decltype(test<T>(0)),type_traits::true_type> type;
   };
   template <typename T, typename R>
   using if_container = typename std::enable_if<is_container<T>::type::value,R>::type;
@@ -426,11 +420,11 @@ namespace stf { namespace detail
   {
     template<typename U>
     static auto test( int ) -> decltype ( std::cout << declval<U>()
-                                        , std::true_type()
+                                        , type_traits::true_type()
                                         );
     template<typename>
-    static auto test( ... ) -> std::false_type;
-    typedef std::is_same<decltype(test<T>(0)),std::true_type> type;
+    static auto test( ... ) -> type_traits::false_type;
+    typedef std::is_same<decltype(test<T>(0)),type_traits::true_type> type;
   };
   template <typename T, typename R>
   using if_streamable = typename std::enable_if<is_streamable<T>::type::value,R>::type;


### PR DESCRIPTION
This is basically an upgrade to #382, since the boolean constant types derives from the integral_constant type, it is important to pick them in the same namespace for some overload resolution. 