### PR TITLE
improving ilogb and adding std_ decorator

### DIFF
--- a/include/boost/simd/arch/common/scalar/function/ilogb.hpp
+++ b/include/boost/simd/arch/common/scalar/function/ilogb.hpp
@@ -11,15 +11,14 @@
 #ifndef BOOST_SIMD_ARCH_COMMON_SCALAR_FUNCTION_ILOGB_HPP_INCLUDED
 #define BOOST_SIMD_ARCH_COMMON_SCALAR_FUNCTION_ILOGB_HPP_INCLUDED
 
-#include <boost/simd/constant/zero.hpp>
-#include <boost/simd/detail/nsm.hpp>
+#include <boost/simd/constant/valmax.hpp>
 #include <boost/simd/function/exponent.hpp>
-#include <boost/simd/function/is_gtz.hpp>
-#include <boost/simd/detail/math.hpp>
+#include <boost/simd/function/is_inf.hpp>
 #include <boost/simd/detail/dispatch/function/overload.hpp>
 #include <boost/simd/detail/dispatch/meta/as_floating.hpp>
 #include <boost/simd/detail/dispatch/meta/as_integer.hpp>
 #include <boost/config.hpp>
+#include <cmath>
 
 namespace boost { namespace simd { namespace ext
 {
@@ -37,48 +36,34 @@ namespace boost { namespace simd { namespace ext
     }
   };
 
-#ifdef BOOST_SIMD_HAS_ILOGB
+
   BOOST_DISPATCH_OVERLOAD ( ilogb_
                           , (typename A0)
                           , bd::cpu_
-                          , bd::scalar_< bd::double_<A0> >
+                          , bs::std_tag
+                          , bd::scalar_< bd::floating_<A0> >
                           )
   {
     using result_t = bd::as_integer_t<A0, signed>;
-    BOOST_FORCEINLINE result_t operator() ( A0 a0 ) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE result_t operator() (const std_tag &, A0 a0 ) const BOOST_NOEXCEPT
     {
-      return is_gtz(a0) ? ::ilogb(a0) : Zero<result_t>();
+      return std::ilogb(a0);
     }
   };
-#endif
 
-#ifdef BOOST_SIMD_HAS_ILOGBF
-  BOOST_DISPATCH_OVERLOAD ( ilogb_
-                          , (typename A0)
-                          , bd::cpu_
-                          , bd::scalar_< bd::single_<A0> >
-                          )
-  {
-    using result_t = bd::as_integer_t<A0, signed>;
-    BOOST_FORCEINLINE result_t operator() ( A0 a0 ) const BOOST_NOEXCEPT
-    {
-      return is_gtz(a0) ? ::ilogbf(a0) : Zero<result_t>();
-    }
-  };
-#endif
-
-  BOOST_DISPATCH_OVERLOAD ( ilogb_
+   BOOST_DISPATCH_OVERLOAD ( ilogb_
                           , (typename A0)
                           , bd::cpu_
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
     using result_t = bd::as_integer_t<A0, signed>;
-    BOOST_FORCEINLINE result_t operator() ( A0 a0 ) const BOOST_NOEXCEPT
+    BOOST_FORCEINLINE result_t operator() (A0 a0 ) const BOOST_NOEXCEPT
     {
-      return is_gtz(a0) ? bs::exponent(a0) : Zero<result_t>();
+      return is_inf(a0) ? Valmax<result_t>() : exponent(a0);
     }
   };
+
 } } }
 
 

--- a/include/boost/simd/arch/common/scalar/function/ilogb.hpp
+++ b/include/boost/simd/arch/common/scalar/function/ilogb.hpp
@@ -14,6 +14,8 @@
 #include <boost/simd/constant/valmax.hpp>
 #include <boost/simd/function/exponent.hpp>
 #include <boost/simd/function/is_inf.hpp>
+#include <boost/simd/function/pedantic.hpp>
+#include <boost/simd/function/std.hpp>
 #include <boost/simd/detail/dispatch/function/overload.hpp>
 #include <boost/simd/detail/dispatch/meta/as_floating.hpp>
 #include <boost/simd/detail/dispatch/meta/as_integer.hpp>
@@ -51,7 +53,21 @@ namespace boost { namespace simd { namespace ext
     }
   };
 
-   BOOST_DISPATCH_OVERLOAD ( ilogb_
+  BOOST_DISPATCH_OVERLOAD ( ilogb_
+                          , (typename A0)
+                          , bd::cpu_
+                          , bs::pedantic_tag
+                          , bd::scalar_< bd::floating_<A0> >
+                          )
+  {
+    using result_t = bd::as_integer_t<A0, signed>;
+    BOOST_FORCEINLINE result_t operator() (const pedantic_tag &, A0 a0 ) const BOOST_NOEXCEPT
+    {
+      return std::ilogb(a0);
+    }
+  };
+
+  BOOST_DISPATCH_OVERLOAD ( ilogb_
                           , (typename A0)
                           , bd::cpu_
                           , bd::scalar_< bd::floating_<A0> >

--- a/include/boost/simd/arch/common/simd/function/ilogb.hpp
+++ b/include/boost/simd/arch/common/simd/function/ilogb.hpp
@@ -2,7 +2,7 @@
 /*!
   @file
 
-  @copyright 2016 NumScale SAS
+  @copyright 2017 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
@@ -13,28 +13,76 @@
 #include <boost/simd/detail/overload.hpp>
 
 #include <boost/simd/meta/hierarchy/simd.hpp>
+#include <boost/simd/function/bitwise_cast.hpp>
 #include <boost/simd/function/exponent.hpp>
-#include <boost/simd/function/if_else_zero.hpp>
-#include <boost/simd/function/is_gtz.hpp>
+#include <boost/simd/function/if_else.hpp>
+#include <boost/simd/function/is_inf.hpp>
+#include <boost/simd/function/split.hpp>
+#include <boost/simd/function/group.hpp>
+#include <boost/simd/function/tofloat.hpp>
+#include <boost/simd/constant/valmax.hpp>
 #include <boost/simd/detail/dispatch/meta/as_integer.hpp>
+#include <boost/simd/detail/dispatch/meta/as_floating.hpp>
 
 namespace boost { namespace simd { namespace ext
 {
-   namespace bd = boost::dispatch;
-   namespace bs = boost::simd;
-   BOOST_DISPATCH_OVERLOAD_IF(ilogb_
-                          , (typename A0, typename X)
-                          , (detail::is_native<X>)
-                          , bd::cpu_
-                          , bs::pack_<bd::floating_<A0>, X>
-                          )
-   {
-      BOOST_FORCEINLINE bd::as_integer_t<A0> operator()( const A0& a0) const BOOST_NOEXCEPT
-      {
-        return if_else_zero(is_gtz(a0), exponent(a0));
-      }
-   };
+  namespace bd = boost::dispatch;
+  namespace bs = boost::simd;
+  BOOST_DISPATCH_OVERLOAD_IF(ilogb_
+                            , (typename A0, typename X)
+                            , (detail::is_native<X>)
+                            , bd::cpu_
+                            , bs::pack_<bd::floating_<A0>, X>
+                            )
+  {
+    using result_t = bd::as_integer_t<A0>;
+    BOOST_FORCEINLINE result_t operator()( const A0& a0) const BOOST_NOEXCEPT
+    {
+      return if_else(is_inf(a0), Valmax<result_t>(), exponent(a0));
+    }
+  };
 
+  BOOST_DISPATCH_OVERLOAD_IF(ilogb_
+                            , (typename A0, typename X)
+                            , (detail::is_native<X>)
+                            , bd::cpu_
+                            , bs::pack_<bd::integer_<A0>, X>
+                            )
+  {
+    BOOST_FORCEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
+    {
+      return bitwise_cast<A0>(ilogb(tofloat(a0)));
+    }
+  };
+
+  BOOST_DISPATCH_OVERLOAD_IF ( ilogb_
+                             , (typename A0, typename X)
+                             , (detail::is_native<X>)
+                             , bd::cpu_
+                             , bs::pack_<bd::ints16_<A0>, X>
+                             )
+  {
+    BOOST_FORCEINLINE A0 operator() ( const A0 & a0)
+    {
+      auto s0 = split(a0);
+      return bitwise_cast<A0>(group(ilogb(s0[0]), ilogb(s0[1])));
+    }
+  };
+
+  BOOST_DISPATCH_OVERLOAD_IF ( ilogb_
+                             , (typename A0, typename X)
+                             , (detail::is_native<X>)
+                             , bd::cpu_
+                             , bs::pack_<bd::ints8_<A0>, X>
+                             )
+  {
+    using result = bd::as_integer_t<A0>;
+    BOOST_FORCEINLINE A0 operator() ( const A0 & a0)
+    {
+      auto s0 = split(a0);
+      return bitwise_cast<A0>(group(ilogb(s0[0]), ilogb(s0[1])));
+    }
+  };
 } } }
 
 #endif

--- a/include/boost/simd/arch/x86/sse2/simd/function/ilogb.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/ilogb.hpp
@@ -12,6 +12,7 @@
 #define BOOST_SIMD_ARCH_X86_SSE2_SIMD_FUNCTION_ILOGB_HPP_INCLUDED
 
 #include <boost/simd/detail/overload.hpp>
+#include <boost/simd/function/abs.hpp>
 #include <boost/simd/function/bitwise_and.hpp>
 #include <boost/simd/function/bitwise_cast.hpp>
 #include <boost/simd/function/dec.hpp>
@@ -34,23 +35,6 @@ namespace boost { namespace simd { namespace ext
 {
   namespace bd =  boost::dispatch;
   namespace bs =  boost::simd;
-
-  BOOST_DISPATCH_OVERLOAD ( ilogb_
-                          , (typename A0)
-                          , bs::sse2_
-                          , bs::pack_<bd::int_<A0>, bs::sse_>
-                         )
-  {
-    using result = bd::as_integer_t<A0>;
-    BOOST_FORCEINLINE result operator() ( const A0 & a0)
-    {
-      using vtype = bd::as_integer_t<A0,unsigned>;
-      return simd::bitwise_cast<A0>(if_zero_else( is_lez(a0)
-                                                , ilogb(simd::bitwise_cast<vtype>(a0))
-                                                )
-                                   );
-    }
-  };
 
   BOOST_DISPATCH_OVERLOAD ( ilogb_
                           , (typename A0)
@@ -82,33 +66,20 @@ namespace boost { namespace simd { namespace ext
       return dec(i);
     }
   };
-
   BOOST_DISPATCH_OVERLOAD ( ilogb_
                           , (typename A0)
                           , bs::sse2_
-                          , bs::pack_<bd::ints16_<A0>, bs::sse_>
+                          , bs::pack_<bd::int8_<A0>, bs::sse_>
                           )
   {
-    using result = bd::as_integer_t<A0>;
-    BOOST_FORCEINLINE result operator() ( const A0 & a0)
+
+    BOOST_FORCEINLINE A0 operator() ( const A0 & a0)
     {
-      auto s0 = split(a0);
-      return bitwise_cast<result>(group(ilogb(s0[0]), ilogb(s0[1])));
+      using uA0 = bd::as_integer_t<A0, unsigned>;
+      return bitwise_cast<A0>(ilogb(bitwise_cast<uA0>(saturated_(abs)(a0))));
     }
   };
 
-  BOOST_DISPATCH_OVERLOAD ( ilogb_
-                          , (typename A0)
-                          , bs::sse2_
-                          , bs::pack_<bd::unsigned_<A0>, bs::sse_>
-                          )
-  {
-    using result = bd::as_integer_t<A0>;
-    BOOST_FORCEINLINE result operator() ( const A0 & a0)
-    {
-      return simd::bitwise_cast<A0>(bs::exponent(tofloat(a0)));
-    }
-  };
 } } }
 
 #endif

--- a/include/boost/simd/function/ilogb.hpp
+++ b/include/boost/simd/function/ilogb.hpp
@@ -38,6 +38,9 @@ namespace boost { namespace simd
 
        - std_ provides access to std::ilogb
 
+       - pedantic_ return FP_ILOGB0 and FP_ILOGBNAN for 0 and nan respectively,
+         but the return type is as in the regular call.
+
     @par Header <boost/simd/function/ilogb.hpp>
 
     @par Example:

--- a/include/boost/simd/function/ilogb.hpp
+++ b/include/boost/simd/function/ilogb.hpp
@@ -17,10 +17,26 @@ namespace boost { namespace simd
 
   /*!
     @ingroup group-ieee
-    This function object returns the integer truncation
-    of the base 2 logarithm of x.
-    It coincides with the @ref exponent function
-    on all supported platforms.
+    This function object Extracts the value of the unbiased exponent from
+    the floating-point argument x, and returns it as a signed integer value.
+
+    @par Note:
+
+      - Formally, the unbiased exponent is the integral part of \f$\log_r|x|\f$
+      as a signed integral value, for non-zero x, where r is
+      std::numeric_limits<T>::radix and T is the floating-point type of arg.
+
+      - In practice r = 2 for all supported platforms
+
+      - boost::simd::ilogb differ from std::ilogb in the return type that is always the
+        integer type associated to the input type and the limiting values (zero return zero
+        and the result is always greater than zero)
+
+      - for floating inputs nan and zero returns zero and +-inf return Valmax
+
+     @par Decorators
+
+       - std_ provides access to std::ilogb
 
     @par Header <boost/simd/function/ilogb.hpp>
 

--- a/test/function/scalar/ilogb.cpp
+++ b/test/function/scalar/ilogb.cpp
@@ -31,7 +31,8 @@ STF_CASE_TPL (" ilogb real",  STF_IEEE_TYPES)
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  STF_EQUAL(ilogb(bs::Minf<T>()), bs::Zero<r_t>());
+  STF_EQUAL(ilogb(bs::Minf<T>()), bs::Valmax<r_t>());
+  STF_EQUAL(ilogb(bs::Inf<T>()), bs::Valmax<r_t>());
   STF_EQUAL(ilogb(bs::Nan<T>()), bs::Zero<r_t>());
 #endif
   STF_EQUAL(ilogb(bs::Mone<T>()), bs::Zero<r_t>());

--- a/test/function/simd/ilogb.cpp
+++ b/test/function/simd/ilogb.cpp
@@ -12,36 +12,106 @@
 #include <boost/simd/function/ilogb.hpp>
 #include <boost/simd/meta/cardinal_of.hpp>
 #include <simd_test.hpp>
+#include <boost/simd/constant/inf.hpp>
+#include <boost/simd/constant/minf.hpp>
+#include <boost/simd/constant/mone.hpp>
+#include <boost/simd/constant/nan.hpp>
+#include <boost/simd/constant/one.hpp>
+#include <boost/simd/constant/zero.hpp>
+#include <boost/simd/constant/two.hpp>
+#include <boost/simd/constant/four.hpp>
 
-template <typename T, std::size_t N, typename Env>
-void test(Env& runtime)
+// template <typename T, std::size_t N, typename Env>
+// void test(Env& runtime)
+// {
+//   namespace bs = boost::simd;
+//   namespace bd = boost::dispatch;
+
+//   using p_t = bs::pack<T, N>;
+//   using iT  = bd::as_integer_t<T>;
+//   using i_t = bs::pack<iT, N>;
+
+//   T a1[N];
+//   iT b[N];
+//   for(std::size_t i = 0; i < N; ++i)
+//   {
+//     a1[i] = T(N+i+1);
+//      b[i] = bs::ilogb(a1[i]);
+//    }
+//   p_t aa1(&a1[0], &a1[0]+N);
+//   i_t bb(&b[0], &b[0]+N);
+//   STF_EQUAL(bs::ilogb(aa1), bb);
+// }
+
+// STF_CASE_TPL("Check ilogb on pack" , STF_NUMERIC_TYPES)
+// {
+//   namespace bs = boost::simd;
+//   using p_t = bs::pack<T>;
+//   static const std::size_t N = bs::cardinal_of<p_t>::value;
+//   test<T, N>(runtime);
+//   test<T, N/2>(runtime);
+//   test<T, N*2>(runtime);
+// }
+
+
+STF_CASE_TPL (" ilogb real",  STF_IEEE_TYPES)
 {
   namespace bs = boost::simd;
   namespace bd = boost::dispatch;
+  using bs::ilogb;
+  using p_t = bs::pack<T>;
+  using r_t = decltype(ilogb(p_t()));
 
-  using p_t = bs::pack<T, N>;
-  using iT  = bd::as_integer_t<T>;
-  using i_t = bs::pack<iT, N>;
+  // return type conformity test
+  STF_TYPE_IS(r_t, (bd::as_integer_t<p_t>));
 
-  T a1[N];
-  iT b[N];
-  for(std::size_t i = 0; i < N; ++i)
-  {
-    a1[i] = T(N+i+1);
-     b[i] = bs::ilogb(a1[i]);
-   }
-  p_t aa1(&a1[0], &a1[0]+N);
-  i_t bb(&b[0], &b[0]+N);
-  STF_EQUAL(bs::ilogb(aa1), bb);
+  // specific values tests
+#ifndef BOOST_SIMD_NO_INVALIDS
+  STF_EQUAL(ilogb(bs::Minf<p_t>()), bs::Valmax<r_t>());
+  STF_EQUAL(ilogb(bs::Inf<p_t>()), bs::Valmax<r_t>());
+  STF_EQUAL(ilogb(bs::Nan<p_t>()), bs::Zero<r_t>());
+#endif
+  STF_EQUAL(ilogb(bs::Mone<p_t>()), bs::Zero<r_t>());
+  STF_EQUAL(ilogb(bs::One<p_t>()), bs::Zero<r_t>());
+  STF_EQUAL(ilogb(bs::Two<p_t>()), bs::One<r_t>());
+  STF_EQUAL(ilogb(bs::Four<p_t>()), bs::Two<r_t>());
+  STF_EQUAL(ilogb(bs::Zero<p_t>()), bs::Zero<r_t>());
 }
 
-STF_CASE_TPL("Check ilogb on pack" , // (float)(double)(int8_t)(int32_t)(uint64_t)(uint8_t)(uint32_t)(uint64_t))//
-                                     STF_NUMERIC_TYPES)
+STF_CASE_TPL (" ilogb unsigned_int",  STF_UNSIGNED_INTEGRAL_TYPES)
 {
   namespace bs = boost::simd;
+  namespace bd = boost::dispatch;
+  using bs::ilogb;
   using p_t = bs::pack<T>;
-  static const std::size_t N = bs::cardinal_of<p_t>::value;
-  test<T, N>(runtime);
-  test<T, N/2>(runtime);
-  test<T, N*2>(runtime);
+  using r_t = decltype(ilogb(p_t()));
+
+  // return type conformity test
+  STF_TYPE_IS(r_t, (bd::as_integer_t<p_t>));
+
+  // specific values tests
+  STF_EQUAL(ilogb(bs::One<p_t>()), bs::Zero<r_t>());
+  STF_EQUAL(ilogb(bs::Two<p_t>()), bs::One<r_t>());
+  STF_EQUAL(ilogb(bs::Zero<p_t>()), bs::Zero<r_t>());
+  STF_EQUAL(ilogb(bs::Four<p_t>()), bs::Two<r_t>());
 }
+
+STF_CASE_TPL (" ilogb signed_int",  STF_SIGNED_INTEGRAL_TYPES)
+{
+  namespace bs = boost::simd;
+  namespace bd = boost::dispatch;
+  using bs::ilogb;
+  using p_t = bs::pack<T>;
+  using r_t = decltype(ilogb(p_t()));
+
+  // return type conformity test
+  STF_TYPE_IS(r_t, (bd::as_integer_t<p_t>));
+
+  // specific values tests
+  STF_EQUAL(ilogb(bs::Mone<p_t>()), bs::Zero<r_t>());
+  STF_EQUAL(ilogb(bs::One<p_t>()), bs::Zero<r_t>());
+  STF_EQUAL(ilogb(bs::Two<p_t>()), bs::One<r_t>());
+  STF_EQUAL(ilogb(bs::Zero<p_t>()), bs::Zero<r_t>());
+  STF_EQUAL(ilogb(bs::Four<p_t>()), bs::Two<r_t>());
+}
+

--- a/test/function/simd/ilogb.cpp
+++ b/test/function/simd/ilogb.cpp
@@ -21,37 +21,37 @@
 #include <boost/simd/constant/two.hpp>
 #include <boost/simd/constant/four.hpp>
 
-// template <typename T, std::size_t N, typename Env>
-// void test(Env& runtime)
-// {
-//   namespace bs = boost::simd;
-//   namespace bd = boost::dispatch;
+template <typename T, std::size_t N, typename Env>
+void test(Env& runtime)
+{
+  namespace bs = boost::simd;
+  namespace bd = boost::dispatch;
 
-//   using p_t = bs::pack<T, N>;
-//   using iT  = bd::as_integer_t<T>;
-//   using i_t = bs::pack<iT, N>;
+  using p_t = bs::pack<T, N>;
+  using iT  = bd::as_integer_t<T>;
+  using i_t = bs::pack<iT, N>;
 
-//   T a1[N];
-//   iT b[N];
-//   for(std::size_t i = 0; i < N; ++i)
-//   {
-//     a1[i] = T(N+i+1);
-//      b[i] = bs::ilogb(a1[i]);
-//    }
-//   p_t aa1(&a1[0], &a1[0]+N);
-//   i_t bb(&b[0], &b[0]+N);
-//   STF_EQUAL(bs::ilogb(aa1), bb);
-// }
+  T a1[N];
+  iT b[N];
+  for(std::size_t i = 0; i < N; ++i)
+  {
+    a1[i] = T(N+i+1);
+     b[i] = bs::ilogb(a1[i]);
+   }
+  p_t aa1(&a1[0], &a1[0]+N);
+  i_t bb(&b[0], &b[0]+N);
+  STF_EQUAL(bs::ilogb(aa1), bb);
+}
 
-// STF_CASE_TPL("Check ilogb on pack" , STF_NUMERIC_TYPES)
-// {
-//   namespace bs = boost::simd;
-//   using p_t = bs::pack<T>;
-//   static const std::size_t N = bs::cardinal_of<p_t>::value;
-//   test<T, N>(runtime);
-//   test<T, N/2>(runtime);
-//   test<T, N*2>(runtime);
-// }
+STF_CASE_TPL("Check ilogb on pack" , STF_NUMERIC_TYPES)
+{
+  namespace bs = boost::simd;
+  using p_t = bs::pack<T>;
+  static const std::size_t N = bs::cardinal_of<p_t>::value;
+  test<T, N>(runtime);
+  test<T, N/2>(runtime);
+  test<T, N*2>(runtime);
+}
 
 
 STF_CASE_TPL (" ilogb real",  STF_IEEE_TYPES)
@@ -115,3 +115,26 @@ STF_CASE_TPL (" ilogb signed_int",  STF_SIGNED_INTEGRAL_TYPES)
   STF_EQUAL(ilogb(bs::Four<p_t>()), bs::Two<r_t>());
 }
 
+STF_CASE_TPL (" ilogb pedantic real",  STF_IEEE_TYPES)
+{
+  namespace bs = boost::simd;
+  namespace bd = boost::dispatch;
+  using bs::ilogb;
+  using p_t = bs::pack<T>;
+  using r_t = decltype(bs::pedantic_(ilogb)(p_t()));
+
+  // return type conformity test
+  STF_TYPE_IS(r_t, (bd::as_integer_t<p_t>));
+
+  // specific values tests
+#ifndef BOOST_SIMD_NO_INVALIDS
+  STF_EQUAL(bs::pedantic_(ilogb)(bs::Minf<p_t>()), bs::Valmax<r_t>());
+  STF_EQUAL(bs::pedantic_(ilogb)(bs::Inf<p_t>()),  bs::Valmax<r_t>());
+  STF_EQUAL(bs::pedantic_(ilogb)(bs::Nan<p_t>()),  r_t(FP_ILOGBNAN));
+#endif
+  STF_EQUAL(bs::pedantic_(ilogb)(bs::Mone<p_t>()), bs::Zero<r_t>());
+  STF_EQUAL(bs::pedantic_(ilogb)(bs::One<p_t>()),  bs::Zero<r_t>());
+  STF_EQUAL(bs::pedantic_(ilogb)(bs::Two<p_t>()),  bs::One<r_t>());
+  STF_EQUAL(bs::pedantic_(ilogb)(bs::Four<p_t>()), bs::Two<r_t>());
+  STF_EQUAL(bs::pedantic_(ilogb)(bs::Zero<p_t>()), r_t(FP_ILOGB0));
+}


### PR DESCRIPTION
In fact ilogb was not very standard conformant and needed repairs.
Now its behaviour is distinct of ilog2 and of exponent.