### PR TITLE
Duplicate labels in tutorials

### DIFF
--- a/doc/custom/sections/tutorials/tutorial_dot.md
+++ b/doc/custom/sections/tutorials/tutorial_dot.md
@@ -7,7 +7,7 @@ Writing a dot product the SIMD way {#tutorial-dot}
 In this tutorial we will show how data can be processed using **@projectname**
 by writing a naive dot product using **@projectname**.
 
-@section data-objectives Objectives
+@section tutorial-dot-objectives Objectives
 
 -------------------------------------
 

--- a/doc/custom/sections/tutorials/tutorial_mathematical.md
+++ b/doc/custom/sections/tutorials/tutorial_mathematical.md
@@ -7,7 +7,7 @@ Mathematical Functions {#tutorial-mathematical}
 In this tutorial we will demonstrate the use of SIMD mathematical functions
 such as boost::simd::sin and boost::simd::cos.
 
-@section data-objectives Objectives
+@section tutorial-math-objectives Objectives
 
 -------------------------------------
 

--- a/doc/custom/sections/tutorials/tutorial_memory.md
+++ b/doc/custom/sections/tutorials/tutorial_memory.md
@@ -10,7 +10,7 @@ buffers was correctly aligned. Depending on your memory allocator and architectu
 this may not always be true. In this tutorial we will discuss memory alignment
 and demonstrate how to ensure that your memory is always correctly aligned.
 
-@section hello-objectives Objectives
+@section memory-objectives Objectives
 
 -------------------------------------
 

--- a/doc/custom/sections/tutorials/tutorial_nbody.md
+++ b/doc/custom/sections/tutorials/tutorial_nbody.md
@@ -8,7 +8,7 @@ N-Body Problem {#tutorial-nbody}
 In this tutorial we will show you how to optimize an n-body
 simulation using **@projectname**,
 
-@section data-objectives Objectives
+@section tutorial-nbody-objectives Objectives
 
 -------------------------------------
 

--- a/include/boost/simd/function/frexp.hpp
+++ b/include/boost/simd/function/frexp.hpp
@@ -44,7 +44,7 @@ namespace boost { namespace simd
     an exponent \f$e\f$ so that:  \f$x = m\times 2^e\f$,
     with absolute value of \f$m \in [0.5, 1[\f$ (except for \f$x = 0\f$)
 
-    @warninbox{Take care that these results differ from the returns of the functions @ref mantissa
+    @warningbox{Take care that these results differ from the returns of the functions @ref mantissa
     and @ref exponent}
 
     @par Decorators

--- a/include/boost/simd/function/ifrexp.hpp
+++ b/include/boost/simd/function/ifrexp.hpp
@@ -44,7 +44,7 @@ namespace boost { namespace simd
 
     Without the pedantic_ decorator  @ref Nan or @ref Inf are not handled properly.
 
-    @warninbox{Take care that these results differ from the returns of the functions @ref mantissa
+    @warningbox{Take care that these results differ from the returns of the functions @ref mantissa
     and @ref exponent}
 
     @par Decorators


### PR DESCRIPTION
Some section label were duplicates (probably as the result of copy-paste)