### PR TITLE
Auto in multiple declaration

### DIFF
--- a/include/boost/simd/arch/x86/sse2/simd/function/deinterleave_first.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/deinterleave_first.hpp
@@ -38,8 +38,8 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE A0 operator()(const A0 & a0, const A0 & a1 ) const BOOST_NOEXCEPT
     {
-      auto const  x = _mm_unpacklo_epi16(a0,a1)
-                , y = _mm_unpackhi_epi16(a0,a1);
+      auto const  x = _mm_unpacklo_epi16(a0,a1);
+      auto const  y = _mm_unpackhi_epi16(a0,a1);
 
       return _mm_unpacklo_epi16 ( _mm_unpacklo_epi16(x,y)
                                 , _mm_unpackhi_epi16(x,y)

--- a/include/boost/simd/arch/x86/sse2/simd/function/deinterleave_second.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/deinterleave_second.hpp
@@ -39,8 +39,8 @@ namespace boost { namespace simd { namespace ext
     BOOST_FORCEINLINE A0 operator()(const A0 & a0, const A0 & a1 ) const BOOST_NOEXCEPT
     {
       auto const  x = _mm_unpacklo_epi16(a0,a1)
-                , y = _mm_unpackhi_epi16(a0,a1);
-
+      auto const  y = _mm_unpackhi_epi16(a0,a1);
+      
       return _mm_unpackhi_epi16 ( _mm_unpacklo_epi16(x,y)
                                 , _mm_unpackhi_epi16(x,y)
                                 );

--- a/include/boost/simd/arch/x86/sse2/simd/function/deinterleave_second.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/deinterleave_second.hpp
@@ -38,7 +38,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE A0 operator()(const A0 & a0, const A0 & a1 ) const BOOST_NOEXCEPT
     {
-      auto const  x = _mm_unpacklo_epi16(a0,a1)
+      auto const  x = _mm_unpacklo_epi16(a0,a1);
       auto const  y = _mm_unpackhi_epi16(a0,a1);
       
       return _mm_unpackhi_epi16 ( _mm_unpacklo_epi16(x,y)


### PR DESCRIPTION
That usage of auto seems non conforming (intel warning) as a single 'auto' cannot be used to both deduce and specify a type.