### PR TITLE
Optimize agrgegated all,any,none

### DIFF
--- a/include/boost/simd/arch/common/simd/function/all.hpp
+++ b/include/boost/simd/arch/common/simd/function/all.hpp
@@ -14,6 +14,7 @@
 #include <boost/simd/meta/as_logical.hpp>
 #include <boost/simd/function/genmask.hpp>
 #include <boost/simd/function/hmsb.hpp>
+#include <boost/simd/function/slice.hpp>
 #include <boost/simd/function/splatted.hpp>
 
 namespace boost { namespace simd { namespace ext
@@ -21,16 +22,28 @@ namespace boost { namespace simd { namespace ext
    namespace bd = boost::dispatch;
    namespace bs = boost::simd;
 
-  BOOST_DISPATCH_OVERLOAD_IF( all_
-                            , (typename A0, typename X)
-                            , (detail::is_native<X>)
-                            , bd::cpu_
-                            , bs::pack_<bd::fundamental_<A0>, X>
-                            )
+  BOOST_DISPATCH_OVERLOAD ( all_
+                          , (typename A0, typename X)
+                          , bd::cpu_
+                          , bs::pack_<bd::fundamental_<A0>, X>
+                          )
   {
-    BOOST_FORCEINLINE bool operator()(const A0& a0) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE bool do_(const A0& a0, aggregate_storage const&) const BOOST_NOEXCEPT
+    {
+      auto const all0 = all(slice_high(a0));
+      auto const all1 = all(slice_low(a0) );
+      return  all0 && all1;
+    }
+
+    template<typename K>
+    BOOST_FORCEINLINE bool do_(const A0& a0, K const&) const BOOST_NOEXCEPT
     {
       return hmsb(genmask(a0)).all();
+    }
+
+    BOOST_FORCEINLINE bool operator()(const A0& a0) const BOOST_NOEXCEPT
+    {
+      return do_(a0, typename A0::storage_kind{});
     }
   };
 

--- a/include/boost/simd/arch/common/simd/function/any.hpp
+++ b/include/boost/simd/arch/common/simd/function/any.hpp
@@ -27,9 +27,20 @@ namespace boost { namespace simd { namespace ext
                             , bs::pack_<bd::fundamental_<A0>, X>
                             )
   {
-    BOOST_FORCEINLINE bool operator()( const A0& a0) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE bool do_(const A0& a0, aggregate_storage const&) const BOOST_NOEXCEPT
+    {
+      return any(slice_high(a0)) || any(slice_low(a0));
+    }
+
+    template<typename K>
+    BOOST_FORCEINLINE bool do_(const A0& a0, K const&) const BOOST_NOEXCEPT
     {
       return hmsb(genmask(a0)).any();
+    }
+
+    BOOST_FORCEINLINE bool operator()(const A0& a0) const BOOST_NOEXCEPT
+    {
+      return do_(a0, typename A0::storage_kind{});
     }
   };
 

--- a/include/boost/simd/arch/common/simd/function/none.hpp
+++ b/include/boost/simd/arch/common/simd/function/none.hpp
@@ -10,8 +10,8 @@
 #define BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_NONE_HPP_INCLUDED
 
 #include <boost/simd/detail/overload.hpp>
-#include <boost/simd/function/any.hpp>
 #include <boost/simd/function/splatted.hpp>
+#include <boost/simd/function/hmsb.hpp>
 
 namespace boost { namespace simd { namespace ext
 {
@@ -24,9 +24,22 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::fundamental_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE bool operator()( const A0& a0) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE bool do_(const A0& a0, aggregate_storage const&) const BOOST_NOEXCEPT
     {
-      return !bs::any(a0);
+      auto const all0 = none(slice_high(a0));
+      auto const all1 = none(slice_low(a0) );
+      return  all0 && all1;
+    }
+
+    template<typename K>
+    BOOST_FORCEINLINE bool do_(const A0& a0, K const&) const BOOST_NOEXCEPT
+    {
+      return hmsb(genmask(a0)).none();
+    }
+
+    BOOST_FORCEINLINE bool operator()(const A0& a0) const BOOST_NOEXCEPT
+    {
+      return do_(a0, typename A0::storage_kind{});
     }
   };
 

--- a/test/function/simd/all.cpp
+++ b/test/function/simd/all.cpp
@@ -31,6 +31,7 @@ void test(Env& runtime)
   p_t aa3(&a3[0], &a3[0]+N);
 
   STF_EQUAL(bs::all(aa1), true);
+  STF_EQUAL(bs::all(aa2 == 0), true);
   STF_EQUAL(bs::all(aa2), false);
   STF_EQUAL(bs::all(aa3), false);
 

--- a/test/function/simd/any.cpp
+++ b/test/function/simd/any.cpp
@@ -7,40 +7,44 @@
 **/
 //==================================================================================================
 #include <boost/simd/function/any.hpp>
-#include <boost/simd/function/splatted.hpp>
 #include <boost/simd/logical.hpp>
 #include <boost/simd/pack.hpp>
 #include <simd_test.hpp>
 
-template <typename T, std::size_t N, typename Env> void test(Env& runtime) {
-  namespace bs = boost::simd;
+namespace bs = boost::simd;
+
+template <typename T, std::size_t N, typename Env>
+void test(Env& runtime)
+{
   using p_t = bs::pack<T, N>;
 
-  namespace bs = boost::simd;
-  namespace bd = boost::dispatch;
+  T a1[N], a2[N], a3[N];
 
-  T a1[N], a2[N];
-  bs::logical<T> b = false, c = false;
-  for (std::size_t i = 0; i < N; ++i) {
-    a1[i] = (i % 2) ? -T(0) :T(0);
-    a2[i] = (i % 2) ? T(i + 1) : T(-i);
-    b = b || a1[i] != 0;
-    c = c || a2[i] != 0;
+  for(std::size_t i = 0; i < N; ++i)
+  {
+    a1[i] = T(i+1);
+    a2[i] = T(0);
+    a3[i] = i!=0 ? T(0) : T(i+1);
   }
-  p_t aa1(&a1[0], &a1[0] + N);
-  p_t aa2(&a2[0], &a2[0] + N);
-  STF_EQUAL(bs::any(aa1), b);
-  STF_EQUAL(bs::any(aa2), c);
+  p_t aa1(&a1[0], &a1[0]+N);
+  p_t aa2(&a2[0], &a2[0]+N);
+  p_t aa3(&a3[0], &a3[0]+N);
 
-  STF_EQUAL(bs::splatted_(bs::any)(aa1), (bs::pack<bs::logical<T>, N>(b)));
-  STF_EQUAL(bs::splatted_(bs::any)(aa2), (bs::pack<bs::logical<T>, N>(c)));
+  STF_EQUAL(bs::any(aa1), true);
+  STF_EQUAL(bs::any(aa2 == 0), true);
+  STF_EQUAL(bs::any(aa2), false);
+  STF_EQUAL(bs::any(aa3), true);
+
+  STF_EQUAL(bs::splatted_(bs::any)(aa1), (bs::pack<bs::logical<T>,N>(true)) );
+  STF_EQUAL(bs::splatted_(bs::any)(aa2), (bs::pack<bs::logical<T>,N>(false)) );
+  STF_EQUAL(bs::splatted_(bs::any)(aa3), (bs::pack<bs::logical<T>,N>(true)) );
 }
 
-STF_CASE_TPL("Check any on pack", STF_NUMERIC_TYPES) {
-  namespace bs = boost::simd;
+STF_CASE_TPL("Check any on pack", STF_NUMERIC_TYPES)
+{
   static const std::size_t N = bs::pack<T>::static_size;
 
   test<T, N>(runtime);
-  test<T, N / 2>(runtime);
-  test<T, N * 2>(runtime);
+  test<T, N/2>(runtime);
+  test<T, N*2>(runtime);
 }

--- a/test/function/simd/none.cpp
+++ b/test/function/simd/none.cpp
@@ -7,37 +7,44 @@
 **/
 //==================================================================================================
 #include <boost/simd/function/none.hpp>
-#include <boost/simd/function/splatted.hpp>
 #include <boost/simd/logical.hpp>
 #include <boost/simd/pack.hpp>
 #include <simd_test.hpp>
 
 namespace bs = boost::simd;
 
-template <typename T, std::size_t N, typename Env> void test(Env& runtime) {
+template <typename T, std::size_t N, typename Env>
+void test(Env& runtime)
+{
   using p_t = bs::pack<T, N>;
 
-  T a1[N], a2[N];
-  bs::logical<T> b = true, c = true;
-  for (std::size_t i = 0; i < N; ++i) {
-    a1[i] = -T(0);
-    a2[i] = (i % 2) ? T(i + 1) : T(-i * 2 + 1);
-    b = b && a1[i] == 0;
-    c = c && a2[i] == 0;
-  }
-  p_t aa1(&a1[0], &a1[0] + N);
-  p_t aa2(&a2[0], &a2[0] + N);
-  STF_EQUAL(bs::none(aa1), b);
-  STF_EQUAL(bs::none(aa2), c);
+  T a1[N], a2[N], a3[N];
 
-  STF_EQUAL(bs::splatted_(bs::none)(aa1), (bs::pack<bs::logical<T>, N>(b)));
-  STF_EQUAL(bs::splatted_(bs::none)(aa2), (bs::pack<bs::logical<T>, N>(c)));
+  for(std::size_t i = 0; i < N; ++i)
+  {
+    a1[i] = T(i+1);
+    a2[i] = T(0);
+    a3[i] = i!=0 ? T(0) : T(i+1);
+  }
+  p_t aa1(&a1[0], &a1[0]+N);
+  p_t aa2(&a2[0], &a2[0]+N);
+  p_t aa3(&a3[0], &a3[0]+N);
+
+  STF_EQUAL(bs::none(aa1), false);
+  STF_EQUAL(bs::none(aa2 != 0), true);
+  STF_EQUAL(bs::none(aa2), true);
+  STF_EQUAL(bs::none(aa3), false);
+
+  STF_EQUAL(bs::splatted_(bs::none)(aa1), (bs::pack<bs::logical<T>,N>(false)) );
+  STF_EQUAL(bs::splatted_(bs::none)(aa2), (bs::pack<bs::logical<T>,N>(true)) );
+  STF_EQUAL(bs::splatted_(bs::none)(aa3), (bs::pack<bs::logical<T>,N>(false)) );
 }
 
-STF_CASE_TPL("Check none on pack", STF_NUMERIC_TYPES) {
+STF_CASE_TPL("Check none on pack", STF_NUMERIC_TYPES)
+{
   static const std::size_t N = bs::pack<T>::static_size;
 
   test<T, N>(runtime);
-  test<T, N / 2>(runtime);
-  test<T, N * 2>(runtime);
+  test<T, N/2>(runtime);
+  test<T, N*2>(runtime);
 }


### PR DESCRIPTION
Aggregated implementation of all,any and none was using a sub-par, piecewise implementation. We now slice the value, perform the two operations and use the appropriate logical operation to merge the result.

Tests have been also simplified and ameneded to actually test corner cases.