### PR TITLE
user literal fixes

### DIFF
--- a/include/boost/simd/literal.hpp
+++ b/include/boost/simd/literal.hpp
@@ -6,8 +6,8 @@
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 **/
 //==================================================================================================
-#ifndef BOOST_SIMD_LITTERALS_HPP_INCLUDED
-#define BOOST_SIMD_LITTERALS_HPP_INCLUDED
+#ifndef BOOST_SIMD_LITERALS_HPP_INCLUDED
+#define BOOST_SIMD_LITERALS_HPP_INCLUDED
 
 #include <boost/simd/detail/nsm.hpp>
 

--- a/test/function/simd/extract/static.arithmetic.cpp
+++ b/test/function/simd/extract/static.arithmetic.cpp
@@ -6,11 +6,15 @@
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 **/
 //==================================================================================================
+#include <boost/config.hpp>
+#include <simd_test.hpp>
+
+#ifndef BOOST_NO_CXX11_USER_DEFINED_LITERALS
+
 #include <boost/simd/function/extract.hpp>
 #include <boost/simd/detail/unroll.hpp>
 #include <boost/simd/litteral.hpp>
 #include <boost/simd/pack.hpp>
-#include <simd_test.hpp>
 #include <array>
 
 namespace bs = boost::simd;
@@ -75,3 +79,14 @@ STF_CASE_TPL("Check extract on pack using literals" , STF_NUMERIC_TYPES)
   test_lt<T, N>($);
   test_lt<T, N*2>($);
 }
+
+#else // BOOST_NO_CXX11_USER_DEFINED_LITERALS
+
+STF_CASE("Cannot check extract on pack using literals")
+{
+  STF_WARNING("User defined literals are not supported on this platform.");
+  STF_PASS("Nothing to run.");
+}
+
+#endif
+

--- a/test/function/simd/extract/static.arithmetic.cpp
+++ b/test/function/simd/extract/static.arithmetic.cpp
@@ -19,8 +19,6 @@
 namespace bs = boost::simd;
 namespace bd = boost::dispatch;
 
-using namespace bs::literal;
-
 template <typename T, std::size_t N, typename Env, typename Idx>
 void unroll_step ( bs::pack<T,N> const& p, std::array<T,N> const& ref, Idx const&, Env& $)
 {
@@ -58,6 +56,8 @@ STF_CASE_TPL("Check static extract on pack" , STF_NUMERIC_TYPES)
 }
 
 #ifndef BOOST_NO_CXX11_USER_DEFINED_LITERALS
+
+using namespace bs::literal;
 
 template <typename T, std::size_t N, typename Env>
 void test_lt(Env& $)

--- a/test/function/simd/extract/static.arithmetic.cpp
+++ b/test/function/simd/extract/static.arithmetic.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/simd/function/extract.hpp>
 #include <boost/simd/detail/unroll.hpp>
-#include <boost/simd/litteral.hpp>
+#include <boost/simd/literal.hpp>
 #include <boost/simd/pack.hpp>
 #include <array>
 

--- a/test/function/simd/extract/static.arithmetic.cpp
+++ b/test/function/simd/extract/static.arithmetic.cpp
@@ -8,12 +8,11 @@
 //==================================================================================================
 #include <boost/config.hpp>
 #include <simd_test.hpp>
-
-#ifndef BOOST_NO_CXX11_USER_DEFINED_LITERALS
-
 #include <boost/simd/function/extract.hpp>
 #include <boost/simd/detail/unroll.hpp>
+#ifndef BOOST_NO_CXX11_USER_DEFINED_LITERALS
 #include <boost/simd/literal.hpp>
+#endif
 #include <boost/simd/pack.hpp>
 #include <array>
 
@@ -58,6 +57,8 @@ STF_CASE_TPL("Check static extract on pack" , STF_NUMERIC_TYPES)
   test_st<T, N*2>($);
 }
 
+#ifndef BOOST_NO_CXX11_USER_DEFINED_LITERALS
+
 template <typename T, std::size_t N, typename Env>
 void test_lt(Env& $)
 {
@@ -80,13 +81,4 @@ STF_CASE_TPL("Check extract on pack using literals" , STF_NUMERIC_TYPES)
   test_lt<T, N*2>($);
 }
 
-#else // BOOST_NO_CXX11_USER_DEFINED_LITERALS
-
-STF_CASE("Cannot check extract on pack using literals")
-{
-  STF_WARNING("User defined literals are not supported on this platform.");
-  STF_PASS("Nothing to run.");
-}
-
-#endif
-
+#endif // !BOOST_NO_CXX11_USER_DEFINED_LITERALS

--- a/test/function/simd/insert/static.arithmetic.cpp
+++ b/test/function/simd/insert/static.arithmetic.cpp
@@ -20,8 +20,6 @@
 namespace bs = boost::simd;
 namespace bd = boost::dispatch;
 
-using namespace bs::literal;
-
 template<typename A, typename P, typename... N>
 void f( nsm::list<N...> const&, A& a, P& p)
 {
@@ -52,6 +50,8 @@ STF_CASE_TPL("Check static insert on pack" , STF_NUMERIC_TYPES)
 }
 
 #ifndef BOOST_NO_CXX11_USER_DEFINED_LITERALS
+
+using namespace bs::literal;
 
 template <typename T, std::size_t N, typename Env>
 void test_lt(Env& $)

--- a/test/function/simd/insert/static.arithmetic.cpp
+++ b/test/function/simd/insert/static.arithmetic.cpp
@@ -8,11 +8,11 @@
 //==================================================================================================
 #include <boost/config.hpp>
 #include <simd_test.hpp>
-
-#ifndef BOOST_NO_CXX11_USER_DEFINED_LITERALS
 #include <boost/simd/function/insert.hpp>
 #include <boost/simd/detail/unroll.hpp>
+#ifndef BOOST_NO_CXX11_USER_DEFINED_LITERALS
 #include <boost/simd/literal.hpp>
+#endif
 #include <boost/simd/pack.hpp>
 #include <simd_test.hpp>
 #include <array>
@@ -51,6 +51,8 @@ STF_CASE_TPL("Check static insert on pack" , STF_NUMERIC_TYPES)
   test_st<T, N*2>($);
 }
 
+#ifndef BOOST_NO_CXX11_USER_DEFINED_LITERALS
+
 template <typename T, std::size_t N, typename Env>
 void test_lt(Env& $)
 {
@@ -80,12 +82,4 @@ STF_CASE_TPL("Check static insert on pack using literals" , STF_NUMERIC_TYPES)
   test_lt<T, N*2>($);
 }
 
-#else // BOOST_NO_CXX11_USER_DEFINED_LITERALS
-
-STF_CASE("Cannot check insert on pack using literals")
-{
-  STF_WARNING("User defined literals are not supported on this platform.");
-  STF_PASS("Nothing to run.");
-}
-
-#endif
+#endif // !BOOST_NO_CXX11_USER_DEFINED_LITERALS

--- a/test/function/simd/insert/static.arithmetic.cpp
+++ b/test/function/simd/insert/static.arithmetic.cpp
@@ -6,9 +6,13 @@
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 **/
 //==================================================================================================
+#include <boost/config.hpp>
+#include <simd_test.hpp>
+
+#ifndef BOOST_NO_CXX11_USER_DEFINED_LITERALS
 #include <boost/simd/function/insert.hpp>
 #include <boost/simd/detail/unroll.hpp>
-#include <boost/simd/litteral.hpp>
+#include <boost/simd/literal.hpp>
 #include <boost/simd/pack.hpp>
 #include <simd_test.hpp>
 #include <array>
@@ -75,3 +79,13 @@ STF_CASE_TPL("Check static insert on pack using literals" , STF_NUMERIC_TYPES)
   test_lt<T, N/2>($);
   test_lt<T, N*2>($);
 }
+
+#else // BOOST_NO_CXX11_USER_DEFINED_LITERALS
+
+STF_CASE("Cannot check insert on pack using literals")
+{
+  STF_WARNING("User defined literals are not supported on this platform.");
+  STF_PASS("Nothing to run.");
+}
+
+#endif


### PR DESCRIPTION
De activate user defined literal test on platforms with no user defined literals.
rename litteral to literal.