### PR TITLE
add missing msvc #pragma warning(pop)

### DIFF
--- a/include/boost/simd/arch/common/scalar/function/divfloor.hpp
+++ b/include/boost/simd/arch/common/scalar/function/divfloor.hpp
@@ -106,6 +106,11 @@ namespace boost { namespace simd { namespace ext
       return boost::simd::floor(a0/a1);
     }
   };
+
+#ifdef BOOST_MSVC
+#pragma warning(pop)
+#endif
+
 } } }
 
 

--- a/include/boost/simd/arch/common/scalar/function/divides_s.hpp
+++ b/include/boost/simd/arch/common/scalar/function/divides_s.hpp
@@ -77,6 +77,11 @@ namespace boost { namespace simd { namespace ext
       return a1 ? a0/a1 : genmask(a0);
     }
   };
+
+#ifdef BOOST_MSVC
+#pragma warning(pop)
+#endif
+
 } } }
 
 


### PR DESCRIPTION
warning: C5032: detected #pragma warning(push) with no corresponding #pragma warning(pop)