### PR TITLE
Fix #457 - Bad scalar copysign performance for floating point

### DIFF
--- a/include/boost/simd/arch/common/scalar/function/copysign.hpp
+++ b/include/boost/simd/arch/common/scalar/function/copysign.hpp
@@ -16,14 +16,13 @@
 #include <boost/simd/function/bitofsign.hpp>
 #include <boost/simd/function/signnz.hpp>
 #include <boost/simd/constant/signmask.hpp>
-#include <boost/simd/detail/math.hpp>
 #include <boost/simd/detail/dispatch/function/overload.hpp>
 #include <boost/config.hpp>
-
 
 namespace boost { namespace simd { namespace ext
 {
   namespace bd = boost::dispatch;
+
   BOOST_DISPATCH_OVERLOAD ( copysign_
                           , (typename A0)
                           , bd::cpu_
@@ -40,39 +39,13 @@ namespace boost { namespace simd { namespace ext
   BOOST_DISPATCH_OVERLOAD ( copysign_
                           , (typename A0)
                           , bd::cpu_
-                          , bd::scalar_< bd::double_<A0> >
-                          , bd::scalar_< bd::double_<A0> >
+                          , bd::scalar_< bd::floating_<A0> >
+                          , bd::scalar_< bd::floating_<A0> >
                           )
   {
     BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
-    #ifdef BOOST_SIMD_HAS_COPYSIGN
-      return ::copysign(a0, a1);
-      // _copysign appears to be bogus for a1 = -0 in old MSVCRT
-    #elif defined(BOOST_SIMD_HAS__COPYSIGN) && !defined(__MSVCRT__)
-      return ::_copysign(a0, a1);
-    #else
       return bitwise_or(bitofsign(a1), bitwise_notand(Signmask<A0>(), a0));
-    #endif
-    }
-  };
-
-  BOOST_DISPATCH_OVERLOAD ( copysign_
-                          , (typename A0)
-                          , bd::cpu_
-                          , bd::scalar_< bd::single_<A0> >
-                          , bd::scalar_< bd::single_<A0> >
-                                    )
-  {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
-    {
-    #ifdef BOOST_SIMD_HAS_COPYSIGNF
-      return ::copysignf(a0, a1);
-    #elif defined(BOOST_SIMD_HAS__COPYSIGNF)
-      return ::_copysignf(a0, a1);
-    #else
-       return bitwise_or(bitofsign(a1), bitwise_notand(Signmask<A0>(), a0));
-    #endif
     }
   };
 


### PR DESCRIPTION
Using the standard function was generating subpar code. We now only use our bitwise implementation. This wins us a full cycle per element on gcc and more on MSVC that wasn't inlining anything at all.