### PR TITLE
removed superfluous semicolons; failed with -pedantic-errors

### DIFF
--- a/include/boost/simd/constant/definition/denormalfactor.hpp
+++ b/include/boost/simd/constant/definition/denormalfactor.hpp
@@ -32,7 +32,7 @@ namespace boost { namespace simd
 
   namespace ext
   {
-    BOOST_DISPATCH_FUNCTION_DECLARATION(tag,denormalfactor_);
+    BOOST_DISPATCH_FUNCTION_DECLARATION(tag,denormalfactor_)
   }
 
   namespace detail

--- a/include/boost/simd/constant/definition/inveps.hpp
+++ b/include/boost/simd/constant/definition/inveps.hpp
@@ -32,7 +32,7 @@ namespace boost { namespace simd
 
   namespace ext
   {
-    BOOST_DISPATCH_FUNCTION_DECLARATION(tag,inveps_);
+    BOOST_DISPATCH_FUNCTION_DECLARATION(tag,inveps_)
   }
 
   namespace detail

--- a/include/boost/simd/constant/definition/pow2mask.hpp
+++ b/include/boost/simd/constant/definition/pow2mask.hpp
@@ -32,7 +32,7 @@ namespace boost { namespace simd
 
   namespace ext
   {
-    BOOST_DISPATCH_FUNCTION_DECLARATION(tag,exp_1_);
+    BOOST_DISPATCH_FUNCTION_DECLARATION(tag,exp_1_)
   }
 
   namespace detail

--- a/include/boost/simd/detail/constant/pow2mask.hpp
+++ b/include/boost/simd/detail/constant/pow2mask.hpp
@@ -43,7 +43,7 @@ namespace boost { namespace simd
 
   namespace ext
   {
-    BOOST_DISPATCH_FUNCTION_DECLARATION(tag,pow2mask_);
+    BOOST_DISPATCH_FUNCTION_DECLARATION(tag,pow2mask_)
   }
 
   namespace detail


### PR DESCRIPTION
Same purpose as [my previous PR](https://github.com/NumScale/boost.simd/pull/436). I wrote a regex to find and fix all such instances and ran it over the whole /include folder.