### PR TITLE
Explicit make

### DIFF
--- a/include/boost/simd/arch/common/simd/function/combine.hpp
+++ b/include/boost/simd/arch/common/simd/function/combine.hpp
@@ -33,7 +33,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE pack<T,2> operator()(T const& a, T const& b) const BOOST_NOEXCEPT
     {
-      return detail::make(as_<pack<T,2>>{}, a,b);
+      return make(as_<pack<T,2>>{}, a,b);
     }
   };
 
@@ -61,10 +61,10 @@ namespace boost { namespace simd { namespace ext
                                           , nsm::list<N...> const&
                                           ) BOOST_NOEXCEPT
     {
-      return detail::make(as_<result_t>{}
-                          , bs::extract<N::value>(a)...
-                          , bs::extract<N::value>(b)...
-                          );
+      return make(as_<result_t>{}
+                 , bs::extract<N::value>(a)...
+                 , bs::extract<N::value>(b)...
+                 );
     }
 
     BOOST_FORCEINLINE result_t operator()(T const& a, T const& b) const BOOST_NOEXCEPT

--- a/include/boost/simd/arch/common/simd/function/deinterleave_first.hpp
+++ b/include/boost/simd/arch/common/simd/function/deinterleave_first.hpp
@@ -35,7 +35,7 @@ namespace boost { namespace simd { namespace ext
     template<typename K, typename... N> static BOOST_FORCEINLINE
     T do_( T const& x, T const& y, K const&, nsm::list<N...> const&) BOOST_NOEXCEPT
     {
-      return make<T>( bs::extract<N::value*2>(x)..., bs::extract<N::value*2>(y)... );
+      return make( as_<T>{}, bs::extract<N::value*2>(x)..., bs::extract<N::value*2>(y)... );
     }
 
     template<typename N0, typename N1, typename... Ns> static BOOST_FORCEINLINE

--- a/include/boost/simd/arch/common/simd/function/deinterleave_second.hpp
+++ b/include/boost/simd/arch/common/simd/function/deinterleave_second.hpp
@@ -1,3 +1,4 @@
+\
 //==================================================================================================
 /**
   Copyright 2016 NumScale SAS
@@ -33,7 +34,7 @@ namespace boost { namespace simd { namespace ext
     template<typename K, typename... N> static BOOST_FORCEINLINE
     T do_( T const& x, T const& y, K const&, nsm::list<N...> const&) BOOST_NOEXCEPT
     {
-      return make<T>( bs::extract<N::value*2+1>(x)..., bs::extract<N::value*2+1>(y)... );
+      return make(as_<T>{}, bs::extract<N::value*2+1>(x)..., bs::extract<N::value*2+1>(y)... );
     }
 
     template<typename N0, typename N1, typename... Ns> static BOOST_FORCEINLINE

--- a/include/boost/simd/arch/common/simd/function/enumerate.hpp
+++ b/include/boost/simd/arch/common/simd/function/enumerate.hpp
@@ -33,7 +33,7 @@ namespace boost { namespace simd { namespace ext
     template<typename... N>
     static BOOST_FORCEINLINE typename T::type do_( nsm::list<N...> const& ) BOOST_NOEXCEPT
     {
-      return detail::make(as_<typename T::type>{}, N::value...);
+      return make(as_<typename T::type>{}, N::value...);
     }
   };
 

--- a/include/boost/simd/arch/common/simd/function/make.hpp
+++ b/include/boost/simd/arch/common/simd/function/make.hpp
@@ -73,7 +73,7 @@ namespace boost { namespace simd { namespace ext
     {
       using   target_t = as_arithmetic_t<Target>;
       using   value_t  = typename target_t::value_type;
-      return  bitwise_cast<Target>( detail::make( as_<target_t>{}, genmask<value_t>(vs)...));
+      return  bitwise_cast<Target>( make( as_<target_t>{}, genmask<value_t>(vs)...));
     }
   };
 

--- a/include/boost/simd/arch/common/simd/function/slice_high.hpp
+++ b/include/boost/simd/arch/common/simd/function/slice_high.hpp
@@ -42,7 +42,7 @@ namespace boost { namespace simd { namespace ext
     static BOOST_FORCEINLINE
     result_t do_( T const& a, K const&, nsm::list<N...> const&) BOOST_NOEXCEPT
     {
-      return  detail::make(as_<result_t>{}, bs::extract<N::value>(a)... );
+      return  make(as_<result_t>{}, bs::extract<N::value>(a)... );
     }
 
     BOOST_FORCEINLINE result_t operator()(T const& a) const BOOST_NOEXCEPT

--- a/include/boost/simd/arch/common/simd/function/slice_low.hpp
+++ b/include/boost/simd/arch/common/simd/function/slice_low.hpp
@@ -42,7 +42,7 @@ namespace boost { namespace simd { namespace ext
     static BOOST_FORCEINLINE
     result_t do_( T const& a, K const&, nsm::list<N...> const&) BOOST_NOEXCEPT
     {
-      return  detail::make(as_<result_t>{}, bs::extract<N::value>(a)... );
+      return  make(as_<result_t>{}, bs::extract<N::value>(a)... );
     }
 
     BOOST_FORCEINLINE result_t operator()(T const& a) const BOOST_NOEXCEPT

--- a/include/boost/simd/function/definition/make.hpp
+++ b/include/boost/simd/function/definition/make.hpp
@@ -39,6 +39,12 @@ namespace boost { namespace simd
   {
     return detail::make(as_<Target>(), args... );
   }
+  
+  template<typename Target, typename... Args> auto make(as_<Target> const& tgt, Args const&... args)
+  BOOST_NOEXCEPT_DECLTYPE(detail::make(tgt, args... ))
+  {
+    return detail::make(tgt, args... );
+}
 } }
 
 #endif

--- a/include/boost/simd/function/definition/make.hpp
+++ b/include/boost/simd/function/definition/make.hpp
@@ -44,7 +44,7 @@ namespace boost { namespace simd
   BOOST_NOEXCEPT_DECLTYPE(detail::make(tgt, args... ))
   {
     return detail::make(tgt, args... );
-}
+  }
 } }
 
 #endif

--- a/include/boost/simd/function/make.hpp
+++ b/include/boost/simd/function/make.hpp
@@ -44,6 +44,11 @@ namespace boost { namespace simd
     @return A value of type @c T built from each args.
   **/
   template<typename T, typename.. Args> T make(Args const&... args);
+  
+  /*!
+    @overload
+  **/
+  template<typename Target, typename.. Value> T make(as_<Target> const& t, Value const&... args);
 } }
 #endif
 

--- a/include/boost/simd/pack.hpp
+++ b/include/boost/simd/pack.hpp
@@ -185,7 +185,7 @@ namespace boost { namespace simd
                    , "pack<T,N>(T v...) must take exactly N arguments"
                    );
 
-      data_ = boost::simd::detail::make(as_<pack>{},v0,v1,vn...).storage();
+      data_ = boost::simd::make(as_<pack>{},v0,v1,vn...).storage();
     }
 
     /*!

--- a/test/function/simd/make/arithmetic.cpp
+++ b/test/function/simd/make/arithmetic.cpp
@@ -74,47 +74,47 @@ STF_CASE_TPL( "Check make(a0,...,a31)", STF_NUMERIC_TYPES )
 
 // These must work anyway
 
-STF_CASE_TPL( "Check detail::make(a0,a1)", STF_NUMERIC_TYPES )
+STF_CASE_TPL( "Check make(a0,a1)", STF_NUMERIC_TYPES )
 {
   namespace bs = boost::simd;
 
   std::array<T,2> ref = {{ T(1), T(2) }};
-  auto p = bs::detail::make(bs::as_<bs::pack<T,2>>{},1,2);
+  auto p = bs::make(bs::as_<bs::pack<T,2>>{},1,2);
 
   STF_ALL_EQUAL(p, ref);
 }
 
-STF_CASE_TPL( "Check detail::make(a0,...,a3)", STF_NUMERIC_TYPES )
+STF_CASE_TPL( "Check make(as_<tag>{},a0,...,a3)", STF_NUMERIC_TYPES )
 {
   namespace bs = boost::simd;
 
   std::array<T,4> ref = {{ T(1), T(2), T(3), T(4) }};
-  auto p = bs::detail::make(bs::as_<bs::pack<T,4>>{},1,2,3,4);
+  auto p = bs::make(bs::as_<bs::pack<T,4>>{},1,2,3,4);
 
   STF_ALL_EQUAL(p, ref);
 }
 
-STF_CASE_TPL( "Check detail::make(a0,...,a7)", STF_NUMERIC_TYPES )
+STF_CASE_TPL( "Check make(as_<tag>{}a0,...,a7)", STF_NUMERIC_TYPES )
 {
   namespace bs = boost::simd;
   std::array<T,8> ref = {{ T(1), T(2), T(3), T(4), T(5), T(6), T(7), T(8) }};
-  auto p = bs::detail::make(bs::as_<bs::pack<T,8>>{},1,2,3,4,5,6,7,8);
+  auto p = bs::make(bs::as_<bs::pack<T,8>>{},1,2,3,4,5,6,7,8);
 
   STF_ALL_EQUAL(p, ref);
 }
 
-STF_CASE_TPL( "Check detail::make(a0,...,a15)", STF_NUMERIC_TYPES )
+STF_CASE_TPL( "Check make(as_<tag>{},a0,...,a15)", STF_NUMERIC_TYPES )
 {
   namespace bs = boost::simd;
   std::array<T,16> ref  = {{  T(1), T(2) , T(3) , T(4) , T(5) , T(6) , T(7) , T(8)
                           ,   T(9), T(10), T(11), T(12), T(13), T(14), T(15), T(16)
                           }};
-  auto p = bs::detail::make(bs::as_<bs::pack<T,16>>{},1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
+  auto p = bs::make(bs::as_<bs::pack<T,16>>{},1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
 
   STF_ALL_EQUAL(p, ref);
 }
 
-STF_CASE_TPL( "Check detail::make(a0,...,a31)", STF_NUMERIC_TYPES )
+STF_CASE_TPL( "Check make(as_<tag>{},a0,...,a31)", STF_NUMERIC_TYPES )
 {
   namespace bs = boost::simd;
   std::array<T,32> ref  = {{  T(1) , T(2) , T(3) , T(4) , T(5) , T(6) , T(7) , T(8)
@@ -122,10 +122,10 @@ STF_CASE_TPL( "Check detail::make(a0,...,a31)", STF_NUMERIC_TYPES )
                           ,   T(17), T(18), T(19), T(20), T(21), T(22), T(23), T(24)
                           ,   T(25), T(26), T(27), T(28), T(29), T(30), T(31), T(32)
                           }};
-  auto p = bs::detail::make(bs::as_<bs::pack<T,32>>{}
-                            , 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15,16
-                            ,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32
-                            );
+  auto p = bs::make(bs::as_<bs::pack<T,32>>{}
+                   , 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15,16
+                   ,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32
+                   );
 
   STF_ALL_EQUAL(p, ref);
 }

--- a/test/function/simd/make/logical.cpp
+++ b/test/function/simd/make/logical.cpp
@@ -83,51 +83,51 @@ STF_CASE_TPL( "Check make(a0,...,a31)", STF_NUMERIC_TYPES )
 
 // These must work anyway
 
-STF_CASE_TPL( "Check detail::make(a0,a1)", STF_NUMERIC_TYPES )
+STF_CASE_TPL( "Check make(as_<tag>{},a0,a1)", STF_NUMERIC_TYPES )
 {
   namespace bs = boost::simd;
   std::array<bs::logical<T>,2> ref = {{ true,false }};
-  auto p = bs::detail::make(bs::as_<bs::pack<bs::logical<T>,2>>{}, true,false);
+  auto p = bs::make(bs::as_<bs::pack<bs::logical<T>,2>>{}, true,false);
 
   STF_ALL_EQUAL(p, ref);
 }
 
-STF_CASE_TPL( "Check detail::make(a0,...,a3)", STF_NUMERIC_TYPES )
+STF_CASE_TPL( "Check make(as_<tag>{},a0,...,a3)", STF_NUMERIC_TYPES )
 {
   namespace bs = boost::simd;
 
   std::array<bs::logical<T>,4> ref = {{ true,false,false,true }};
-  auto p = bs::detail::make(bs::as_<bs::pack<bs::logical<T>,4>>{}, true,false,false,true);
+  auto p = bs::make(bs::as_<bs::pack<bs::logical<T>,4>>{}, true,false,false,true);
 
   STF_ALL_EQUAL(p, ref);
 }
 
-STF_CASE_TPL( "Check detail::make(a0,...,a7)", STF_NUMERIC_TYPES )
+STF_CASE_TPL( "Check make(as_<tag>{},a0,...,a7)", STF_NUMERIC_TYPES )
 {
   namespace bs = boost::simd;
 
   std::array<bs::logical<T>,8> ref = {{ true,false,false,true,true,false,false,true }};
-  auto p = bs::detail::make(bs::as_<bs::pack<bs::logical<T>,8>>{},true,false,false,true,true,false,false,true);
+  auto p = bs::make(bs::as_<bs::pack<bs::logical<T>,8>>{},true,false,false,true,true,false,false,true);
 
   STF_ALL_EQUAL(p, ref);
 }
 
-STF_CASE_TPL( "Check detail::make(a0,...,a15)", STF_NUMERIC_TYPES )
+STF_CASE_TPL( "Check make(as_<tag>{},a0,...,a15)", STF_NUMERIC_TYPES )
 {
   namespace bs = boost::simd;
   std::array<bs::logical<T>,16> ref  =  {{  true,false,false,true,true,false,false,true
                                         ,   true,false,false,true,true,false,false,true
                                         }};
 
-  auto p = bs::detail::make(bs::as_< bs::pack<bs::logical<T>,16> >{}
-                            , true,false,false,true,true,false,false,true
-                            , true,false,false,true,true,false,false,true
-                    );
+  auto p = bs::make(bs::as_< bs::pack<bs::logical<T>,16> >{}
+                   , true,false,false,true,true,false,false,true
+                   , true,false,false,true,true,false,false,true
+                   );
   
   STF_ALL_EQUAL(p, ref);
 }
 
-STF_CASE_TPL( "Check detail::make(a0,...,a31)", STF_NUMERIC_TYPES )
+STF_CASE_TPL( "Check make(as_<tag>{},a0,...,a31)", STF_NUMERIC_TYPES )
 {
   namespace bs = boost::simd;
   std::array<bs::logical<T>,32> ref = {{  true,false,false,true,true,false,false,true
@@ -136,7 +136,7 @@ STF_CASE_TPL( "Check detail::make(a0,...,a31)", STF_NUMERIC_TYPES )
                                       ,   true,false,false,true,true,false,false,true
                                       }};
 
-  auto p = bs::detail::make(bs::as_< bs::pack<bs::logical<T>,32> >{}
+  auto p = bs::make(bs::as_< bs::pack<bs::logical<T>,32> >{}
                     , true,false,false,true,true,false,false,true
                     , true,false,false,true,true,false,false,true
                     , true,false,false,true,true,false,false,true


### PR DESCRIPTION
All the make usages have been modified to use the new explicit one in simd namespace.
84% of the tests passes.