### PR TITLE
As such, it seems that the cont applies to the return type, not the f…

### DIFF
--- a/test/doc/range/replace_if.cpp
+++ b/test/doc/range/replace_if.cpp
@@ -18,7 +18,7 @@ struct p
 {
 
   template < typename T >
-  auto operator()(const T & t) -> decltype((t >= 3.5f)&&(t < 5.0f)) const
+  auto operator()(const T & t) const -> decltype((t >= 3.5f)&&(t < 5.0f))
   {
     return (t >= 3.5f)&&(t < 5.0f);
   }


### PR DESCRIPTION

It appears that
```
template < typename T >  
auto operator()(const T & t) -> decltype((t\|ar.div.div.iround.unit >= 3.5f)&&(t < 5.0f))     const
```
declare a non const operator returning a const qualified type, and not a const method as probably expected.

As a result, the function cannot be invoked on a const predicate object.