### PR TITLE
changing some param names to avoid clang warnings

### DIFF
--- a/include/boost/simd/algorithm/iota.hpp
+++ b/include/boost/simd/algorithm/iota.hpp
@@ -50,8 +50,8 @@ namespace boost { namespace simd
   {
     struct sg
     {
-      sg(T1 seed, T2 step)
-        : i_(seed),  step_(step) {}
+      sg(T1 seed1, T2 step1)
+        : i_(seed1),  step_(step1) {}
       T operator()()
       {
         auto z = i_;
@@ -64,8 +64,8 @@ namespace boost { namespace simd
     struct vg
     {
       using p_t =  pack<T>;
-      vg(T1 seed, T2 step)
-        : i_(bs::enumerate<p_t>(seed, step)), step_(step) {}
+      vg(T1 seed1, T2 step1)
+        : i_(bs::enumerate<p_t>(seed1, step1)), step_(step1) {}
        p_t operator()()
       {
         auto z = i_;
@@ -100,8 +100,8 @@ namespace boost { namespace simd
   {
     struct sg
     {
-      sg(T1 seed)
-        : i_(seed) {}
+      sg(T1 seed1)
+        : i_(seed1) {}
       T operator()()
       {
         return i_++;
@@ -111,8 +111,8 @@ namespace boost { namespace simd
     struct vg
     {
       using p_t =  pack<T>;
-      vg(T seed)
-        : i_(bs::enumerate<p_t>(seed)) {}
+      vg(T seed1)
+        : i_(bs::enumerate<p_t>(seed1)) {}
        p_t operator()()
       {
         auto z = i_;

--- a/include/boost/simd/algorithm/replace_if.hpp
+++ b/include/boost/simd/algorithm/replace_if.hpp
@@ -54,7 +54,7 @@ namespace boost { namespace simd
     struct local
     {
       using p_t = pack<T>;
-      local(P const& p, const T & nv) : p_(p), nv_(nv), pnv_(nv){}
+      local(P const& pp, const T & nv) : p_(pp), nv_(nv), pnv_(nv){}
 
       T operator()(T const& x) { return p_(x) ? nv_ : x; }
       p_t operator()(p_t const& x) {

--- a/include/boost/simd/memory/allocate.hpp
+++ b/include/boost/simd/memory/allocate.hpp
@@ -42,7 +42,7 @@ namespace boost { namespace simd
 
     @return  A pointer to the allocated space.
   */
-  template<typename T, typename Arch> T* allocate(std::size_t size, Arch const& arch)
+  template<typename T, typename Arch> T* allocate(std::size_t size, Arch const& )
   {
     return reinterpret_cast<T*>(boost::alignment::aligned_alloc(limits<Arch>::bytes,size*sizeof(T)));
   }


### PR DESCRIPTION
There is another warning with clang that must be spurious:

  void replace_if(T * first, T * last, P p, T const & new_val)
  {
    struct local
    {
      using p_t = pack<T>;
      local(P const& pp, const T & nv) : p_(pp), nv_(nv), pnv_(nv){}

      T operator()(T const& x) { return p_(x) ? nv_ : x; }
      p_t operator()(p_t const& x) {
        return if_else(p_(x), pnv_, x);
      }
...
typedef p_t is reputed unused by clang 3.9 (and 4.0) !?