### PR TITLE
Fix undefined BOOST_SIMD_DEFAULT_SITE whenever no simd has been found

### DIFF
--- a/include/boost/simd/arch/common/spec.hpp
+++ b/include/boost/simd/arch/common/spec.hpp
@@ -17,11 +17,9 @@
 #include <boost/simd/detail/predef.hpp>
 
 #if !defined(BOOST_SIMD_DEFAULT_FAMILY)
-  #if !defined(BOOST_HW_SIMD_AVAILABLE)
-    #define BOOST_SIMD_DEFAULT_FAMILY ::boost::simd::simd_emulation_
-    #define BOOST_SIMD_DEFAULT_SITE   ::boost::dispatch::cpu_
-    #define BOOST_SIMD_STRICT_EMULATION
-  #endif
+  #define BOOST_SIMD_DEFAULT_FAMILY ::boost::simd::simd_emulation_
+  #define BOOST_SIMD_DEFAULT_SITE   ::boost::dispatch::cpu_
+  #define BOOST_SIMD_STRICT_EMULATION
 #endif
 
 // Used as fallbacks for generic cases


### PR DESCRIPTION
The strict emulation site was unreachable whenever any BOOST_HW_SIMD_*
was defined but not caught by boost.simd (this is currently the case on
non-x86 architectures), in that case BOOST_HW_SIMD_AVAILABLE is defined
making the most-inner #if unreachable.