### PR TITLE
using permutevar8x32 for some lookup dispatches

### DIFF
--- a/include/boost/simd/arch/x86/avx/simd/function/lookup.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/lookup.hpp
@@ -11,6 +11,7 @@
 
 #include <boost/simd/detail/overload.hpp>
 #include <boost/simd/detail/dispatch/meta/as_floating.hpp>
+#include <boost/simd/function/bitwise_cast.hpp>
 
 namespace boost { namespace simd { namespace ext
 {
@@ -28,7 +29,7 @@ namespace boost { namespace simd { namespace ext
     {
       using fA0 = bd::as_floating_t<A0>;
       fA0 tmp = bitwise_cast<fA0>(a0);
-      return bitwise_cast<A0>(_mm_permutevar_pd(tmp,a1));
+      return bitwise_cast<A0>(lookup(tmp,a1));
     }
   };
 
@@ -43,7 +44,7 @@ namespace boost { namespace simd { namespace ext
     {
       using fA0 = bd::as_floating_t<A0>;
       fA0 tmp = bitwise_cast<fA0>(a0);
-      return bitwise_cast<A0>(_mm_permutevar_ps(tmp,a1));
+      return bitwise_cast<A0>(lookup(tmp,a1));
     }
   };
 
@@ -56,7 +57,7 @@ namespace boost { namespace simd { namespace ext
   {
     BOOST_FORCEINLINE A0 operator()(A0 const& a0, A1 const& a1) const BOOST_NOEXCEPT
     {
-      return _mm_permutevar_pd(a0,a1);
+      return _mm_permutevar_pd(a0,a1+a1);
     }
   };
 
@@ -72,8 +73,6 @@ namespace boost { namespace simd { namespace ext
       return _mm_permutevar_ps(a0,a1);
     }
   };
-
-
 } } }
 
 #endif

--- a/include/boost/simd/arch/x86/avx/simd/function/lookup.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/lookup.hpp
@@ -10,65 +10,68 @@
 #define BOOST_SIMD_ARCH_X86_AVX_SIMD_FUNCTION_LOOKUP_HPP_INCLUDED
 
 #include <boost/simd/detail/overload.hpp>
+#include <boost/simd/detail/dispatch/meta/as_floating.hpp>
 
 namespace boost { namespace simd { namespace ext
 {
    namespace bd = boost::dispatch;
    namespace bs = boost::simd;
 
-   BOOST_DISPATCH_OVERLOAD( lookup_
-                          , (typename A0, typename A0)
-                          , bs::avx_
-                          , bs::pack_<bd::ints64_<A0>, bs::avx_>
-                          , bs::pack_<bd::ints64_<A1>, bs::avx_>
-                          )
-   {
-      BOOST_FORCEINLINE A0 operator()(A0 const& a0, A1 const& a1) const BOOST_NOEXCEPT
-      {
-        using fA0 = bd::as_floating_t<A0>;
-        return bitwise_cast<A0>(_mm256_permutevar_pd(bitwise_cast<fA0>(a0),a1));
-      }
-   };
+  BOOST_DISPATCH_OVERLOAD( lookup_
+                         , (typename A0, typename A1)
+                         , bs::avx_
+                         , bs::pack_<bd::ints64_<A0>, bs::sse_>
+                         , bs::pack_<bd::ints64_<A1>, bs::sse_>
+                         )
+  {
+    BOOST_FORCEINLINE A0 operator()(A0 const& a0, A1 const& a1) const BOOST_NOEXCEPT
+    {
+      using fA0 = bd::as_floating_t<A0>;
+      fA0 tmp = bitwise_cast<fA0>(a0);
+      return bitwise_cast<A0>(_mm_permutevar_pd(tmp,a1));
+    }
+  };
 
-   BOOST_DISPATCH_OVERLOAD( lookup_
-                          , (typename A0, typename A0)
-                          , bs::avx_
-                          , bs::pack_<bd::ints32_<A0>, bs::avx_>
-                          , bs::pack_<bd::ints32_<A1>, bs::avx_>
-                          )
-   {
-      BOOST_FORCEINLINE A0 operator()(A0 const& a0, A1 const& a1) const BOOST_NOEXCEPT
-      {
-        using fA0 = bd::as_floating_t<A0>;
-        return bitwise_cast<A0>(_mm256_permutevar_ps(bitwise_cast<fA0>(a0),a1));
-      }
-   };
+  BOOST_DISPATCH_OVERLOAD( lookup_
+                         , (typename A0, typename A1)
+                         , bs::avx_
+                         , bs::pack_<bd::ints32_<A0>, bs::sse_>
+                         , bs::pack_<bd::ints32_<A1>, bs::sse_>
+                         )
+  {
+    BOOST_FORCEINLINE A0 operator()(A0 const& a0, A1 const& a1) const BOOST_NOEXCEPT
+    {
+      using fA0 = bd::as_floating_t<A0>;
+      fA0 tmp = bitwise_cast<fA0>(a0);
+      return bitwise_cast<A0>(_mm_permutevar_ps(tmp,a1));
+    }
+  };
 
-   BOOST_DISPATCH_OVERLOAD( lookup_
-                          , (typename A0, typename A1)
-                          , bs::avx_
-                          , bs::pack_<bd::double_<A0>, bs::avx_>
-                          , bs::pack_<bd::ints64_<A1>, bs::avx_>
-                          )
-   {
-      BOOST_FORCEINLINE A0 operator()(A0 const& a0, A0 const& a1) const BOOST_NOEXCEPT
-      {
-        return _mm256_permutevar_pd(a0,a1);
-      }
-   };
+  BOOST_DISPATCH_OVERLOAD( lookup_
+                         , (typename A0, typename A1)
+                         , bs::avx_
+                         , bs::pack_<bd::double_<A0>, bs::sse_>
+                         , bs::pack_<bd::ints64_<A1>, bs::sse_>
+                         )
+  {
+    BOOST_FORCEINLINE A0 operator()(A0 const& a0, A1 const& a1) const BOOST_NOEXCEPT
+    {
+      return _mm_permutevar_pd(a0,a1);
+    }
+  };
 
-   BOOST_DISPATCH_OVERLOAD( lookup_
-                          , (typename A0, typename A1)
-                          , bs::avx_
-                          , bs::pack_<bd::single_<A0>, bs::avx_>
-                          , bs::pack_<bd::ints32_<A1>, bs::avx_>
-                          )
-   {
-      BOOST_FORCEINLINE A0 operator()(A0 const& a0, A0 const& a1) const BOOST_NOEXCEPT
-      {
-        return _mm256_permutevar_ps(a0,a1);
-      }
-   };
+  BOOST_DISPATCH_OVERLOAD( lookup_
+                         , (typename A0, typename A1)
+                         , bs::avx_
+                         , bs::pack_<bd::single_<A0>, bs::sse_>
+                         , bs::pack_<bd::ints32_<A1>, bs::sse_>
+                         )
+  {
+    BOOST_FORCEINLINE A0 operator()(A0 const& a0, A1 const& a1) const BOOST_NOEXCEPT
+    {
+      return _mm_permutevar_ps(a0,a1);
+    }
+  };
 
 
 } } }

--- a/include/boost/simd/arch/x86/avx/simd/function/lookup.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/lookup.hpp
@@ -1,0 +1,76 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_X86_AVX_SIMD_FUNCTION_LOOKUP_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_X86_AVX_SIMD_FUNCTION_LOOKUP_HPP_INCLUDED
+
+#include <boost/simd/detail/overload.hpp>
+
+namespace boost { namespace simd { namespace ext
+{
+   namespace bd = boost::dispatch;
+   namespace bs = boost::simd;
+
+   BOOST_DISPATCH_OVERLOAD( lookup_
+                          , (typename A0, typename A0)
+                          , bs::avx_
+                          , bs::pack_<bd::ints64_<A0>, bs::avx_>
+                          , bs::pack_<bd::ints64_<A1>, bs::avx_>
+                          )
+   {
+      BOOST_FORCEINLINE A0 operator()(A0 const& a0, A1 const& a1) const BOOST_NOEXCEPT
+      {
+        using fA0 = bd::as_floating_t<A0>;
+        return bitwise_cast<A0>(_mm256_permutevar_pd(bitwise_cast<fA0>(a0),a1));
+      }
+   };
+
+   BOOST_DISPATCH_OVERLOAD( lookup_
+                          , (typename A0, typename A0)
+                          , bs::avx_
+                          , bs::pack_<bd::ints32_<A0>, bs::avx_>
+                          , bs::pack_<bd::ints32_<A1>, bs::avx_>
+                          )
+   {
+      BOOST_FORCEINLINE A0 operator()(A0 const& a0, A1 const& a1) const BOOST_NOEXCEPT
+      {
+        using fA0 = bd::as_floating_t<A0>;
+        return bitwise_cast<A0>(_mm256_permutevar_ps(bitwise_cast<fA0>(a0),a1));
+      }
+   };
+
+   BOOST_DISPATCH_OVERLOAD( lookup_
+                          , (typename A0, typename A1)
+                          , bs::avx_
+                          , bs::pack_<bd::double_<A0>, bs::avx_>
+                          , bs::pack_<bd::ints64_<A1>, bs::avx_>
+                          )
+   {
+      BOOST_FORCEINLINE A0 operator()(A0 const& a0, A0 const& a1) const BOOST_NOEXCEPT
+      {
+        return _mm256_permutevar_pd(a0,a1);
+      }
+   };
+
+   BOOST_DISPATCH_OVERLOAD( lookup_
+                          , (typename A0, typename A1)
+                          , bs::avx_
+                          , bs::pack_<bd::single_<A0>, bs::avx_>
+                          , bs::pack_<bd::ints32_<A1>, bs::avx_>
+                          )
+   {
+      BOOST_FORCEINLINE A0 operator()(A0 const& a0, A0 const& a1) const BOOST_NOEXCEPT
+      {
+        return _mm256_permutevar_ps(a0,a1);
+      }
+   };
+
+
+} } }
+
+#endif

--- a/include/boost/simd/arch/x86/avx2/simd/function/lookup.hpp
+++ b/include/boost/simd/arch/x86/avx2/simd/function/lookup.hpp
@@ -1,0 +1,47 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_X86_AVX2_SIMD_FUNCTION_LOOKUP_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_X86_AVX2_SIMD_FUNCTION_LOOKUP_HPP_INCLUDED
+
+#include <boost/simd/detail/overload.hpp>
+
+namespace boost { namespace simd { namespace ext
+{
+   namespace bd = boost::dispatch;
+   namespace bs = boost::simd;
+
+   BOOST_DISPATCH_OVERLOAD( lookup_
+                          , (typename A0, typename A0)
+                          , bs::avx2_
+                          , bs::pack_<bd::ints32_<A0>, bs::avx_>
+                          , bs::pack_<bd::ints32_<A1>, bs::avx_>
+                          )
+   {
+      BOOST_FORCEINLINE A0 operator()(A0 const& a0, A1 const& a1) const BOOST_NOEXCEPT
+      {
+        return _mm256_permutevar8x32_epi32(a0,a1);
+      }
+   };
+   BOOST_DISPATCH_OVERLOAD( lookup_
+                          , (typename A0, typename A1)
+                          , bs::avx2_
+                          , bs::pack_<bd::single_<A0>, bs::avx_>
+                          , bs::pack_<bd::ints32_<A1>, bs::avx_>
+                          )
+   {
+      BOOST_FORCEINLINE A0 operator()(A0 const& a0, A0 const& a1) const BOOST_NOEXCEPT
+      {
+        return _mm256_permutevar8x32_ps(a0,a1);
+      }
+   };
+
+
+} } }
+
+#endif

--- a/include/boost/simd/arch/x86/avx2/simd/function/lookup.hpp
+++ b/include/boost/simd/arch/x86/avx2/simd/function/lookup.hpp
@@ -18,7 +18,6 @@ namespace boost { namespace simd { namespace ext
 
   BOOST_DISPATCH_OVERLOAD( lookup_
                          , (typename A0, typename A1)
-                         , (detail::is_native<X>)
                          , bs::avx2_
                          , bs::pack_<bd::ints32_<A0>, bs::avx_>
                          , bs::pack_<bd::ints32_<A1>, bs::avx_>

--- a/include/boost/simd/arch/x86/avx2/simd/function/lookup.hpp
+++ b/include/boost/simd/arch/x86/avx2/simd/function/lookup.hpp
@@ -16,30 +16,31 @@ namespace boost { namespace simd { namespace ext
    namespace bd = boost::dispatch;
    namespace bs = boost::simd;
 
-   BOOST_DISPATCH_OVERLOAD( lookup_
-                          , (typename A0, typename A0)
-                          , bs::avx2_
-                          , bs::pack_<bd::ints32_<A0>, bs::avx_>
-                          , bs::pack_<bd::ints32_<A1>, bs::avx_>
-                          )
-   {
-      BOOST_FORCEINLINE A0 operator()(A0 const& a0, A1 const& a1) const BOOST_NOEXCEPT
-      {
-        return _mm256_permutevar8x32_epi32(a0,a1);
-      }
-   };
-   BOOST_DISPATCH_OVERLOAD( lookup_
-                          , (typename A0, typename A1)
-                          , bs::avx2_
-                          , bs::pack_<bd::single_<A0>, bs::avx_>
-                          , bs::pack_<bd::ints32_<A1>, bs::avx_>
-                          )
-   {
-      BOOST_FORCEINLINE A0 operator()(A0 const& a0, A0 const& a1) const BOOST_NOEXCEPT
-      {
-        return _mm256_permutevar8x32_ps(a0,a1);
-      }
-   };
+  BOOST_DISPATCH_OVERLOAD( lookup_
+                         , (typename A0, typename A1)
+                         , (detail::is_native<X>)
+                         , bs::avx2_
+                         , bs::pack_<bd::ints32_<A0>, bs::avx_>
+                         , bs::pack_<bd::ints32_<A1>, bs::avx_>
+                         )
+  {
+    BOOST_FORCEINLINE A0 operator()(A0 const& a0, A1 const& a1) const BOOST_NOEXCEPT
+    {
+      return _mm256_permutevar8x32_epi32(a0,a1);
+    }
+  };
+  BOOST_DISPATCH_OVERLOAD( lookup_
+                         , (typename A0, typename A1)
+                         , bs::avx2_
+                         , bs::pack_<bd::single_<A0>, bs::avx_>
+                         , bs::pack_<bd::ints32_<A1>, bs::avx_>
+                         )
+  {
+    BOOST_FORCEINLINE A0 operator()(A0 const& a0, A1 const& a1) const BOOST_NOEXCEPT
+    {
+      return _mm256_permutevar8x32_ps(a0,a1);
+    }
+  };
 
 
 } } }

--- a/include/boost/simd/function/simd/lookup.hpp
+++ b/include/boost/simd/function/simd/lookup.hpp
@@ -21,7 +21,6 @@
 #  if BOOST_HW_SIMD_X86_OR_AMD >= BOOST_HW_SIMD_X86_AVX_VERSION
 #    include <boost/simd/arch/x86/avx/simd/function/lookup.hpp>
 #  endif
-#endif
 #  if BOOST_HW_SIMD_X86_OR_AMD >= BOOST_HW_SIMD_X86_AVX2_VERSION
 #    include <boost/simd/arch/x86/avx2/simd/function/lookup.hpp>
 #  endif

--- a/include/boost/simd/function/simd/lookup.hpp
+++ b/include/boost/simd/function/simd/lookup.hpp
@@ -18,6 +18,13 @@
 #  if BOOST_HW_SIMD_X86_OR_AMD >= BOOST_HW_SIMD_X86_SSSE3_VERSION
 #    include <boost/simd/arch/x86/ssse3/simd/function/lookup.hpp>
 #  endif
+#  if BOOST_HW_SIMD_X86_OR_AMD >= BOOST_HW_SIMD_X86_AVX_VERSION
+#    include <boost/simd/arch/x86/avx/simd/function/lookup.hpp>
+#  endif
+#endif
+#  if BOOST_HW_SIMD_X86_OR_AMD >= BOOST_HW_SIMD_X86_AVX2_VERSION
+#    include <boost/simd/arch/x86/avx2/simd/function/lookup.hpp>
+#  endif
 #endif
 
 #endif

--- a/test/function/simd/lookup.cpp
+++ b/test/function/simd/lookup.cpp
@@ -25,8 +25,8 @@ void test(Env& runtime)
 
   for(std::size_t i = 0; i < N; ++i)
   {
-     a1[i] = (i%2) ? T(i) : T(2*i);
-     a2[i] = (N-i)/2+N/3;
+     a1[i] = T(2*i+1);
+     a2[i] = N-i-1;
   }
 
   for(std::size_t i = 0; i < N; ++i)
@@ -41,10 +41,10 @@ void test(Env& runtime)
   STF_EQUAL(bs::lookup(aa1, aa2), bb);
 }
 
-STF_CASE_TPL("Check lookup on pack" , STF_NUMERIC_TYPES)
+STF_CASE_TPL("Check lookup on pack", STF_NUMERIC_TYPES)
 {
   static const std::size_t N = bs::pack<T>::static_size;
   test<T, N>(runtime);
-//   test<T, N/2>(runtime);
-   test<T, N*2>(runtime);
+  test<T, N/2>(runtime);
+  test<T, N*2>(runtime);
 }

--- a/test/function/simd/lookup.cpp
+++ b/test/function/simd/lookup.cpp
@@ -45,6 +45,6 @@ STF_CASE_TPL("Check lookup on pack" , STF_NUMERIC_TYPES)
 {
   static const std::size_t N = bs::pack<T>::static_size;
   test<T, N>(runtime);
-  test<T, N/2>(runtime);
-  test<T, N*2>(runtime);
+//   test<T, N/2>(runtime);
+   test<T, N*2>(runtime);
 }


### PR DESCRIPTION
Is there a reason not to use these intrinsics ?

Also I was not able to test the commit. Travis will tell...