### PR TITLE
Avoid truncation warning on sizeof...

### DIFF
--- a/include/boost/simd/arch/common/simd/function/shuffle/repeat.hpp
+++ b/include/boost/simd/arch/common/simd/function/shuffle/repeat.hpp
@@ -24,9 +24,9 @@ namespace boost { namespace simd
     template<int P0, int... Ps>
     struct  is_repeat
           : std::is_same< nsm::integral_list<int,P0,Ps...>
-                        , nsm::append < nsm::range<int,P0,P0+(sizeof...(Ps)+1)/2>
-                                          , nsm::range<int,P0,P0+(sizeof...(Ps)+1)/2>
-                                          >
+                        , nsm::append < nsm::range<int,P0,P0+int(sizeof...(Ps)+1)/2>
+                                      , nsm::range<int,P0,P0+int(sizeof...(Ps)+1)/2>
+                                      >
                         >
     {};
 


### PR DESCRIPTION
I guess the warning was due to the fact that **sizeof...** is unsigned.