### PR TITLE
impl_make_ instantiated with empty Values 

### DIFF
--- a/include/boost/simd/arch/common/simd/function/make.hpp
+++ b/include/boost/simd/arch/common/simd/function/make.hpp
@@ -72,7 +72,7 @@ namespace boost { namespace simd { namespace ext
                             ) BOOST_NOEXCEPT
     {
       using   value_t = typename as_arithmetic_t<Target>::value_type;
-      return  bitwise_cast<Target>( make<as_arithmetic_t<Target>>( genmask<value_t>(vs)...));
+      return  bitwise_cast<Target>( make<as_arithmetic_t<Target>, value_t >( genmask<value_t>(vs)...));
     }
   };
 

--- a/include/boost/simd/arch/common/simd/function/make.hpp
+++ b/include/boost/simd/arch/common/simd/function/make.hpp
@@ -71,8 +71,9 @@ namespace boost { namespace simd { namespace ext
                             , K const&
                             ) BOOST_NOEXCEPT
     {
-      using   value_t = typename as_arithmetic_t<Target>::value_type;
-      return  bitwise_cast<Target>( make<as_arithmetic_t<Target>>( genmask<value_t>(vs)...));
+      using   target_t = as_arithmetic_t<Target>;
+      using   value_t  = typename target_t::value_type;
+      return  bitwise_cast<Target>( detail::make( as_<target_t>{}, genmask<value_t>(vs)...));
     }
   };
 

--- a/include/boost/simd/arch/common/simd/function/make.hpp
+++ b/include/boost/simd/arch/common/simd/function/make.hpp
@@ -72,7 +72,7 @@ namespace boost { namespace simd { namespace ext
                             ) BOOST_NOEXCEPT
     {
       using   value_t = typename as_arithmetic_t<Target>::value_type;
-      return  bitwise_cast<Target>( make<as_arithmetic_t<Target>, value_t >( genmask<value_t>(vs)...));
+      return  bitwise_cast<Target>( make<as_arithmetic_t<Target>>( genmask<value_t>(vs)...));
     }
   };
 

--- a/include/boost/simd/pack.hpp
+++ b/include/boost/simd/pack.hpp
@@ -185,7 +185,7 @@ namespace boost { namespace simd
                    , "pack<T,N>(T v...) must take exactly N arguments"
                    );
 
-      data_ = boost::simd::make<pack,T0,T1,Ts...>(v0,v1,vn...).storage();
+      data_ = boost::simd::make<pack>(v0,v1,vn...).storage();
     }
 
     /*!

--- a/include/boost/simd/pack.hpp
+++ b/include/boost/simd/pack.hpp
@@ -185,7 +185,7 @@ namespace boost { namespace simd
                    , "pack<T,N>(T v...) must take exactly N arguments"
                    );
 
-      data_ = boost::simd::make<pack>(v0,v1,vn...).storage();
+      data_ = boost::simd::detail::make(as_<pack>{},v0,v1,vn...).storage();
     }
 
     /*!

--- a/include/boost/simd/pack.hpp
+++ b/include/boost/simd/pack.hpp
@@ -185,7 +185,7 @@ namespace boost { namespace simd
                    , "pack<T,N>(T v...) must take exactly N arguments"
                    );
 
-      data_ = boost::simd::make<pack>(v0,v1,vn...).storage();
+      data_ = boost::simd::make<pack,T0,T1,Ts...>(v0,v1,vn...).storage();
     }
 
     /*!


### PR DESCRIPTION
With Intel15 (yes, I know...) boost::simd::ext::impl_make_ get easily instantiated with empty values. 
Somehow, it's like the variadic part of the templates gets bound to '<>'....

Helping the compiler by providing a few more templates seems to help getting things done. It is necessary to provide them all, as illustrated in commit b4fa50a.
As a variation to the fix, it would be possible to only add these helping parameters conditionally, as in:
     
`return  bitwise_cast<Target>( make<as_arithmetic_t<Target>, BOOST_SIMD_POOR_VARIADIC_HELPER(value_t) >( genmask<value_t>(vs)...));`

but since the extra parameter do not hurt (providing the template parameters of the make function following the target are actually supposed to be the parameters) and is know at that point anyway, maybe shorter is better.


There are a few places in the code where such a move gets more tests passing, but I'd like to go through with one before I process them.