### PR TITLE
Pick is_same in the same lib as integral_constant

### DIFF
--- a/include/boost/simd/arch/common/generic/function/saturate.hpp
+++ b/include/boost/simd/arch/common/generic/function/saturate.hpp
@@ -28,6 +28,8 @@ namespace boost { namespace simd { namespace ext
 {
   // floating -> floating
   namespace bd = boost::dispatch;
+namespace tt = nsm::type_traits;
+
   BOOST_DISPATCH_OVERLOAD ( saturate_
                           , (typename A0, typename T)
                           , bd::cpu_
@@ -82,14 +84,14 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE A0 operator() ( A0 const& a0, T const& ) const BOOST_NOEXCEPT
     {
       return impl( a0
-                   , typename nsm::or_< typename std::is_same< bd::scalar_of_t<typename T::type>
-                                                         , bd::scalar_of_t<A0>
-                                                        >::type
-                                           , nsm::bool_< (sizeof(bd::scalar_of_t<typename T::type>)
-                                                             > sizeof(bd::scalar_of_t<A0>))
-                                                           >
-                                          >::type()
-                   );
+                 , typename nsm::or_< typename tt::is_same< bd::scalar_of_t<typename T::type>
+                                                          , bd::scalar_of_t<A0>
+                                                          >::type
+                                     , nsm::bool_< ( sizeof(bd::scalar_of_t<typename T::type>)
+                                                   > sizeof(bd::scalar_of_t<A0>))
+                                                 >
+                                     >::type()
+                 );
     }
     static BOOST_FORCEINLINE A0 impl( A0 const& a0
                                         , const tt::true_type &) BOOST_NOEXCEPT

--- a/include/boost/simd/arch/common/simd/function/bitwise_cast.hpp
+++ b/include/boost/simd/arch/common/simd/function/bitwise_cast.hpp
@@ -18,8 +18,9 @@
 
 namespace boost { namespace simd { namespace ext
 {
- namespace bd = boost::dispatch;
- namespace bs = boost::simd;
+  namespace bd = boost::dispatch;
+  namespace bs = boost::simd;
+  namespace tt = nsm::type_traits;
 
   BOOST_DISPATCH_OVERLOAD_IF ( bitwise_cast_
                              , (typename A0, typename A1, typename X)
@@ -80,7 +81,7 @@ namespace boost { namespace simd { namespace ext
 
     BOOST_FORCEINLINE result_t operator()(A0 const& a0, A1 const& ) const BOOST_NOEXCEPT
     {
-      return do_(a0, typename std::is_same<A0, result_t>::type());
+      return do_(a0, typename tt::is_same<A0, result_t>::type());
     }
 
     BOOST_FORCEINLINE result_t do_(A0 const& a0, tt::false_type ) const BOOST_NOEXCEPT


### PR DESCRIPTION
If we don't, some overload won't be resolved as **is_same<...>** will end up as a **integral_constant**.