### PR TITLE
shuffle and intel15

### DIFF
--- a/include/boost/simd/detail/shuffle/helpers.hpp
+++ b/include/boost/simd/detail/shuffle/helpers.hpp
@@ -39,8 +39,9 @@ namespace boost { namespace simd { namespace detail
   template<int... Is>
   struct side<pattern_<Is...>>
   {
-    using idx_a0 = nsm::integral_list<bool,  (Is <  int(sizeof...(Is)))...              >;
-    using idx_a1 = nsm::integral_list<bool, ((Is >= int(sizeof...(Is))) || (Is==-1))... >;
+    static int const size = int(sizeof...(Is));
+    using idx_a0 = nsm::integral_list<bool,  (Is <  size)...              >;
+    using idx_a1 = nsm::integral_list<bool, ((Is >= size) || (Is==-1))... >;
 
     using type = tt::integral_constant < int
                                         , 0x01*nsm::all<idx_a0>::value


### PR DESCRIPTION
Intel 15 does not seems to enjoy that expression:
`using idx_a1 = nsm::integral_list<bool, ((Is >= sizeof...(Is)) || (Is==-1))... >;
`
that is, the embedded sizeof... nested in a ... is not correctly evaluated.
As a result, is we enter the 'side' template with pattern `<0,-1>`, idx_a1 evaluate to `<true, true>` instead of `<false, true>`
As a result, some test were compiling but failling as the shuffle operation were making wrong assumptions.
