### PR TITLE
Adds operator to convert between packs of different value types

### DIFF
--- a/include/boost/simd/pack.hpp
+++ b/include/boost/simd/pack.hpp
@@ -25,6 +25,7 @@
 #include <boost/simd/function/aligned_load.hpp>
 #include <boost/simd/function/extract.hpp>
 #include <boost/simd/function/insert.hpp>
+#include <boost/simd/function/pack_cast.hpp>
 #include <boost/simd/function/splat.hpp>
 #include <boost/simd/function/load.hpp>
 #include <boost/simd/function/inc.hpp>
@@ -120,6 +121,10 @@ namespace boost { namespace simd
 
     /// @brief Copy constructor
     BOOST_FORCEINLINE pack(pack const& rhs) BOOST_NOEXCEPT : data_(rhs.data_) {}
+
+    /// @brief Construct from a pack of different value type
+    template<typename U>
+    BOOST_FORCEINLINE explicit pack(rebind<U> const& rhs) BOOST_NOEXCEPT : pack(pack_cast<T>(rhs)) {}
 
     /*!
       @brief Construct a pack from aligned, contiguous memory

--- a/test/api/pack/ctor/CMakeLists.txt
+++ b/test/api/pack/ctor/CMakeLists.txt
@@ -12,6 +12,7 @@ set ( SOURCES
       default.cpp
       pointer.cpp
       iterator.cpp
+      rebind.cpp
       splat.cpp
     )
 

--- a/test/api/pack/ctor/rebind.cpp
+++ b/test/api/pack/ctor/rebind.cpp
@@ -1,0 +1,51 @@
+//==================================================================================================
+/*
+  Copyright 2017 NumScale SAS
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+//==================================================================================================
+#include <boost/simd/pack.hpp>
+#include <numeric>
+#include <type_traits>
+#include <simd_test.hpp>
+
+// test construction of pack<T, N> from pack<U, N>
+template <typename T, typename U, std::size_t N, typename Env>
+void test_for_u(Env& runtime)
+{
+    using destination = boost::simd::pack<T, N>;
+    using source = boost::simd::pack<U, N>;
+
+    source x;
+    std::iota(std::begin(x), std::end(x), T{1});
+
+    destination y(x);
+    STF_ALL_EQUAL(y, x);
+    
+    destination z{x};
+    STF_ALL_EQUAL(z, x);
+}
+
+template <typename T, std::size_t N, typename Env>
+void test(Env& runtime)
+{
+  test_for_u<T, float, N, Env>(runtime);
+  test_for_u<T, double, N, Env>(runtime);
+  test_for_u<T, int, N, Env>(runtime);
+  test_for_u<T, std::uint8_t, N, Env>(runtime);
+  test_for_u<T, std::int16_t, N, Env>(runtime);
+  test_for_u<T, std::uint32_t, N, Env>(runtime);
+  test_for_u<T, std::int64_t, N, Env>(runtime);
+}
+
+STF_CASE_TPL("Check that pack constructs from pack of different value type" , STF_NUMERIC_TYPES)
+{
+  test<T,  1>(runtime);
+  test<T,  2>(runtime);
+  test<T,  4>(runtime);
+  test<T,  8>(runtime);
+  test<T, 16>(runtime);
+  test<T, 32>(runtime);
+}


### PR DESCRIPTION
I think this could easily not be `explicit` but there is no reason currently.