### PR TITLE
Fix #6 - Implement subadd

### DIFF
--- a/include/boost/simd/arch/common/scalar/function/subadd.hpp
+++ b/include/boost/simd/arch/common/scalar/function/subadd.hpp
@@ -1,6 +1,6 @@
 //==================================================================================================
 /**
-  Copyright 2016 NumScale SAS
+  Copyright 2017 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)

--- a/include/boost/simd/arch/common/scalar/function/subadd.hpp
+++ b/include/boost/simd/arch/common/scalar/function/subadd.hpp
@@ -1,0 +1,32 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_COMMON_SCALAR_FUNCTION_SUBADD_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_COMMON_SCALAR_FUNCTION_SUBADD_HPP_INCLUDED
+
+#include <boost/config.hpp>
+
+namespace boost { namespace simd { namespace ext
+{
+  namespace bd = boost::dispatch;
+
+  BOOST_DISPATCH_OVERLOAD ( subadd_
+                          , (typename T)
+                          , bd::cpu_
+                          , bd::scalar_<bd::unspecified_<T>>
+                          , bd::scalar_<bd::unspecified_<T>>
+                          )
+  {
+    BOOST_FORCEINLINE T operator()(T a, T b) const BOOST_NOEXCEPT
+    {
+      return a - b;
+    }
+  };
+} } }
+
+#endif

--- a/include/boost/simd/arch/common/simd/function/subadd.hpp
+++ b/include/boost/simd/arch/common/simd/function/subadd.hpp
@@ -1,6 +1,6 @@
 //==================================================================================================
 /**
-  Copyright 2016 NumScale SAS
+  Copyright 2017 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)

--- a/include/boost/simd/arch/common/simd/function/subadd.hpp
+++ b/include/boost/simd/arch/common/simd/function/subadd.hpp
@@ -1,0 +1,71 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_SUBADD_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_COMMON_SIMD_FUNCTION_SUBADD_HPP_INCLUDED
+
+#include <boost/simd/detail/overload.hpp>
+#include <boost/simd/detail/traits.hpp>
+#include <boost/simd/function/slice.hpp>
+#include <boost/simd/function/combine.hpp>
+#include <boost/simd/function/fma.hpp>
+#include <boost/simd/meta/hierarchy/simd.hpp>
+
+namespace boost { namespace simd { namespace ext
+{
+  namespace bd = boost::dispatch;
+  namespace bs = boost::simd;
+
+  BOOST_DISPATCH_OVERLOAD ( subadd_
+                          , (typename A0, typename X)
+                          , bd::cpu_
+                          , bs::pack_<bd::arithmetic_<A0>, X>
+                          , bs::pack_<bd::arithmetic_<A0>, X>
+                          )
+   {
+
+      template<typename... N>
+      BOOST_FORCEINLINE A0 do_( const A0& a0, const A0& a1
+                              , scalar_storage const&,  nsm::list<N...> const&
+                              ) const BOOST_NOEXCEPT
+      {
+        return A0 ( (nsm::bool_<N::value%2>::value ? extract<N::value>(a0) + extract<N::value>(a1)
+                                                   : extract<N::value>(a0) - extract<N::value>(a1)
+                    )...
+                  );
+      }
+
+      template<typename ... N>
+      BOOST_FORCEINLINE A0 do_( const A0& a0, const A0& a1
+                              , native_storage const&, nsm::list<N...> const&
+                              ) const BOOST_NOEXCEPT
+      {
+        A0 twd( nsm::ptrdiff_t<(N::value%2 ?  1 : -1)>::value... );
+        return fma(a1,twd,a0);
+      }
+
+      template<typename L>
+      BOOST_FORCEINLINE A0 do_( const A0& a0, const A0& a1
+                              , aggregate_storage const&, L const&
+                              ) const BOOST_NOEXCEPT
+      {
+        auto h0 = slice_high(a0);
+        auto h1 = slice_high(a1);
+        auto l0 = slice_low(a0);
+        auto l1 = slice_low(a1);
+        return combine( subadd(l0,l1), subadd(h0,h1) );
+      }
+
+      BOOST_FORCEINLINE A0 operator()(const A0& a0, const A0& a1) const BOOST_NOEXCEPT
+      {
+        return do_(a0, a1, typename A0::storage_kind{}, typename A0::traits::element_range{});
+      }
+   };
+} } }
+
+#endif

--- a/include/boost/simd/arch/x86/avx/simd/function/subadd.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/subadd.hpp
@@ -1,0 +1,46 @@
+//==================================================================================================
+/**
+  Copyright 2016 Numscale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_X86_AVX_SIMD_FUNCTION_SUBADD_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_X86_AVX_SIMD_FUNCTION_SUBADD_HPP_INCLUDED
+
+#include <boost/simd/detail/overload.hpp>
+
+namespace boost { namespace simd { namespace ext
+{
+  namespace bd =  boost::dispatch;
+  namespace bs =  boost::simd;
+
+  BOOST_DISPATCH_OVERLOAD ( subadd_
+                          , (typename A0)
+                          , bs::avx_
+                          , bs::pack_<bd::single_<A0>, bs::avx_>
+                          , bs::pack_<bd::single_<A0>, bs::avx_>
+                         )
+  {
+    BOOST_FORCEINLINE A0 operator() ( const A0 & a0, const A0 & a1 ) const BOOST_NOEXCEPT
+    {
+      return _mm256_addsub_ps(a0,a1);
+    }
+  };
+
+  BOOST_DISPATCH_OVERLOAD ( subadd_
+                          , (typename A0)
+                          , bs::avx_
+                          , bs::pack_<bd::double_<A0>, bs::avx_>
+                          , bs::pack_<bd::double_<A0>, bs::avx_>
+                         )
+  {
+    BOOST_FORCEINLINE A0 operator() ( const A0 & a0, const A0 & a1 ) const BOOST_NOEXCEPT
+    {
+      return _mm256_addsub_pd(a0,a1);
+    }
+  };
+} } }
+
+#endif

--- a/include/boost/simd/arch/x86/avx/simd/function/subadd.hpp
+++ b/include/boost/simd/arch/x86/avx/simd/function/subadd.hpp
@@ -1,6 +1,6 @@
 //==================================================================================================
 /**
-  Copyright 2016 Numscale SAS
+  Copyright 2017 Numscale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)

--- a/include/boost/simd/arch/x86/sse3/simd/function/subadd.hpp
+++ b/include/boost/simd/arch/x86/sse3/simd/function/subadd.hpp
@@ -1,0 +1,46 @@
+//==================================================================================================
+/**
+  Copyright 2016 Numscale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef BOOST_SIMD_ARCH_X86_SSE3_SIMD_FUNCTION_SUBADD_HPP_INCLUDED
+#define BOOST_SIMD_ARCH_X86_SSE3_SIMD_FUNCTION_SUBADD_HPP_INCLUDED
+
+#include <boost/simd/detail/overload.hpp>
+
+namespace boost { namespace simd { namespace ext
+{
+  namespace bd =  boost::dispatch;
+  namespace bs =  boost::simd;
+
+  BOOST_DISPATCH_OVERLOAD ( subadd_
+                          , (typename A0)
+                          , bs::sse3_
+                          , bs::pack_<bd::single_<A0>, bs::sse_>
+                          , bs::pack_<bd::single_<A0>, bs::sse_>
+                         )
+  {
+    BOOST_FORCEINLINE A0 operator() ( const A0 & a0, const A0 & a1 ) const BOOST_NOEXCEPT
+    {
+      return _mm_addsub_ps(a0,a1);
+    }
+  };
+
+  BOOST_DISPATCH_OVERLOAD ( subadd_
+                          , (typename A0)
+                          , bs::sse3_
+                          , bs::pack_<bd::double_<A0>, bs::sse_>
+                          , bs::pack_<bd::double_<A0>, bs::sse_>
+                         )
+  {
+    BOOST_FORCEINLINE A0 operator() ( const A0 & a0, const A0 & a1 ) const BOOST_NOEXCEPT
+    {
+      return _mm_addsub_pd(a0,a1);
+    }
+  };
+} } }
+
+#endif

--- a/include/boost/simd/arch/x86/sse3/simd/function/subadd.hpp
+++ b/include/boost/simd/arch/x86/sse3/simd/function/subadd.hpp
@@ -1,6 +1,6 @@
 //==================================================================================================
 /**
-  Copyright 2016 Numscale SAS
+  Copyright 2017 Numscale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)

--- a/include/boost/simd/function/definition/subadd.hpp
+++ b/include/boost/simd/function/definition/subadd.hpp
@@ -2,7 +2,7 @@
 /*!
   @file
 
-  @copyright 2016 NumScale SAS
+  @copyright 2017 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)

--- a/include/boost/simd/function/definition/subadd.hpp
+++ b/include/boost/simd/function/definition/subadd.hpp
@@ -1,0 +1,36 @@
+//==================================================================================================
+/*!
+  @file
+
+  @copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#ifndef BOOST_SIMD_FUNCTION_DEFINITION_SUBADD_HPP_INCLUDED
+#define BOOST_SIMD_FUNCTION_DEFINITION_SUBADD_HPP_INCLUDED
+
+#include <boost/simd/config.hpp>
+#include <boost/simd/detail/dispatch/function/make_callable.hpp>
+#include <boost/simd/detail/dispatch/hierarchy/functions.hpp>
+#include <boost/simd/detail/dispatch.hpp>
+
+namespace boost { namespace simd
+{
+  namespace tag
+  {
+    BOOST_DISPATCH_MAKE_TAG(ext, subadd_, boost::dispatch::abstract_<subadd_>);
+  }
+
+  namespace ext
+  {
+    BOOST_DISPATCH_FUNCTION_DECLARATION(tag, subadd_)
+  }
+
+  BOOST_DISPATCH_CALLABLE_DEFINITION(tag::subadd_,subadd);
+
+
+} }
+
+#endif

--- a/include/boost/simd/function/scalar/subadd.hpp
+++ b/include/boost/simd/function/scalar/subadd.hpp
@@ -1,0 +1,16 @@
+//==================================================================================================
+/**
+  Copyright 2017 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+
+#ifndef BOOST_SIMD_FUNCTION_SCALAR_SUBADD_HPP_INCLUDED
+#define BOOST_SIMD_FUNCTION_SCALAR_SUBADD_HPP_INCLUDED
+
+#include <boost/simd/function/definition/subadd.hpp>
+#include <boost/simd/arch/common/scalar/function/subadd.hpp>
+
+#endif

--- a/include/boost/simd/function/simd/subadd.hpp
+++ b/include/boost/simd/function/simd/subadd.hpp
@@ -1,0 +1,26 @@
+//==================================================================================================
+/**
+  Copyright 2017 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+
+#ifndef BOOST_SIMD_FUNCTION_SIMD_SUBADD_HPP_INCLUDED
+#define BOOST_SIMD_FUNCTION_SIMD_SUBADD_HPP_INCLUDED
+
+#include <boost/simd/function/scalar/subadd.hpp>
+#include <boost/simd/arch/common/generic/function/autodispatcher.hpp>
+#include <boost/simd/arch/common/simd/function/subadd.hpp>
+
+#if defined(BOOST_HW_SIMD_X86_OR_AMD_AVAILABLE)
+#  if BOOST_HW_SIMD_X86_OR_AMD >= BOOST_HW_SIMD_X86_SSE3_VERSION
+#    include <boost/simd/arch/x86/sse3/simd/function/subadd.hpp>
+#  endif
+#  if BOOST_HW_SIMD_X86_OR_AMD >= BOOST_HW_SIMD_X86_AVX_VERSION
+#    include <boost/simd/arch/x86/avx/simd/function/subadd.hpp>
+#  endif
+#endif
+
+#endif

--- a/include/boost/simd/function/subadd.hpp
+++ b/include/boost/simd/function/subadd.hpp
@@ -1,0 +1,37 @@
+//==================================================================================================
+/*!
+  @file
+
+  @copyright 2017 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#ifndef BOOST_SIMD_FUNCTION_SUBADD_HPP_INCLUDED
+#define BOOST_SIMD_FUNCTION_SUBADD_HPP_INCLUDED
+
+namespace boost { namespace simd
+{
+  /*!
+    @ingroup group-swar
+    @ingroup swar-subadd
+
+    Computes the interleaved sum/difference of two vlaues
+
+    @par Header <boost/simd/function/subadd.hpp>
+    @par Example:
+
+    @snippet abs.cpp abs
+
+    @par Possible output:
+
+    @snippet abs.txt abs
+
+  **/
+} }
+
+#include <boost/simd/function/scalar/subadd.hpp>
+#include <boost/simd/function/simd/subadd.hpp>
+
+#endif

--- a/test/function/simd/CMakeLists.txt
+++ b/test/function/simd/CMakeLists.txt
@@ -359,6 +359,7 @@ set ( SOURCES
       sqrt.regular.cpp
       sqrt.raw.cpp
       stirling.cpp
+      subadd.cpp
       successor.cpp
       sum.cpp
       swapbytes.cpp

--- a/test/function/simd/subadd.cpp
+++ b/test/function/simd/subadd.cpp
@@ -1,6 +1,6 @@
 //==================================================================================================
 /**
-  Copyright 2016 NumScale SAS
+  Copyright 2017 NumScale SAS
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)

--- a/test/function/simd/subadd.cpp
+++ b/test/function/simd/subadd.cpp
@@ -1,0 +1,41 @@
+//==================================================================================================
+/**
+  Copyright 2016 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#include <boost/simd/function/subadd.hpp>
+#include <boost/simd/pack.hpp>
+#include <simd_test.hpp>
+
+namespace bs = boost::simd;
+
+template <typename T, std::size_t N, typename Env>
+void test(Env& runtime)
+{
+  using p_t = bs::pack<T, N>;
+
+  T a1[N], a2[N], b[N];
+  for(std::size_t i = 0; i < N; ++i)
+  {
+    a1[i] = (i%2) ? T(i) : T(2*i+1);
+    a2[i] = (i%2) ? T(2*i) : T(i+3);
+    b[i]  = i%2 ? a1[i] + a2[i] : a1[i] - a2[i];
+  }
+
+  p_t aa1(&a1[0], &a1[0]+N);
+  p_t aa2(&a2[0], &a2[0]+N);
+  p_t bb (&b[0], &b[0]+N);
+  STF_EQUAL(bs::subadd(aa1,aa2), bb);
+}
+
+STF_CASE_TPL("Check abs on pack" , STF_NUMERIC_TYPES)
+{
+  static const std::size_t N = bs::pack<T>::static_size;
+
+  test<T, N>(runtime);
+  test<T, N/2>(runtime);
+  test<T, N*2>(runtime);
+}


### PR DESCRIPTION
subadd provide ad hoc interleaved sum/difference of values inside a register. This maps to _mm*_addsub or devolves into using a fma with a properly computed twiddle factor.