### PR TITLE
pick is_unsigned from the same namespace as integral_constant

### DIFF
--- a/include/boost/simd/detail/assert_utils.hpp
+++ b/include/boost/simd/detail/assert_utils.hpp
@@ -13,12 +13,15 @@
 #include <boost/simd/function/definition/bitwise_cast.hpp>
 #include <boost/simd/constant/allbits.hpp>
 #include <boost/simd/meta/cardinal_of.hpp>
+#include <boost/simd/detail/nsm.hpp>
 #include <boost/simd/detail/dispatch/meta/scalar_of.hpp>
 #include <boost/simd/detail/dispatch/meta/as_integer.hpp>
 
 namespace boost { namespace simd
 {
   namespace bs = boost::simd;
+  namespace tt = nsm::type_traits;
+
   template<typename T> BOOST_FORCEINLINE bool assert_all( T const& t )
   {
     for(std::size_t i = 0; i != cardinal_of<T>::value; ++i)
@@ -76,7 +79,7 @@ namespace boost { namespace simd
   template<typename A0, typename A1>
   BOOST_FORCEINLINE bool assert_good_shift( A1 const& t )
   {
-    return assert_good_shift<A0>(t, typename std::is_unsigned<dispatch::scalar_of_t<A1>>::type{});
+    return assert_good_shift<A0>(t, typename tt::is_unsigned<dispatch::scalar_of_t<A1>>::type{});
   }
 
 } }


### PR DESCRIPTION
the is_unsigned predicate raises a integral_constant, so we need to pick it from the same librairy (boost or std). This is a follow up to #389 and #382 