### PR TITLE
aligned_store documentation

### DIFF
--- a/include/boost/simd/function/aligned_store.hpp
+++ b/include/boost/simd/function/aligned_store.hpp
@@ -20,7 +20,7 @@ namespace boost { namespace simd
 
     Store a given value into an aligned memory location referenced by either
     a pointer or a pointer and an offset. To support SIMD idioms like data
-    scattering or non-POD values, both pointer and offset arguments can
+    scattering or non-POD values, both @c Pointer and @c Offset arguments can
     themselves be SIMD register or Fusion Sequences.
 
     @par Semantic:
@@ -84,17 +84,21 @@ namespace boost { namespace simd
     @param offset Optional memory offset.
     @param mask   Optional logical mask. Only stores values for which the mask is true.
   **/
-  template<typename Value, typename Pointer, typename Offset>
-  void aligned_store( Value const& val, Pointer const& ptr, Offset const& offset) {}
+  template<typename Value, typename Pointer, typename Offset, typename Mask>
+  void aligned_store( Value const& val, Pointer const& ptr, Offset const& offset, Mask const& mask) {}
 
-  /// @overload
+  /*!
+   * @overload 
+   */
   template<typename Value, typename Pointer>
   void aligned_store( Value const& val, Pointer ptr) {}
 
-  /// @overload
+  /*!
+   * @overload 
+   */
   template<typename Value, typename Pointer, typename Offset>
   void aligned_store( Value const& val, Pointer const& ptr
-                    , Offset const& offset, Mask const& mask) {}
+                    , Offset const& offset) {}
 
 } }
 #endif


### PR DESCRIPTION
The doxygen @overload command is not supposed to work inside one liner (see [note 2](https://www.stack.nl/~dimitri/doxygen/manual/commands.html#cmdoverload) in Doxygen Doc).
As a result, the "above" function was not above but on another page.

Also, the Mask parameter was missing from the function prototype main documentation, so the prototypes have bben re ordered

Class param coloring and upper case added to the short desc.