### PR TITLE
MSVC: BOOST_FORCEINLINE -> BOOST_MAYBEINLINE

### DIFF
--- a/include/boost/simd/arch/common/generic/function/sincos.hpp
+++ b/include/boost/simd/arch/common/generic/function/sincos.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::generic_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE std::pair<A0, A0> operator() ( A0 const& a0) const
+    BOOST_MAYBEINLINE std::pair<A0, A0> operator() ( A0 const& a0) const
     {
       return detail::trig_base <A0,tag::radian_tag,is_not_scalar_t<A0>,tag::big_tag>::sincosa(a0);
     }
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::generic_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE std::pair<A0, A0> operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE std::pair<A0, A0> operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0, tag::radian_tag,is_not_scalar_t<A0>,tag::clipped_pio4_tag>::sincosa(a0);
     }
@@ -54,7 +54,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE std::pair<A0, A0> operator() (const A0 & a0,  A1 const &) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE std::pair<A0, A0> operator() (const A0 & a0,  A1 const &) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0, tag::radian_tag,is_not_scalar_t<A0>,A1>::sincosa(a0);
     }

--- a/include/boost/simd/arch/common/generic/function/sincosd.hpp
+++ b/include/boost/simd/arch/common/generic/function/sincosd.hpp
@@ -29,7 +29,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
     using result_t = std::pair<A0, A0>                     ;
-    BOOST_FORCEINLINE result_t operator() ( A0 const& a0) const
+    BOOST_MAYBEINLINE result_t operator() ( A0 const& a0) const
     {
       return detail::trig_base <A0,tag::degree_tag,is_not_scalar_t<A0>,tag::big_tag>::sincosa(a0);
     }
@@ -42,7 +42,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::generic_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE std::pair<A0, A0> operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE std::pair<A0, A0> operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0, tag::degree_tag,is_not_scalar_t<A0>,tag::clipped_pio4_tag>::sincosa(a0);
     }
@@ -55,7 +55,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE std::pair<A0, A0> operator() (const A0 & a0,  A1 const &) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE std::pair<A0, A0> operator() (const A0 & a0,  A1 const &) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0, tag::degree_tag,is_not_scalar_t<A0>,A1>::sincosa(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/acos.hpp
+++ b/include/boost/simd/arch/common/scalar/function/acos.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
 
-    BOOST_FORCEINLINE A0 operator() (const pedantic_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const pedantic_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return detail::invtrig_base<A0,tag::radian_tag,tag::not_simd_type>::acos(a0);
     }
@@ -43,7 +43,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
 
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       //Exhaustive test for: boost::dispatch::functor<boost::simd::tag::acos_, boost::simd::sse4_2_>
       //             versus: raw_acos
@@ -76,7 +76,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
     {
       return std::acos(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/acosd.hpp
+++ b/include/boost/simd/arch/common/scalar/function/acosd.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return indeg(bs::acos(a0));
     }
@@ -40,7 +40,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const pedantic_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const pedantic_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return indeg(bs::pedantic_(bs::acos)(a0));
     }

--- a/include/boost/simd/arch/common/scalar/function/acosh.hpp
+++ b/include/boost/simd/arch/common/scalar/function/acosh.hpp
@@ -32,7 +32,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       A0 t = dec(a0);
       if(BOOST_LIKELY(t <= Oneotwoeps<A0>()))
@@ -49,7 +49,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag&, A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag&, A0 a0) const BOOST_NOEXCEPT
     {
       return std::acosh(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/acospi.hpp
+++ b/include/boost/simd/arch/common/scalar/function/acospi.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return Invpi<A0>()*bs::acos(a0);
     }
@@ -39,7 +39,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const pedantic_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const pedantic_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return Invpi<A0>()*bs::pedantic_(acos)(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/acot.hpp
+++ b/include/boost/simd/arch/common/scalar/function/acot.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return detail::invtrig_base<A0,tag::radian_tag,tag::not_simd_type>::acot(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/acotd.hpp
+++ b/include/boost/simd/arch/common/scalar/function/acotd.hpp
@@ -36,7 +36,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       A0 z = Ratio<A0, 90>()-if_else_zero(is_nez(a0),atand(bs::abs(a0)));
       #ifndef BOOST_SIMD_NO_INFINITIES

--- a/include/boost/simd/arch/common/scalar/function/acoth.hpp
+++ b/include/boost/simd/arch/common/scalar/function/acoth.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::unspecified_<A0> >
                           )
   {
-     BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+     BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return bs::atanh(rec(a0));
     }

--- a/include/boost/simd/arch/common/scalar/function/acotpi.hpp
+++ b/include/boost/simd/arch/common/scalar/function/acotpi.hpp
@@ -36,7 +36,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       A0 z =Half<A0>()-if_else_zero(is_nez(a0),atanpi(bs::abs(a0)));
       #ifndef BOOST_SIMD_NO_INFINITIES

--- a/include/boost/simd/arch/common/scalar/function/acsc.hpp
+++ b/include/boost/simd/arch/common/scalar/function/acsc.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return bs::asin(rec(a0));
     }

--- a/include/boost/simd/arch/common/scalar/function/acsch.hpp
+++ b/include/boost/simd/arch/common/scalar/function/acsch.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace simd { namespace ext
                             , bd::scalar_< bd::unspecified_<A0> >
                             )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       return bs::asinh(bs::rec(a0));
     }

--- a/include/boost/simd/arch/common/scalar/function/asec.hpp
+++ b/include/boost/simd/arch/common/scalar/function/asec.hpp
@@ -38,7 +38,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::double_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       if (is_equal(a0, One<A0>())) return Zero<A0>();
       return (Pio_2<A0>()-acsc(a0)) +  Constant<A0, 0x3c91a62633145c07ll>();
@@ -51,7 +51,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::single_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       A0 ax =  bs::abs(a0);
       if (ax <  One<A0>()) return Nan<A0>();

--- a/include/boost/simd/arch/common/scalar/function/asech.hpp
+++ b/include/boost/simd/arch/common/scalar/function/asech.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::unspecified_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return bs::acosh(bs::rec(a0));
     }

--- a/include/boost/simd/arch/common/scalar/function/asin.hpp
+++ b/include/boost/simd/arch/common/scalar/function/asin.hpp
@@ -29,7 +29,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return detail::invtrig_base<A0,tag::radian_tag,tag::not_simd_type>::asin(a0);
     }
@@ -42,7 +42,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
     {
       return std::asin(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/asind.hpp
+++ b/include/boost/simd/arch/common/scalar/function/asind.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace simd { namespace ext
                             , bd::scalar_< bd::floating_<A0> >
                             )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return indeg(bs::asin(a0));
     }

--- a/include/boost/simd/arch/common/scalar/function/asinh.hpp
+++ b/include/boost/simd/arch/common/scalar/function/asinh.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::double_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       A0 x = bs::abs(a0);
       if  (BOOST_UNLIKELY(x < bs::Sqrteps<A0>() ))
@@ -74,7 +74,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::single_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       // Exhaustive test for: boost::dispatch::functor<bs::tag::asinh_, boost::simd::tag::sse4_2_>
       //              versus:  float(boost::math::asinh(double)
@@ -117,7 +117,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator()(const std_tag&, A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator()(const std_tag&, A0 a0) const BOOST_NOEXCEPT
     {
       return std::asinh(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/asinpi.hpp
+++ b/include/boost/simd/arch/common/scalar/function/asinpi.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return Invpi<A0>()*bs::asin(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/atan.hpp
+++ b/include/boost/simd/arch/common/scalar/function/atan.hpp
@@ -29,7 +29,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::invtrig_base<A0,tag::radian_tag,tag::not_simd_type>::atan(a0);
     }
@@ -42,7 +42,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
     {
       return std::atan(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/atan2.hpp
+++ b/include/boost/simd/arch/common/scalar/function/atan2.hpp
@@ -46,7 +46,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const pedantic_tag &,
+    BOOST_MAYBEINLINE A0 operator() (const pedantic_tag &,
                                      A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
       #ifndef BOOST_SIMD_NO_NANS
@@ -76,7 +76,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &,  A0 a0, A0 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &,  A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
       return std::atan2(a0, a1);
     }
@@ -88,7 +88,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
       A0 q = bs::abs(a0/a1);
       A0 z = detail::invtrig_base<A0,tag::radian_tag, tag::not_simd_type>::kernel_atan(q, bs::rec(q));

--- a/include/boost/simd/arch/common/scalar/function/atan2d.hpp
+++ b/include/boost/simd/arch/common/scalar/function/atan2d.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A1> >
                           )
   {
-     BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
+     BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
     {
       return indeg(atan2(a0, a1));
     }
@@ -42,7 +42,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A1> >
                           )
   {
-     BOOST_FORCEINLINE A0 operator() (const pedantic_tag &,
+     BOOST_MAYBEINLINE A0 operator() (const pedantic_tag &,
                                       A0 a0, A1 a1) const BOOST_NOEXCEPT
     {
       return indeg(pedantic_(atan2)(a0, a1));

--- a/include/boost/simd/arch/common/scalar/function/atan2pi.hpp
+++ b/include/boost/simd/arch/common/scalar/function/atan2pi.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A1> >
                           )
   {
-     BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
+     BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
     {
       return Invpi<A0>()*(atan2(a0, a1));
     }
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A1> >
                           )
   {
-     BOOST_FORCEINLINE A0 operator() (const pedantic_tag &,
+     BOOST_MAYBEINLINE A0 operator() (const pedantic_tag &,
                                       A0 a0, A1 a1) const BOOST_NOEXCEPT
     {
       return Invpi<A0>()*(pedantic_(atan2)(a0, a1));

--- a/include/boost/simd/arch/common/scalar/function/atand.hpp
+++ b/include/boost/simd/arch/common/scalar/function/atand.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return indeg(bs::atan(a0));
     }

--- a/include/boost/simd/arch/common/scalar/function/atanh.hpp
+++ b/include/boost/simd/arch/common/scalar/function/atanh.hpp
@@ -34,7 +34,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       A0 absa0 = bs::abs(a0);
       A0 t =  absa0+absa0;
@@ -54,7 +54,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                          )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &,  A0  a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &,  A0  a0) const BOOST_NOEXCEPT
     {
       return std::atanh(a0);
     }
@@ -67,7 +67,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                          )
   {
-    BOOST_FORCEINLINE A0 operator() (const raw_tag &,  A0  a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const raw_tag &,  A0  a0) const BOOST_NOEXCEPT
     {
        return  Half<A0>()*log(inc(a0)/oneminus(a0));
     }

--- a/include/boost/simd/arch/common/scalar/function/atanpi.hpp
+++ b/include/boost/simd/arch/common/scalar/function/atanpi.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return Invpi<A0>()*bs::atan(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/cbrt.hpp
+++ b/include/boost/simd/arch/common/scalar/function/cbrt.hpp
@@ -168,7 +168,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &,  A0  a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &,  A0  a0) const BOOST_NOEXCEPT
     {
       return std::cbrt(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/clz.hpp
+++ b/include/boost/simd/arch/common/scalar/function/clz.hpp
@@ -33,7 +33,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
     using result_t = bd::as_integer_t<A0>;
-    BOOST_FORCEINLINE result_t operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE result_t operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       result_t t1 = bitwise_cast<result_t>(a0);
       BOOST_ASSERT_MSG( t1, "clz not defined for 0" );
@@ -53,7 +53,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
     using result_t = bd::as_integer_t<A0>;
-    BOOST_FORCEINLINE result_t operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE result_t operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       result_t t1 = bitwise_cast<result_t>(a0);
       BOOST_ASSERT_MSG( t1, "clz not defined for 0" );
@@ -72,7 +72,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::type16_<A0> >
                           )
   {
-    BOOST_FORCEINLINE  bd::as_integer_t<A0> operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE  bd::as_integer_t<A0> operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       using i_t = typename bd::as_integer_t<A0, unsigned>;
       i_t t1 = bitwise_cast<i_t>(a0);
@@ -87,7 +87,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::type8_<A0> >
                           )
   {
-    BOOST_FORCEINLINE bd::as_integer_t<A0> operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE bd::as_integer_t<A0> operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       using i_t = typename bd::as_integer_t<A0, unsigned>;
       i_t t1 = bitwise_cast<i_t>(a0);

--- a/include/boost/simd/arch/common/scalar/function/cos.hpp
+++ b/include/boost/simd/arch/common/scalar/function/cos.hpp
@@ -29,7 +29,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
     {
       return std::cos(a0);
     }
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::radian_tag,tag::not_simd_type,tag::big_tag>::cosa(a0);
     }
@@ -53,7 +53,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0, tag::radian_tag,tag::not_simd_type,A1>::cosa(a0);
     }
@@ -65,7 +65,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0, tag::radian_tag,tag::not_simd_type,tag::clipped_pio4_tag>::cosa(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/cosd.hpp
+++ b/include/boost/simd/arch/common/scalar/function/cosd.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::not_simd_type,tag::big_tag>::cosa(a0);
     }
@@ -39,7 +39,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::not_simd_type,tag::clipped_pio4_tag>::cosa(a0);
     }
@@ -51,7 +51,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0,  A1 const &) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0,  A1 const &) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::not_simd_type,tag::big_tag>::cosa(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/cosh.hpp
+++ b/include/boost/simd/arch/common/scalar/function/cosh.hpp
@@ -36,7 +36,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &,  A0  a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &,  A0  a0) const BOOST_NOEXCEPT
     {
       return std::cosh(a0);
     }
@@ -48,7 +48,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       //////////////////////////////////////////////////////////////////////////////
       // if x = abs(a0) according x < Threshold e =  exp(x) or exp(x/2) is

--- a/include/boost/simd/arch/common/scalar/function/cospi.hpp
+++ b/include/boost/simd/arch/common/scalar/function/cospi.hpp
@@ -31,7 +31,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::not_simd_type,tag::big_tag>::cosa(a0);
     }
@@ -43,7 +43,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::not_simd_type,tag::clipped_pio4_tag>::cosa(a0);
     }
@@ -55,7 +55,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 const&) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 const&) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::not_simd_type,A1>::cosa(a0);
     }
@@ -67,7 +67,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
     using result_t = bd::as_floating_t<A0>;
-    BOOST_FORCEINLINE result_t operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE result_t operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return(bs::is_odd(a0)?Mone<result_t>():One<result_t>());
     }

--- a/include/boost/simd/arch/common/scalar/function/cot.hpp
+++ b/include/boost/simd/arch/common/scalar/function/cot.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::radian_tag,tag::not_simd_type,tag::big_tag>::cota(a0);
     }
@@ -39,7 +39,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::radian_tag,tag::not_simd_type,tag::clipped_pio4_tag>::cota(a0);
     }
@@ -51,7 +51,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0,  A1 const &) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0,  A1 const &) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::radian_tag,tag::not_simd_type,A1>::cota(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/cotd.hpp
+++ b/include/boost/simd/arch/common/scalar/function/cotd.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::not_simd_type,tag::big_tag>::cota(a0);
     }
@@ -39,7 +39,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::not_simd_type,tag::clipped_pio4_tag>::cota(a0);
     }
@@ -51,7 +51,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0,  A1 const &) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0,  A1 const &) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::not_simd_type,A1>::cota(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/coth.hpp
+++ b/include/boost/simd/arch/common/scalar/function/coth.hpp
@@ -37,7 +37,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       //////////////////////////////////////////////////////////////////////////////
       // if x = abs(a0) is less than 5/8 sinh is computed using a polynomial(float)

--- a/include/boost/simd/arch/common/scalar/function/cotpi.hpp
+++ b/include/boost/simd/arch/common/scalar/function/cotpi.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,is_not_scalar_t<A0>,tag::big_tag>::cota(a0);
     }
@@ -39,7 +39,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,is_not_scalar_t<A0>,tag::clipped_pio4_tag>::cota(a0);
     }
@@ -51,7 +51,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 const&) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 const&) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,is_not_scalar_t<A0>,A1>::cota(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/csc.hpp
+++ b/include/boost/simd/arch/common/scalar/function/csc.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return csc(a0, tag::big_);
     }
@@ -39,7 +39,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 const&) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 const&) const BOOST_NOEXCEPT
     {
       return rec(sin(a0, A1()));
     }
@@ -51,7 +51,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return rec(restricted_(sin)(a0));
     }

--- a/include/boost/simd/arch/common/scalar/function/cscd.hpp
+++ b/include/boost/simd/arch/common/scalar/function/cscd.hpp
@@ -31,7 +31,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return cscd(a0, tag::big_);
     }
@@ -43,7 +43,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 const&) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 const&) const BOOST_NOEXCEPT
     {
       return if_nan_else( is_nez(a0)&&is_flint(a0*Ratio<A0,1,180>())
                         , rec(sind(a0, tag::big_)));
@@ -56,7 +56,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return rec(restricted_(sind)(a0));
     }

--- a/include/boost/simd/arch/common/scalar/function/csch.hpp
+++ b/include/boost/simd/arch/common/scalar/function/csch.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::unspecified_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return rec(bs::sinh(a0));
     }

--- a/include/boost/simd/arch/common/scalar/function/cscpi.hpp
+++ b/include/boost/simd/arch/common/scalar/function/cscpi.hpp
@@ -32,7 +32,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return cscpi(a0, tag::big_);
     }
@@ -44,7 +44,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 const&) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 const&) const BOOST_NOEXCEPT
     {
       return if_nan_else(is_nez(a0)&&is_flint(a0), rec(sinpi(a0, A1())));
     }
@@ -56,7 +56,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return rec(restricted_(sinpi)(a0));
     }

--- a/include/boost/simd/arch/common/scalar/function/div.hpp
+++ b/include/boost/simd/arch/common/scalar/function/div.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::arithmetic_<T>>
                           )
   {
-    BOOST_FORCEINLINE T operator()(T  a, T  b ) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE T operator()(T  a, T  b ) const BOOST_NOEXCEPT
     {
       return divides(a, b);
     }
@@ -54,7 +54,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::arithmetic_<T>>
                           )
   {
-    BOOST_FORCEINLINE T operator()( bd::functor<bs::tag::fix_> const&
+    BOOST_MAYBEINLINE T operator()( bd::functor<bs::tag::fix_> const&
                                   , T  a, T  b ) const BOOST_NOEXCEPT
     {
       return div(bs::trunc, a, b);
@@ -74,7 +74,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::floating_<T>>
                           )
   {
-    BOOST_FORCEINLINE bd::as_integer_t<T> operator()( bd::functor<bs::tag::ifix_> const&
+    BOOST_MAYBEINLINE bd::as_integer_t<T> operator()( bd::functor<bs::tag::ifix_> const&
                                                     , T const& a, T const& b ) const BOOST_NOEXCEPT
     {
       return saturated_(toint)(a/b);
@@ -88,7 +88,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::floating_<T>>
                           )
   {
-    BOOST_FORCEINLINE bd::as_integer_t<T> operator()( bd::functor<bs::tag::iceil_> const&
+    BOOST_MAYBEINLINE bd::as_integer_t<T> operator()( bd::functor<bs::tag::iceil_> const&
                                                     , T const& a, T const& b ) const BOOST_NOEXCEPT
     {
       return iceil(a/b);
@@ -103,7 +103,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::floating_<T>>
                           )
   {
-    BOOST_FORCEINLINE bd::as_integer_t<T> operator()( bd::functor<bs::tag::ifloor_> const&
+    BOOST_MAYBEINLINE bd::as_integer_t<T> operator()( bd::functor<bs::tag::ifloor_> const&
                                                     ,T const& a, T const& b) const BOOST_NOEXCEPT
     {
       return ifloor(a/b);
@@ -118,7 +118,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::floating_<T>>
                           )
   {
-    BOOST_FORCEINLINE  bd::as_integer_t<T>  operator()( bd::functor<bs::tag::iround_> const&
+    BOOST_MAYBEINLINE  bd::as_integer_t<T>  operator()( bd::functor<bs::tag::iround_> const&
                                                       ,T const& a, T const& b) const BOOST_NOEXCEPT
     {
       return iround(a/b);
@@ -133,7 +133,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::floating_<T>>
                           )
   {
-    BOOST_FORCEINLINE bd::as_integer_t<T> operator()( bd::functor<bs::tag::inearbyint_> const&
+    BOOST_MAYBEINLINE bd::as_integer_t<T> operator()( bd::functor<bs::tag::inearbyint_> const&
                                                     ,T const& a, T const& b) const BOOST_NOEXCEPT
     {
       return pedantic_(inearbyint)(a/b);
@@ -152,7 +152,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::integer_<T>>
                           )
   {
-    BOOST_FORCEINLINE T operator()( bd::functor<bs::tag::ifix_> const&
+    BOOST_MAYBEINLINE T operator()( bd::functor<bs::tag::ifix_> const&
                                                     , T  a, T  b ) const BOOST_NOEXCEPT
     {
       return  div(fix, a, b);
@@ -167,7 +167,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::integer_<T>>
                           )
   {
-    BOOST_FORCEINLINE T operator()( bd::functor<bs::tag::iceil_> const&
+    BOOST_MAYBEINLINE T operator()( bd::functor<bs::tag::iceil_> const&
                                                     , T  a, T  b ) const BOOST_NOEXCEPT
     {
       return div(ceil, a, b);
@@ -182,7 +182,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::integer_<T>>
                           )
   {
-    BOOST_FORCEINLINE T operator()( bd::functor<bs::tag::ifloor_> const&
+    BOOST_MAYBEINLINE T operator()( bd::functor<bs::tag::ifloor_> const&
                                                     ,T  a, T  b) const BOOST_NOEXCEPT
     {
       return  div(floor, a, b);
@@ -197,7 +197,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::integer_<T>>
                           )
   {
-    BOOST_FORCEINLINE T operator()( bd::functor<bs::tag::iround_> const&
+    BOOST_MAYBEINLINE T operator()( bd::functor<bs::tag::iround_> const&
                                                     ,T  a, T  b) const BOOST_NOEXCEPT
     {
       return div(round, a, b);
@@ -212,7 +212,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::integer_<T>>
                           )
   {
-    BOOST_FORCEINLINE T operator()( bd::functor<bs::tag::inearbyint_> const&
+    BOOST_MAYBEINLINE T operator()( bd::functor<bs::tag::inearbyint_> const&
                                   ,T  a, T  b) const BOOST_NOEXCEPT
     {
       return  div(nearbyint, a, b);

--- a/include/boost/simd/arch/common/scalar/function/divides.hpp
+++ b/include/boost/simd/arch/common/scalar/function/divides.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::unspecified_<T>>
                           )
   {
-    BOOST_FORCEINLINE auto operator()(T const& a, T const& b) const BOOST_NOEXCEPT -> decltype(a/b)
+    BOOST_MAYBEINLINE auto operator()(T const& a, T const& b) const BOOST_NOEXCEPT -> decltype(a/b)
     {
       return a/b;
     }
@@ -39,7 +39,7 @@ namespace boost { namespace simd { namespace ext
                           ,  bd::scalar_< bd::fundamental_<T>>
                           )
   {
-    BOOST_FORCEINLINE T operator()(T a, T b) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE T operator()(T a, T b) const BOOST_NOEXCEPT
     {
       return a/b;
     }
@@ -53,7 +53,7 @@ namespace boost { namespace simd { namespace ext
                           ,  bd::scalar_<bd::fundamental_<T>>
                           )
   {
-    BOOST_FORCEINLINE T operator()(const saturated_tag &, T a, T b) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE T operator()(const saturated_tag &, T a, T b) const BOOST_NOEXCEPT
     {
       return saturated_(divides)(a, b);
     }

--- a/include/boost/simd/arch/common/scalar/function/erfc.hpp
+++ b/include/boost/simd/arch/common/scalar/function/erfc.hpp
@@ -43,7 +43,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::single_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       A0 x =  bs::abs(a0);
       A0 r1 = Zero<A0>();
@@ -72,7 +72,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::double_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 x) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 x) const BOOST_NOEXCEPT
     {
       #ifndef BOOST_SIMD_NO_INVALIDS
       if(is_nan(x)) return x;
@@ -108,7 +108,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
     {
       return std::erfc(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/erfcx.hpp
+++ b/include/boost/simd/arch/common/scalar/function/erfcx.hpp
@@ -46,7 +46,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::double_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 x) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 x) const BOOST_NOEXCEPT
     {
       #ifndef BOOST_SIMD_NO_INVALIDS
       if(is_nan(x)) return x;
@@ -85,7 +85,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::single_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       #ifndef BOOST_SIMD_NO_INFINITIES
       if(a0 == Inf<A0>()) return Zero<A0>();

--- a/include/boost/simd/arch/common/scalar/function/exp.hpp
+++ b/include/boost/simd/arch/common/scalar/function/exp.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       return detail::exponential<A0,bs::tag::exp_,tag::not_simd_type>::expa(a0);
     }
@@ -42,7 +42,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
     {
       return std::exp(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/exp2.hpp
+++ b/include/boost/simd/arch/common/scalar/function/exp2.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       return detail::exponential<A0,bs::tag::exp2_,tag::not_simd_type>::expa(a0);
     }
@@ -40,7 +40,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
     {
       return std::exp2(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/expm1.hpp
+++ b/include/boost/simd/arch/common/scalar/function/expm1.hpp
@@ -39,7 +39,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       using sA0 = bd::scalar_of_t<A0>;
     #ifndef BOOST_SIMD_NO_INVALIDS
@@ -57,7 +57,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
     {
       return std::expm1(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/exprecneg.hpp
+++ b/include/boost/simd/arch/common/scalar/function/exprecneg.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return exp(-rec(a0));
     }

--- a/include/boost/simd/arch/common/scalar/function/exprecnegc.hpp
+++ b/include/boost/simd/arch/common/scalar/function/exprecnegc.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return -expm1(-rec(a0));
     }

--- a/include/boost/simd/arch/common/scalar/function/expx2.hpp
+++ b/include/boost/simd/arch/common/scalar/function/expx2.hpp
@@ -37,7 +37,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
     #ifndef BOOST_SIMD_NO_INFINITIES
       if (is_inf(a0)) return Inf<A0>();
@@ -64,7 +64,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 s) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A0 s) const BOOST_NOEXCEPT
     {
       const A0 Expx2c1 = Real<A0, 0x4060000000000000ull, 0x42000000UL>();
       const A0 Expx2c2 = Real<A0, 0x3f80000000000000ull, 0x3d000000UL>();

--- a/include/boost/simd/arch/common/scalar/function/fma.hpp
+++ b/include/boost/simd/arch/common/scalar/function/fma.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::unspecified_<A0> >
                           )
   {
-    BOOST_FORCEINLINE
+    BOOST_MAYBEINLINE
     A0 operator() ( A0 a0, A0 a1, A0 a2) const BOOST_NOEXCEPT
     {
       return plus(multiplies(a0, a1), a2);

--- a/include/boost/simd/arch/common/scalar/function/gamma.hpp
+++ b/include/boost/simd/arch/common/scalar/function/gamma.hpp
@@ -43,7 +43,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       if (is_eqz(a0)) return copysign(Inf<A0>(), a0);
       #ifndef BOOST_SIMD_NO_INVALIDS
@@ -94,11 +94,11 @@ namespace boost { namespace simd { namespace ext
       return z*detail::gamma_kernel<A0>::gamma1(x);
     }
   private:
-    static BOOST_FORCEINLINE bool inftest(const float a0)
+    static BOOST_MAYBEINLINE bool inftest(const float a0)
     {
       return a0 > 35.4f;
     }
-    static BOOST_FORCEINLINE bool inftest(const double a0)
+    static BOOST_MAYBEINLINE bool inftest(const double a0)
     {
       return a0 > 171.624;
     }
@@ -111,7 +111,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
     {
       return std::tgamma(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/gammaln.hpp
+++ b/include/boost/simd/arch/common/scalar/function/gammaln.hpp
@@ -45,7 +45,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::single_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       A0 Maxgammaln = Constant<A0, 0x7bc3f8eaUL>(); //2.035093e36f
       if ((a0 > Maxgammaln) || bs::is_eqz(a0) ) return bs::Inf<A0>();
@@ -73,7 +73,7 @@ namespace boost { namespace simd { namespace ext
       }
     }
   private:
-    static /*BOOST_FORCEINLINE*/ A0 gammaln_pos(A0 x) BOOST_NOEXCEPT
+    static /*BOOST_MAYBEINLINE*/ A0 gammaln_pos(A0 x) BOOST_NOEXCEPT
     {
       if( x < 6.5f )
       {
@@ -132,7 +132,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::double_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       A0 Maxgammaln = Constant<A0, 0x7f574c5dd06d2516ULL>();
       if ((a0 == bs::Inf<A0>()) || bs::is_eqz(a0) ) return bs::Inf<A0>(); //2.556348e305
@@ -161,7 +161,7 @@ namespace boost { namespace simd { namespace ext
       }
     }
   private:
-    static /*BOOST_FORCEINLINE*/ A0 gammaln_pos(A0 x) BOOST_NOEXCEPT
+    static /*BOOST_MAYBEINLINE*/ A0 gammaln_pos(A0 x) BOOST_NOEXCEPT
     {
       if( x < 13.0 )
       {
@@ -203,7 +203,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0, A0&sgn) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0, A0&sgn) const BOOST_NOEXCEPT
     {
       sgn = signgam(a0);
       return std::lgamma(a0);
@@ -216,7 +216,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
     {
       return std::lgamma(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/hypot.hpp
+++ b/include/boost/simd/arch/common/scalar/function/hypot.hpp
@@ -47,7 +47,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
 
-    BOOST_FORCEINLINE A0 operator() (const pedantic_tag &,
+    BOOST_MAYBEINLINE A0 operator() (const pedantic_tag &,
                                      A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
       using i_t = bd::as_integer_t<A0>;
@@ -72,7 +72,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
 
-    BOOST_FORCEINLINE A0 operator() (const std_tag &,  A0 a0, A0 a1
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &,  A0 a0, A0 a1
                                     ) const BOOST_NOEXCEPT
     {
       return std::hypot(a0, a1);
@@ -87,7 +87,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
 
-    BOOST_FORCEINLINE A0 operator() ( A0  a0, A0  a1
+    BOOST_MAYBEINLINE A0 operator() ( A0  a0, A0  a1
                                     ) const BOOST_NOEXCEPT
     {
       return boost::simd::sqrt(bs::fma(a0, a0, sqr(a1)));

--- a/include/boost/simd/arch/common/scalar/function/ilog2.hpp
+++ b/include/boost/simd/arch/common/scalar/function/ilog2.hpp
@@ -24,7 +24,7 @@ namespace boost { namespace simd { namespace ext
 
   BOOST_DISPATCH_OVERLOAD(ilog2_, (typename A0), bd::cpu_, bd::scalar_<bd::floating_<A0>>)
   {
-    BOOST_FORCEINLINE bd::as_integer_t<A0> operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE bd::as_integer_t<A0> operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       BOOST_ASSERT_MSG( a0 > 0
                       , "Logarithm is not defined for zero or negative values." );
@@ -34,7 +34,7 @@ namespace boost { namespace simd { namespace ext
 
   BOOST_DISPATCH_OVERLOAD(ilog2_, (typename A0), bd::cpu_, bd::scalar_<bd::arithmetic_<A0>>)
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       BOOST_ASSERT_MSG( a0 > 0
                       , "Logarithm is not defined for zero or negative values." );
@@ -45,13 +45,13 @@ namespace boost { namespace simd { namespace ext
 #if defined(BOOST_MSVC)
   BOOST_DISPATCH_OVERLOAD(ilog2_, (typename A0), bd::cpu_, bd::scalar_<bd::integer_<A0>>)
   {
-    BOOST_FORCEINLINE A0 operator()(A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator()(A0 a0) const BOOST_NOEXCEPT
     {
       BOOST_ASSERT_MSG( a0 > 0, "Logarithm is not defined for zero or negative values." );
       return impl(a0, typename nsm::bool_<sizeof(A0) <= 4>::type());
     }
 
-    static BOOST_FORCEINLINE A0 impl( A0  a0,  tt::true_type const &) BOOST_NOEXCEPT
+    static BOOST_MAYBEINLINE A0 impl( A0  a0,  tt::true_type const &) BOOST_NOEXCEPT
     {
       unsigned long index;
       BOOST_VERIFY(::_BitScanReverse(&index, a0));
@@ -59,14 +59,14 @@ namespace boost { namespace simd { namespace ext
     }
 
     #if defined(_WIN64)
-    static BOOST_FORCEINLINE A0 impl(A0 a0, tt::false_type const &) BOOST_NOEXCEPT
+    static BOOST_MAYBEINLINE A0 impl(A0 a0, tt::false_type const &) BOOST_NOEXCEPT
     {
       unsigned long index;
       BOOST_VERIFY(::_BitScanReverse64(&index, a0));
       return static_cast<A0>(index);
     }
     #else
-    static BOOST_FORCEINLINE A0 impl(A0 a0, tt::false_type const &) BOOST_NOEXCEPT
+    static BOOST_MAYBEINLINE A0 impl(A0 a0, tt::false_type const &) BOOST_NOEXCEPT
     {
       return static_cast<A0>(sizeof(A0)*8-boost::simd::clz(a0)-1);
     }

--- a/include/boost/simd/arch/common/scalar/function/ilogb.hpp
+++ b/include/boost/simd/arch/common/scalar/function/ilogb.hpp
@@ -32,7 +32,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::integer_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0 ) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0 ) const BOOST_NOEXCEPT
     {
       return static_cast<A0>(bs::ilogb(static_cast<bd::as_floating_t<A0>>(a0)));
     }
@@ -47,7 +47,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
     using result_t = bd::as_integer_t<A0, signed>;
-    BOOST_FORCEINLINE result_t operator() (const std_tag &, A0 a0 ) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE result_t operator() (const std_tag &, A0 a0 ) const BOOST_NOEXCEPT
     {
       return std::ilogb(a0);
     }
@@ -61,7 +61,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
     using result_t = bd::as_integer_t<A0, signed>;
-    BOOST_FORCEINLINE result_t operator() (const pedantic_tag &, A0 a0 ) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE result_t operator() (const pedantic_tag &, A0 a0 ) const BOOST_NOEXCEPT
     {
       return std::ilogb(a0);
     }
@@ -74,7 +74,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
     using result_t = bd::as_integer_t<A0, signed>;
-    BOOST_FORCEINLINE result_t operator() (A0 a0 ) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE result_t operator() (A0 a0 ) const BOOST_NOEXCEPT
     {
       return is_inf(a0) ? Valmax<result_t>() : exponent(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/ldexp.hpp
+++ b/include/boost/simd/arch/common/scalar/function/ldexp.hpp
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::integer_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
     {
       return (a1>0)?(a0<<a1):(a0>>a1);
     }
@@ -56,7 +56,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::integer_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const pedantic_tag &
+    BOOST_MAYBEINLINE A0 operator() (const pedantic_tag &
                                     ,  A0 a0, A1 a1) const BOOST_NOEXCEPT
     {
       using i_t = bd::as_integer_t<A0>;
@@ -85,7 +85,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::integer_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const pedantic_tag &
+    BOOST_MAYBEINLINE A0 operator() (const pedantic_tag &
                                     , A0 a0, A1 a1) const BOOST_NOEXCEPT
     {
       return bs::ldexp(a0, a1);
@@ -100,7 +100,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::integer_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
     {
       using i_t = bd::as_integer_t<A0>;
       i_t ik =  a1+Maxexponent<A0>();
@@ -117,7 +117,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::integer_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &
                                     ,  A0 a0, A1 a1 ) const BOOST_NOEXCEPT
     {
       return std::ldexp(a0, a1);
@@ -131,7 +131,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::integer_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &
                                     ,  A0 a0, A1 a1 ) const BOOST_NOEXCEPT
     {
       return bs::ldexp(a0, a1);
@@ -146,7 +146,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &
                                     ,  A0 a0, A1 a1 ) const BOOST_NOEXCEPT
     {
       BOOST_ASSERT_MSG(is_flint(a1)||is_invalid(a1), "parameter is not a flint nor is invalid");
@@ -161,7 +161,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0, A1 a1 ) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0, A1 a1 ) const BOOST_NOEXCEPT
     {
       BOOST_ASSERT_MSG(is_flint(a1)||is_invalid(a1), "parameter is not a flint nor is invalid");
       return std::ldexp(a0, toint(a1));

--- a/include/boost/simd/arch/common/scalar/function/log.hpp
+++ b/include/boost/simd/arch/common/scalar/function/log.hpp
@@ -51,7 +51,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
     {
       return std::log(a0);
     }
@@ -63,7 +63,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       return musl_(log)(a0);
     }
@@ -87,7 +87,7 @@ namespace boost { namespace simd { namespace ext
    * is preserved.
    * ====================================================
    */
-     BOOST_FORCEINLINE A0 operator() (const musl_tag &, A0 x) const BOOST_NOEXCEPT
+     BOOST_MAYBEINLINE A0 operator() (const musl_tag &, A0 x) const BOOST_NOEXCEPT
     {
       using uiA0 = bd::as_integer_t<A0, unsigned>;
       using iA0 = bd::as_integer_t<A0,   signed>;
@@ -136,7 +136,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::double_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const musl_tag &, A0 x) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const musl_tag &, A0 x) const BOOST_NOEXCEPT
     {
       using uiA0 = bd::as_integer_t<A0, unsigned>;
       using iA0 = bd::as_integer_t<A0,   signed>;
@@ -187,7 +187,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const plain_tag &, A0 x) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const plain_tag &, A0 x) const BOOST_NOEXCEPT
     {
       return musl_(log)(x); //the "plain" version of the algorithm is never speedier than the "musl" version.
       // the call is here to allow a scalar fallback to simd calls

--- a/include/boost/simd/arch/common/scalar/function/log10.hpp
+++ b/include/boost/simd/arch/common/scalar/function/log10.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::int_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       using ui_t = bd::as_integer_t<A0, unsigned>;
       BOOST_ASSERT_MSG( a0 > 0, "log10 is not defined for zero or negative integers." );
@@ -53,7 +53,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::uint8_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return (a0 >= 100u) ? 2 :
              (a0 >= 10u)  ? 1 : 0;
@@ -65,7 +65,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::uint16_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return (a0 >= 10000u) ? 4 :
              (a0 >= 1000u)  ? 3 :
@@ -80,7 +80,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::uint32_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return (a0 >= 1000000000u) ? 9 :
              (a0 >= 100000000u) ?  8 :
@@ -99,7 +99,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::uint64_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return(a0 >= 10000000000000000000ull) ? 19 :
             (a0 >= 1000000000000000000ull) ?  18 :
@@ -129,7 +129,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
     {
       return std::log10(a0);
     }
@@ -142,7 +142,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const plain_tag &, A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const plain_tag &, A0 a0) const BOOST_NOEXCEPT
     {
       return musl_(log10)(a0);
     }
@@ -154,7 +154,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return musl_(log10)(a0);
     }
@@ -167,7 +167,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::arithmetic_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &, A0 a0
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &, A0 a0
                                     ) const BOOST_NOEXCEPT
     {
       return musl_(log10(a0));
@@ -192,7 +192,7 @@ namespace boost { namespace simd { namespace ext
    * is preserved.
    * ====================================================
    */
-    BOOST_FORCEINLINE A0 operator() (const musl_tag &, A0 x) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const musl_tag &, A0 x) const BOOST_NOEXCEPT
     {
       using uiA0 = bd::as_integer_t<A0, unsigned>;
       using iA0 = bd::as_integer_t<A0,   signed>;
@@ -266,7 +266,7 @@ namespace boost { namespace simd { namespace ext
      * is preserved.
      * ====================================================
      */
-    BOOST_FORCEINLINE A0 operator() (const musl_tag &, A0 x) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const musl_tag &, A0 x) const BOOST_NOEXCEPT
     {
 //       const A0
 //         Invlog_10hi<A0>()  = 4.34294481878168880939e-01, /* 0x3fdbcb7b, 0x15200000 */

--- a/include/boost/simd/arch/common/scalar/function/log1p.hpp
+++ b/include/boost/simd/arch/common/scalar/function/log1p.hpp
@@ -47,7 +47,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return musl_(log1p)(a0);
     }
@@ -59,7 +59,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
     {
       return std::log1p(a0);
     }
@@ -72,7 +72,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::single_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const musl_tag &, A0 x) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const musl_tag &, A0 x) const BOOST_NOEXCEPT
     {
       using uiA0 = bd::as_integer_t<A0, unsigned>;
       using iA0 = bd::as_integer_t<A0,   signed>;
@@ -133,7 +133,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::double_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const musl_tag &, A0 x) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const musl_tag &, A0 x) const BOOST_NOEXCEPT
     {
       using uiA0 = bd::as_integer_t<A0, unsigned>;
       using iA0 = bd::as_integer_t<A0,   signed>;
@@ -195,7 +195,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const plain_tag &, A0 x) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const plain_tag &, A0 x) const BOOST_NOEXCEPT
     {
       return musl_(log1p)(x); //the "plain" version of the algorithm is never speedier than the "musl" version.
       // the call is here to allow a scalar fallback to simd calls

--- a/include/boost/simd/arch/common/scalar/function/log2.hpp
+++ b/include/boost/simd/arch/common/scalar/function/log2.hpp
@@ -53,7 +53,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 const& a0) const BOOST_NOEXCEPT
     {
       return musl_(log2)(a0);
     }
@@ -65,7 +65,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::arithmetic_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 const& a0) const BOOST_NOEXCEPT
     {
       return bs::ilog2(a0);
     }
@@ -78,7 +78,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::arithmetic_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &, A0 a0
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &, A0 a0
                                     ) const BOOST_NOEXCEPT
     {
       return std::log2(a0);
@@ -92,7 +92,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::arithmetic_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &, A0 a0
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &, A0 a0
                                     ) const BOOST_NOEXCEPT
     {
       return musl_(log2(a0));
@@ -117,7 +117,7 @@ namespace boost { namespace simd { namespace ext
      * is preserved.
      * ====================================================
      */
-     BOOST_FORCEINLINE A0 operator() (const musl_tag &, A0 x) const BOOST_NOEXCEPT
+     BOOST_MAYBEINLINE A0 operator() (const musl_tag &, A0 x) const BOOST_NOEXCEPT
     {
       using uiA0 = bd::as_integer_t<A0, unsigned>;
       using iA0 = bd::as_integer_t<A0,   signed>;
@@ -185,7 +185,7 @@ namespace boost { namespace simd { namespace ext
      * is preserved.
      * ====================================================
      */
-    BOOST_FORCEINLINE A0 operator() (const musl_tag &, A0 x) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const musl_tag &, A0 x) const BOOST_NOEXCEPT
     {
       using uiA0 = bd::as_integer_t<A0, unsigned>;
       using iA0 = bd::as_integer_t<A0,   signed>;
@@ -281,7 +281,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const plain_tag &, A0 x) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const plain_tag &, A0 x) const BOOST_NOEXCEPT
     {
       return musl_(log2)(x); //the "plain" version of the algorithm is never speedier than the "musl" version.
       // the call is here to allow a scalar fallback to simd calls

--- a/include/boost/simd/arch/common/scalar/function/nextafter.hpp
+++ b/include/boost/simd/arch/common/scalar/function/nextafter.hpp
@@ -35,7 +35,7 @@ namespace boost { namespace simd {
                             , bd::scalar_< bd::floating_<A0> >
                             )
     {
-      BOOST_FORCEINLINE A0 operator() ( A0 x, A0 y) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator() ( A0 x, A0 y) const BOOST_NOEXCEPT
       {
         return  (y >  x)  ? next(x) : ((y <  x) ?  prev(x) : x);
       }
@@ -47,7 +47,7 @@ namespace boost { namespace simd {
                             , bd::scalar_< bd::arithmetic_<A0> >
                             )
     {
-      BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
       {
         return a0+sign(a1-a0);
       }
@@ -59,7 +59,7 @@ namespace boost { namespace simd {
                             , bd::scalar_< bd::unsigned_<A0> >
                             )
     {
-      BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
       {
         return (a1 == a0) ? a0 : (a1 > a0) ? saturated_(inc)(a0) : saturated_(dec)(a0);
       }
@@ -72,7 +72,7 @@ namespace boost { namespace simd {
                             , bd::scalar_< bd::floating_<A0> >
                             )
     {
-      BOOST_FORCEINLINE A0 operator() (const std_tag &, A0  a0, A0 a1
+      BOOST_MAYBEINLINE A0 operator() (const std_tag &, A0  a0, A0 a1
                                       ) const BOOST_NOEXCEPT
       {
         return std::nextafter(a0, a1);
@@ -86,7 +86,7 @@ namespace boost { namespace simd {
                             , bd::scalar_< bd::integer_<A0> >
                             )
     {
-      BOOST_FORCEINLINE A0 operator() (const std_tag &, A0  a0, A0 a1
+      BOOST_MAYBEINLINE A0 operator() (const std_tag &, A0  a0, A0 a1
                                       ) const BOOST_NOEXCEPT
       {
         return bs::nextafter(a0, a1);

--- a/include/boost/simd/arch/common/scalar/function/pow.hpp
+++ b/include/boost/simd/arch/common/scalar/function/pow.hpp
@@ -72,7 +72,7 @@ namespace boost { namespace simd { namespace ext
   {
     using result_type = A0;
 
-    BOOST_FORCEINLINE result_type operator() ( A0 a0, A1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE result_type operator() ( A0 a0, A1) const BOOST_NOEXCEPT
     {
       return pow_expander<A1::value>::call(a0);
     }
@@ -87,17 +87,17 @@ namespace boost { namespace simd { namespace ext
   {
     using result_type = A0;
 
-    BOOST_FORCEINLINE result_type operator() ( A0  a0, A1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE result_type operator() ( A0  a0, A1) const BOOST_NOEXCEPT
     {
       return eval(a0, boost::mpl::bool_<(A1::value >= 0)>());
     }
 
-    BOOST_FORCEINLINE result_type eval( A0  a0, boost::mpl::true_) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE result_type eval( A0  a0, boost::mpl::true_) const BOOST_NOEXCEPT
     {
       return pow_expander<A1::value>::call(a0);
     }
 
-    BOOST_FORCEINLINE result_type eval( A0  a0, boost::mpl::false_) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE result_type eval( A0  a0, boost::mpl::false_) const BOOST_NOEXCEPT
     {
       return pow_expander<-A1::value>::call(rec(a0));
     }
@@ -139,7 +139,7 @@ namespace boost { namespace simd { namespace ext
   {
     using result_type = A0;
 
-    BOOST_FORCEINLINE A0 operator() ( A0  a0, A1  a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0  a0, A1  a1) const BOOST_NOEXCEPT
     {
       BOOST_ASSERT_MSG( boost::simd::assert_all(a1 >= 0), "integral pow with signed exponent" );
 

--- a/include/boost/simd/arch/common/scalar/function/predecessor.hpp
+++ b/include/boost/simd/arch/common/scalar/function/predecessor.hpp
@@ -32,7 +32,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::integer_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
       BOOST_ASSERT_MSG(is_gez(a1), "predecessor rank must be non negative");
       if (Valmin<A0>()+a1 > a0) return Valmin<A0>();
@@ -46,7 +46,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::arithmetic_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return saturated_(dec)(a0);
     }
@@ -59,7 +59,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::integer_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
     {
       using i_t = bd::as_integer_t<A0>;
       BOOST_ASSERT_MSG(is_gez(a1), "predecessor rank must be non negative");
@@ -74,7 +74,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       if (is_nan(a0)) return a0;
       return bitfloating(saturated_(dec)(bitinteger(a0)));

--- a/include/boost/simd/arch/common/scalar/function/rem.hpp
+++ b/include/boost/simd/arch/common/scalar/function/rem.hpp
@@ -32,7 +32,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::arithmetic_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
       return a1 ? a0%a1 : a0;
     }
@@ -45,7 +45,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (pedantic_tag const &
+    BOOST_MAYBEINLINE A0 operator() (pedantic_tag const &
                                     , A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
       if (is_nez(a1)&&is_eqz(a0)) return a0;
@@ -62,7 +62,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::arithmetic_<T>>
                           )
   {
-    BOOST_FORCEINLINE T operator()( bd::functor<bs::tag::fix_> const&
+    BOOST_MAYBEINLINE T operator()( bd::functor<bs::tag::fix_> const&
                                   , T const& a, T const& b ) const BOOST_NOEXCEPT
     {
       return pedantic_(rem)(a, b);
@@ -76,7 +76,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
       return fnms(a1, div(fix, a0, a1), a0);
     }
@@ -91,7 +91,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &, bd::functor<bs::tag::fix_> const&
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &, bd::functor<bs::tag::fix_> const&
                                     , A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
       return std::fmod(a0, a1);
@@ -106,7 +106,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::arithmetic_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (bd::functor<bs::tag::fix_> const&
+    BOOST_MAYBEINLINE A0 operator() (bd::functor<bs::tag::fix_> const&
                                     , A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
       return fnms(a1, div(fix, a0, a1), a0);
@@ -120,7 +120,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &,  A0 a0, A0 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &,  A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
      return std::fmod(a0, a1);
     }

--- a/include/boost/simd/arch/common/scalar/function/rol.hpp
+++ b/include/boost/simd/arch/common/scalar/function/rol.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::unsigned_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A0 a1) const
     {
       BOOST_ASSERT_MSG(assert_good_shift<A0>(a1), "rol : rotation is out of range");
 
@@ -47,7 +47,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::integer_<A1> >
   )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1 ) const
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 a1 ) const
     {
       using i_t = bd::as_integer_t<A0, unsigned>;
       return bitwise_cast<A0>( rol ( bitwise_cast<i_t>(a0), i_t(a1)));

--- a/include/boost/simd/arch/common/scalar/function/ror.hpp
+++ b/include/boost/simd/arch/common/scalar/function/ror.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::unsigned_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A0 a1) const
     {
       BOOST_ASSERT_MSG(assert_good_shift<A0>(a1), "ror : rotation is out of range");
 
@@ -47,7 +47,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::integer_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1) const
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 a1) const
     {
       using i_t = bd::as_integer_t<A0, unsigned>;
       return bitwise_cast<A0>( ror (bitwise_cast<i_t>(a0), i_t(a1)) );

--- a/include/boost/simd/arch/common/scalar/function/round.hpp
+++ b/include/boost/simd/arch/common/scalar/function/round.hpp
@@ -34,7 +34,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::integer_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return a0;
     }
@@ -46,7 +46,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::single_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       const A0 v = bs::abs(a0);
       if (!(v <=  Maxflint<A0>())) return a0;
@@ -60,7 +60,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::double_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       const A0 v = simd::abs(a0);
       if (!(v <=  Maxflint<A0>())) return a0;
@@ -76,7 +76,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                          )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &
                                     ,  A0  a0) const BOOST_NOEXCEPT
     {
       return std::round(a0);
@@ -90,7 +90,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::integer_<A0> >
                          )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &
                                     ,  A0  a0) const BOOST_NOEXCEPT
     {
       return a0;
@@ -104,7 +104,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::int_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
     {
        using i_t = bd::as_integer_t<A0>;
        A0 fac = tenpower(i_t(a1));
@@ -121,7 +121,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::uint_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
     {
        using i_t = bd::as_integer_t<A0>;
        A0 fac = tenpower(i_t(a1));

--- a/include/boost/simd/arch/common/scalar/function/rrol.hpp
+++ b/include/boost/simd/arch/common/scalar/function/rrol.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::int_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
     {
       return (a1 > 0)? rol(a0, a1) : ror(a0, -a1);
     }
@@ -39,7 +39,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::uint_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
     {
       return  rol(a0, a1);
     }

--- a/include/boost/simd/arch/common/scalar/function/rror.hpp
+++ b/include/boost/simd/arch/common/scalar/function/rror.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::int_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
     {
       return (a1 > 0) ? ror(a0, a1) :rol(a0, -a1);
     }
@@ -38,7 +38,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::uint_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
     {
       return ror(a0, a1);
     }

--- a/include/boost/simd/arch/common/scalar/function/rsqrt.hpp
+++ b/include/boost/simd/arch/common/scalar/function/rsqrt.hpp
@@ -29,7 +29,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return bs::rec(bs::sqrt(a0));
     }
@@ -42,7 +42,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::single_<A0> >
                          )
   {
-    BOOST_FORCEINLINE A0 operator() (const raw_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const raw_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       typedef bd::as_integer_t<A0> i_t;
 
@@ -68,7 +68,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::double_<A0> >
                          )
   {
-    BOOST_FORCEINLINE A0 operator() (const raw_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const raw_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return bs::rsqrt(a0);
     }
@@ -81,7 +81,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                          )
   {
-    BOOST_FORCEINLINE A0 operator() (const pedantic_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const pedantic_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return bs::rec(bs::sqrt(a0));
     }

--- a/include/boost/simd/arch/common/scalar/function/sec.hpp
+++ b/include/boost/simd/arch/common/scalar/function/sec.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return sec(a0, tag::big_);
     }
@@ -39,7 +39,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 const&) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 const&) const BOOST_NOEXCEPT
     {
       return rec(cos(a0, A1()));
     }
@@ -51,7 +51,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return rec(restricted_(cos)(a0));
     }

--- a/include/boost/simd/arch/common/scalar/function/secd.hpp
+++ b/include/boost/simd/arch/common/scalar/function/secd.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return secd(a0, tag::big_);
     }
@@ -42,7 +42,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 const&) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 const&) const BOOST_NOEXCEPT
     {
       return if_nan_else(is_flint((a0- Ratio<A0,90>())*Ratio<A0,1,180>())
                         , rec(cosd(a0,A1())));
@@ -55,7 +55,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return rec(restricted_(cosd)(a0));
     }

--- a/include/boost/simd/arch/common/scalar/function/sech.hpp
+++ b/include/boost/simd/arch/common/scalar/function/sech.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
     using result_t = A0;
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return bs::rec(bs::cosh(a0));
     }

--- a/include/boost/simd/arch/common/scalar/function/secpi.hpp
+++ b/include/boost/simd/arch/common/scalar/function/secpi.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return secpi(a0, tag::big_);
     }
@@ -42,7 +42,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 const&) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 const&) const BOOST_NOEXCEPT
     {
       return if_nan_else(is_flint(a0-Half<A0>()), rec(cospi(a0, A1())));
     }
@@ -54,7 +54,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return rec(restricted_(cospi)(a0));
     }

--- a/include/boost/simd/arch/common/scalar/function/significants.hpp
+++ b/include/boost/simd/arch/common/scalar/function/significants.hpp
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
 
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
     {
       BOOST_ASSERT_MSG( assert_all(is_gtz(a1))
                       , "Number of significant digits must be positive"

--- a/include/boost/simd/arch/common/scalar/function/sin.hpp
+++ b/include/boost/simd/arch/common/scalar/function/sin.hpp
@@ -29,7 +29,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
     {
       return std::sin(a0);
     }
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0  a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0  a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::radian_tag,tag::not_simd_type,tag::big_tag>::sina(a0);
     }
@@ -53,7 +53,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0  a0,  A1 ) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0  a0,  A1 ) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::radian_tag,tag::not_simd_type,A1>::sina(a0);
     }
@@ -65,7 +65,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0  a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0  a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::radian_tag,tag::not_simd_type,tag::clipped_pio4_tag>::sina(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/sinc.hpp
+++ b/include/boost/simd/arch/common/scalar/function/sinc.hpp
@@ -34,7 +34,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       #if !defined(BOOST_SIMD_NO_INFINITIES)
       if(is_inf(a0)) return Zero<A0>();

--- a/include/boost/simd/arch/common/scalar/function/sincos.hpp
+++ b/include/boost/simd/arch/common/scalar/function/sincos.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE std::pair<A0, A0> operator() ( A0 a0) const
+    BOOST_MAYBEINLINE std::pair<A0, A0> operator() ( A0 a0) const
     {
       return detail::trig_base <A0,tag::radian_tag,tag::not_simd_type,tag::big_tag>::sincosa(a0);
     }
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE std::pair<A0, A0> operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE std::pair<A0, A0> operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0, tag::radian_tag,tag::not_simd_type,tag::clipped_pio4_tag>::sincosa(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/sincosd.hpp
+++ b/include/boost/simd/arch/common/scalar/function/sincosd.hpp
@@ -29,7 +29,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
     using result_t = std::pair<A0, A0>                     ;
-    BOOST_FORCEINLINE result_t operator() ( A0 a0) const
+    BOOST_MAYBEINLINE result_t operator() ( A0 a0) const
     {
       return detail::trig_base <A0,tag::degree_tag,tag::not_simd_type,tag::big_tag>::sincosa(a0);
     }
@@ -42,7 +42,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE std::pair<A0, A0> operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE std::pair<A0, A0> operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0, tag::degree_tag,tag::not_simd_type,tag::clipped_pio4_tag>::sincosa(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/sincpi.hpp
+++ b/include/boost/simd/arch/common/scalar/function/sincpi.hpp
@@ -35,7 +35,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       #if !defined(BOOST_SIMD_NO_INFINITIES)
       if(is_inf(a0)) return Zero<A0>();

--- a/include/boost/simd/arch/common/scalar/function/sind.hpp
+++ b/include/boost/simd/arch/common/scalar/function/sind.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::not_simd_type,tag::big_tag>::sina(a0);
     }
@@ -39,7 +39,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::not_simd_type,tag::clipped_pio4_tag>::sina(a0);
     }
@@ -51,7 +51,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0,  A1 const &) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0,  A1 const &) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::not_simd_type,A1>::sina(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/sinh.hpp
+++ b/include/boost/simd/arch/common/scalar/function/sinh.hpp
@@ -37,7 +37,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       //////////////////////////////////////////////////////////////////////////////
       // if x = abs(a0) is less than 1 sinh is computed using a polynomial(float)
@@ -78,7 +78,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                          )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &,  A0  a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &,  A0  a0) const BOOST_NOEXCEPT
     {
       return std::sinh(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/sinhc.hpp
+++ b/include/boost/simd/arch/common/scalar/function/sinhc.hpp
@@ -39,7 +39,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
 
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       //////////////////////////////////////////////////////////////////////////////
       // if x = abs(a0) is less than 1 sinhc is computed using a polynomial(float)

--- a/include/boost/simd/arch/common/scalar/function/sinhcosh.hpp
+++ b/include/boost/simd/arch/common/scalar/function/sinhcosh.hpp
@@ -47,7 +47,7 @@ namespace boost { namespace simd { namespace ext
     // Threshold is Maxlog - Log_2
     //////////////////////////////////////////////////////////////////////////////
     using result_t = std::pair<A0, A0>;
-    BOOST_FORCEINLINE result_t operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE result_t operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       A0 x = bs::abs(a0);
       auto test1 = (x >  Maxlog<A0>()-Log_2<A0>());

--- a/include/boost/simd/arch/common/scalar/function/sinpi.hpp
+++ b/include/boost/simd/arch/common/scalar/function/sinpi.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::not_simd_type,tag::big_tag>::sina(a0);
     }
@@ -39,7 +39,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::not_simd_type,tag::clipped_pio4_tag>::sina(a0);
     }
@@ -51,7 +51,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0,  A1 const &) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0,  A1 const &) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::not_simd_type,tag::big_tag>::sina(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/sqrt.hpp
+++ b/include/boost/simd/arch/common/scalar/function/sqrt.hpp
@@ -35,7 +35,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::double_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0  a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0  a0) const BOOST_NOEXCEPT
     {
       return ::sqrt(a0);
     }
@@ -46,7 +46,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::single_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return std::sqrt(a0);
     }
@@ -57,7 +57,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::integer_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       BOOST_ASSERT_MSG(is_gez(a0), "sqrt input is negative");
 
@@ -71,7 +71,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &,  A0  a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &,  A0  a0) const BOOST_NOEXCEPT
     {
       return std::sqrt(a0);
     }
@@ -84,7 +84,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const raw_tag &,  A0  a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const raw_tag &,  A0  a0) const BOOST_NOEXCEPT
     {
       if (is_ngez(a0)) return Nan<A0>();
       if (is_eqz(a0)) return Zero<A0>();
@@ -99,7 +99,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::integer_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const raw_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const raw_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       BOOST_ASSERT_MSG( is_positive(a0)
                       , "sqrt integer domain is restricted to positive integer."

--- a/include/boost/simd/arch/common/scalar/function/stirling.hpp
+++ b/include/boost/simd/arch/common/scalar/function/stirling.hpp
@@ -37,7 +37,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 a0) const BOOST_NOEXCEPT
     {
       if (is_ltz(a0)) return Nan<A0>();
       const A0 Stirlinglargelim = Real<A0, 0x4065800000000000ULL, 0X420C28F3UL>();// 172, 35.0399895f

--- a/include/boost/simd/arch/common/scalar/function/successor.hpp
+++ b/include/boost/simd/arch/common/scalar/function/successor.hpp
@@ -32,7 +32,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::arithmetic_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
        return saturated_(inc)(a0);
     }
@@ -44,7 +44,7 @@ namespace boost { namespace simd { namespace ext
                                     , bd::scalar_< bd::floating_<A0> >
                                     )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       if (is_nan(a0)) return a0;
       return bitfloating(saturated_(inc)(bitinteger(a0)));
@@ -58,7 +58,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::integer_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
       BOOST_ASSERT_MSG(is_gez(a1), "predecessor rank must be non negative");
       if (Valmax<A0>()-a1 < a0) return Valmax<A0>();
@@ -73,7 +73,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::integer_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A1 a1) const BOOST_NOEXCEPT
     {
       BOOST_ASSERT_MSG(is_gez(a1), "predecessor rank must be non negative");
       using itype = bd::as_integer_t<A0, signed>;

--- a/include/boost/simd/arch/common/scalar/function/tan.hpp
+++ b/include/boost/simd/arch/common/scalar/function/tan.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag &, A0 a0) const BOOST_NOEXCEPT
     {
       return std::tan(a0);
     }
@@ -42,7 +42,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::radian_tag,tag::not_simd_type,tag::big_tag>::tana(a0);
     }
@@ -54,7 +54,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0,  A1 ) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0,  A1 ) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::radian_tag,tag::not_simd_type,A1>::tana(a0);
     }
@@ -66,7 +66,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::radian_tag,tag::not_simd_type,tag::clipped_pio4_tag>::tana(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/tand.hpp
+++ b/include/boost/simd/arch/common/scalar/function/tand.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::not_simd_type,tag::big_tag>::tana(a0);
     }
@@ -39,7 +39,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0,  A1 const &) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0,  A1 const &) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::not_simd_type,A1>::tana(a0);
     }
@@ -51,7 +51,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::not_simd_type,tag::clipped_pio4_tag>::tana(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/tanh.hpp
+++ b/include/boost/simd/arch/common/scalar/function/tanh.hpp
@@ -38,7 +38,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
 
-    BOOST_FORCEINLINE A0 operator() ( A0  a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0  a0) const BOOST_NOEXCEPT
     {
       //////////////////////////////////////////////////////////////////////////////
       // if x = abs(a0) is less than 5/8 sinh is computed using a polynomial(float)
@@ -67,7 +67,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const std_tag&, A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const std_tag&, A0 a0) const BOOST_NOEXCEPT
     {
       return std::tanh(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/tanpi.hpp
+++ b/include/boost/simd/arch/common/scalar/function/tanpi.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::not_simd_type,tag::big_tag>::tana(a0);
     }
@@ -39,7 +39,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0,  A1 const &) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0,  A1 const &) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::not_simd_type,A1>::tana(a0);
     }
@@ -51,7 +51,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::not_simd_type,tag::clipped_pio4_tag>::tana(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/tenpower.hpp
+++ b/include/boost/simd/arch/common/scalar/function/tenpower.hpp
@@ -33,7 +33,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
     using result_t = bd::as_floating_t<A0>;
-    BOOST_FORCEINLINE result_t operator() ( A0 expo) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE result_t operator() ( A0 expo) const BOOST_NOEXCEPT
     {
 
       result_t result = One<result_t>();
@@ -57,7 +57,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
     using result_t = bd::as_floating_t<A0>;
-    BOOST_FORCEINLINE result_t operator() ( A0 expo) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE result_t operator() ( A0 expo) const BOOST_NOEXCEPT
     {
       result_t result = One<result_t>();
       result_t base = Ten<result_t>();

--- a/include/boost/simd/arch/common/scalar/function/toint.hpp
+++ b/include/boost/simd/arch/common/scalar/function/toint.hpp
@@ -22,7 +22,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::integer_<A0> >
                           )
   {
-    BOOST_FORCEINLINE bd::as_integer_t<A0, signed> operator() ( A0  a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE bd::as_integer_t<A0, signed> operator() ( A0  a0) const BOOST_NOEXCEPT
     {
       return a0;
     }
@@ -34,7 +34,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
     using result_t = bd::as_integer_t<A0, signed>;
-    BOOST_FORCEINLINE result_t operator() ( A0  a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE result_t operator() ( A0  a0) const BOOST_NOEXCEPT
     {
       return result_t(a0);
     }

--- a/include/boost/simd/arch/common/scalar/function/ulpdist.hpp
+++ b/include/boost/simd/arch/common/scalar/function/ulpdist.hpp
@@ -36,7 +36,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::int_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
       return (a0>a1) ? saturated_(minus)(a0,a1) : saturated_(minus)(a1,a0);
     }
@@ -49,7 +49,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::uint_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
       return dist(a0,a1);
     }
@@ -62,7 +62,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::floating_<A0> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 a0, A0 a1) const BOOST_NOEXCEPT
     {
       using i_t = bd::as_integer_t<A0>;
 

--- a/include/boost/simd/arch/common/simd/function/acos.hpp
+++ b/include/boost/simd/arch/common/simd/function/acos.hpp
@@ -32,7 +32,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
 
-    BOOST_FORCEINLINE A0 operator() (const pedantic_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const pedantic_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       //Exhaustive test for: boost::simd::detail::decorated_functor<boost::simd::tag::acos_, boost::simd::sse4_2_, boost::simd::pedantic_tag>
       //             versus: raw_acos
@@ -55,7 +55,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
 
-    BOOST_FORCEINLINE A0 operator() (A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 const& a0) const BOOST_NOEXCEPT
     {
       //Exhaustive test for: boost::dispatch::functor<boost::simd::tag::acos_, boost::simd::sse4_2_>
       //             versus: raw_acos

--- a/include/boost/simd/arch/common/simd/function/acosd.hpp
+++ b/include/boost/simd/arch/common/simd/function/acosd.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return indeg(bs::acos(a0));
     }
@@ -42,7 +42,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const pedantic_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const pedantic_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return indeg(bs::pedantic_(bs::acos)(a0));
     }

--- a/include/boost/simd/arch/common/simd/function/acosh.hpp
+++ b/include/boost/simd/arch/common/simd/function/acosh.hpp
@@ -33,7 +33,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         A0 t = dec(a0);
         auto test = is_greater(t,Oneotwoeps<A0>());

--- a/include/boost/simd/arch/common/simd/function/acospi.hpp
+++ b/include/boost/simd/arch/common/simd/function/acospi.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return Invpi<A0>()*acos(a0);
     }
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const pedantic_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const pedantic_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return Invpi<A0>()*bs::pedantic_(acos)(a0);
     }

--- a/include/boost/simd/arch/common/simd/function/acot.hpp
+++ b/include/boost/simd/arch/common/simd/function/acot.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::invtrig_base<A0,tag::radian_tag,tag::simd_type>::acot(a0);
     }

--- a/include/boost/simd/arch/common/simd/function/acotd.hpp
+++ b/include/boost/simd/arch/common/simd/function/acotd.hpp
@@ -37,7 +37,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       A0 z = Ratio<A0, 90>()-if_else_zero(is_nez(a0),atand(bs::abs(a0)));
       #ifndef BOOST_SIMD_NO_INFINITIES

--- a/include/boost/simd/arch/common/simd/function/acoth.hpp
+++ b/include/boost/simd/arch/common/simd/function/acoth.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::unspecified_<A0>, X>
                           )
   {
-     BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+     BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return bs::atanh(rec(a0));
     }

--- a/include/boost/simd/arch/common/simd/function/acotpi.hpp
+++ b/include/boost/simd/arch/common/simd/function/acotpi.hpp
@@ -37,7 +37,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       A0 z =Half<A0>()-if_else_zero(is_nez(a0),atanpi(bs::abs(a0)));
       #ifndef BOOST_SIMD_NO_INFINITIES

--- a/include/boost/simd/arch/common/simd/function/acsc.hpp
+++ b/include/boost/simd/arch/common/simd/function/acsc.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return asin(rec(a0));
     }

--- a/include/boost/simd/arch/common/simd/function/acsch.hpp
+++ b/include/boost/simd/arch/common/simd/function/acsch.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                             , bs::pack_< bd::unspecified_<A0>, X>
                             )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 const& a0) const BOOST_NOEXCEPT
     {
       return bs::asinh(bs::rec(a0));
     }

--- a/include/boost/simd/arch/common/simd/function/asec.hpp
+++ b/include/boost/simd/arch/common/simd/function/asec.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::double_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const A0& a0) const BOOST_NOEXCEPT
     {
       A0 tmp =  (Pio_2<A0>()-acsc(a0)) +  Constant<A0, 0x3c91a62633145c07ll>();
       return if_zero_else(is_equal(a0, One<A0>()), tmp);
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         return (bs::Pio_2<A0>()-bs::acsc(a0));
       }

--- a/include/boost/simd/arch/common/simd/function/asech.hpp
+++ b/include/boost/simd/arch/common/simd/function/asech.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::unspecified_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return bs::acosh(bs::rec(a0));
     }

--- a/include/boost/simd/arch/common/simd/function/asin.hpp
+++ b/include/boost/simd/arch/common/simd/function/asin.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::invtrig_base<A0,tag::radian_tag,tag::simd_type>::asin(a0);
     }

--- a/include/boost/simd/arch/common/simd/function/asind.hpp
+++ b/include/boost/simd/arch/common/simd/function/asind.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                             , bs::pack_< bd::floating_<A0>, X>
                             )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return indeg(asin(a0));
     }

--- a/include/boost/simd/arch/common/simd/function/asinh.hpp
+++ b/include/boost/simd/arch/common/simd/function/asinh.hpp
@@ -52,7 +52,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::double_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         A0 x =  bs::abs(a0);
         auto test = is_greater(x,Oneosqrteps<A0>());
@@ -72,7 +72,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::single_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         // Exhaustive test for: boost::dispatch::functor<bs::tag::asinh_, bs::tag::sse4_2_>
         //              versus: float(boost::math::asinh(double)

--- a/include/boost/simd/arch/common/simd/function/asinpi.hpp
+++ b/include/boost/simd/arch/common/simd/function/asinpi.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return Invpi<A0>()*asin(a0);
     }

--- a/include/boost/simd/arch/common/simd/function/atan.hpp
+++ b/include/boost/simd/arch/common/simd/function/atan.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::invtrig_base<A0,tag::radian_tag,tag::simd_type>::atan(a0);
     }

--- a/include/boost/simd/arch/common/simd/function/atan2d.hpp
+++ b/include/boost/simd/arch/common/simd/function/atan2d.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_< bd::floating_<A0>, X>
                              )
   {
-    BOOST_FORCEINLINE A0 operator() (const pedantic_tag &,
+    BOOST_MAYBEINLINE A0 operator() (const pedantic_tag &,
                                      A0 const& a0, A0 const& a1) const BOOST_NOEXCEPT
     {
       return indeg(pedantic_(atan2)(a0, a1));
@@ -45,7 +45,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X >
                           )
   {
-     BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A0 const& a1) const BOOST_NOEXCEPT
+     BOOST_MAYBEINLINE A0 operator() ( A0 const& a0, A0 const& a1) const BOOST_NOEXCEPT
      {
        return indeg(atan2(a0, a1));
      }

--- a/include/boost/simd/arch/common/simd/function/atan2pi.hpp
+++ b/include/boost/simd/arch/common/simd/function/atan2pi.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A1>, X >
                           )
   {
-     BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 const& a1) const BOOST_NOEXCEPT
+     BOOST_MAYBEINLINE A0 operator() ( A0 const& a0, A1 const& a1) const BOOST_NOEXCEPT
     {
       return Invpi<A0>()*(atan2(a0, a1));
     }
@@ -43,7 +43,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A1>, X >
                           )
   {
-     BOOST_FORCEINLINE A0 operator() (const pedantic_tag &,
+     BOOST_MAYBEINLINE A0 operator() (const pedantic_tag &,
                                       A0 const& a0, A1 const& a1) const BOOST_NOEXCEPT
     {
       return Invpi<A0>()*pedantic_(atan2)(a0, a1);

--- a/include/boost/simd/arch/common/simd/function/atand.hpp
+++ b/include/boost/simd/arch/common/simd/function/atand.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return indeg(atan(a0));
     }

--- a/include/boost/simd/arch/common/simd/function/atanh.hpp
+++ b/include/boost/simd/arch/common/simd/function/atanh.hpp
@@ -39,7 +39,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         A0 absa0 = bs::abs(a0);
         A0 t =  absa0+absa0;
@@ -58,7 +58,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()(const raw_tag &,
+      BOOST_MAYBEINLINE A0 operator()(const raw_tag &,
                                       const A0& a0) const BOOST_NOEXCEPT
       {
         return  Half<A0>()*log(inc(a0)/oneminus(a0));

--- a/include/boost/simd/arch/common/simd/function/atanpi.hpp
+++ b/include/boost/simd/arch/common/simd/function/atanpi.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return Invpi<A0>()*atan(a0);
     }

--- a/include/boost/simd/arch/common/simd/function/cbrt.hpp
+++ b/include/boost/simd/arch/common/simd/function/cbrt.hpp
@@ -59,7 +59,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::single_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()(const A0& a0 ) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()(const A0& a0 ) const BOOST_NOEXCEPT
       {
         A0 z =  bs::abs(a0);
         using int_type =  bd::as_integer_t<A0, signed>;
@@ -114,7 +114,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::double_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()(const A0& a0 ) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()(const A0& a0 ) const BOOST_NOEXCEPT
       {
         using int_type =  bd::as_integer_t<A0, signed>;
         A0 z =  bs::abs(a0);

--- a/include/boost/simd/arch/common/simd/function/clz.hpp
+++ b/include/boost/simd/arch/common/simd/function/clz.hpp
@@ -32,7 +32,7 @@ namespace boost { namespace simd { namespace ext
                           )
    {
       using result = bd::as_integer_t<A0>;
-      BOOST_FORCEINLINE result operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE result operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         result t =  bitwise_cast<result>(a0);
         BOOST_ASSERT_MSG( assert_all(t), "clz not defined for 0" );

--- a/include/boost/simd/arch/common/simd/function/cos.hpp
+++ b/include/boost/simd/arch/common/simd/function/cos.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::radian_tag,tag::simd_type,tag::big_tag>::cosa(a0);
     }
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0, tag::radian_tag,tag::simd_type,A1>::cosa(a0);
     }
@@ -54,7 +54,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0, tag::radian_tag,tag::simd_type,tag::clipped_pio4_tag>::cosa(a0);
     }

--- a/include/boost/simd/arch/common/simd/function/cosd.hpp
+++ b/include/boost/simd/arch/common/simd/function/cosd.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::simd_type,tag::big_tag>::cosa(a0);
     }
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::simd_type,tag::clipped_pio4_tag>::cosa(a0);
     }
@@ -54,7 +54,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::simd_type,tag::big_tag>::cosa(a0);
     }

--- a/include/boost/simd/arch/common/simd/function/cosh.hpp
+++ b/include/boost/simd/arch/common/simd/function/cosh.hpp
@@ -35,7 +35,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       //////////////////////////////////////////////////////////////////////////////
       // if x = abs(a0) according x < Threshold e =  exp(x) or exp(x/2) is

--- a/include/boost/simd/arch/common/simd/function/cospi.hpp
+++ b/include/boost/simd/arch/common/simd/function/cospi.hpp
@@ -32,7 +32,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::simd_type,tag::big_tag>::cosa(a0);
     }
@@ -45,7 +45,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::simd_type,tag::clipped_pio4_tag>::cosa(a0);
     }
@@ -57,7 +57,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 const&) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0, A1 const&) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::simd_type,A1>::cosa(a0);
     }
@@ -70,7 +70,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
     using result_t = bd::as_floating_t<A0>;
-    BOOST_FORCEINLINE result_t operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE result_t operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return bs::if_else(bs::is_odd(a0),Mone<result_t>(),One<result_t>());
     }

--- a/include/boost/simd/arch/common/simd/function/cot.hpp
+++ b/include/boost/simd/arch/common/simd/function/cot.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::radian_tag,tag::simd_type,tag::big_tag>::cota(a0);
     }
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::radian_tag,tag::simd_type,tag::clipped_pio4_tag>::cota(a0);
     }
@@ -53,7 +53,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::radian_tag,tag::simd_type,A1>::cota(a0);
     }

--- a/include/boost/simd/arch/common/simd/function/cotd.hpp
+++ b/include/boost/simd/arch/common/simd/function/cotd.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::simd_type,tag::big_tag>::cota(a0);
     }
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::simd_type,tag::clipped_pio4_tag>::cota(a0);
     }
@@ -53,7 +53,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::simd_type,A1>::cota(a0);
     }

--- a/include/boost/simd/arch/common/simd/function/coth.hpp
+++ b/include/boost/simd/arch/common/simd/function/coth.hpp
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         //////////////////////////////////////////////////////////////////////////////
         // if x = abs(a0) is less than 5/8 sinh is computed using a polynomial(float)

--- a/include/boost/simd/arch/common/simd/function/cotpi.hpp
+++ b/include/boost/simd/arch/common/simd/function/cotpi.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::simd_type,tag::big_tag>::cota(a0);
     }
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::simd_type,tag::clipped_pio4_tag>::cota(a0);
     }
@@ -53,7 +53,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 const&) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0, A1 const&) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::simd_type,A1>::cota(a0);
     }

--- a/include/boost/simd/arch/common/simd/function/csc.hpp
+++ b/include/boost/simd/arch/common/simd/function/csc.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return csc(a0, tag::big_);
     }
@@ -40,7 +40,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 const&) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0, A1 const&) const BOOST_NOEXCEPT
     {
       return rec(sin(a0, A1()));
     }
@@ -53,7 +53,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return rec(restricted_(sin)(a0));
     }

--- a/include/boost/simd/arch/common/simd/function/cscd.hpp
+++ b/include/boost/simd/arch/common/simd/function/cscd.hpp
@@ -32,7 +32,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return cscd(a0, tag::big_);
     }
@@ -44,7 +44,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 const&) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0, A1 const&) const BOOST_NOEXCEPT
     {
       return if_nan_else( is_nez(a0)&&is_flint(a0*Ratio<A0,1,180>())
                         , rec(sind(a0, A1())));
@@ -58,7 +58,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return rec(restricted_(sind)(a0));
     }

--- a/include/boost/simd/arch/common/simd/function/csch.hpp
+++ b/include/boost/simd/arch/common/simd/function/csch.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::unspecified_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return rec(bs::sinh(a0));
     }

--- a/include/boost/simd/arch/common/simd/function/cscpi.hpp
+++ b/include/boost/simd/arch/common/simd/function/cscpi.hpp
@@ -33,7 +33,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return cscpi(a0, tag::big_);
     }
@@ -45,7 +45,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 const&) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0, A1 const&) const BOOST_NOEXCEPT
     {
       return if_nan_else(is_nez(a0)&&is_flint(a0), rec(sinpi(a0, A1())));
     }
@@ -58,7 +58,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return rec(restricted_(sinpi)(a0));
     }

--- a/include/boost/simd/arch/common/simd/function/div.hpp
+++ b/include/boost/simd/arch/common/simd/function/div.hpp
@@ -46,7 +46,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<T>, X>
                           )
   {
-    BOOST_FORCEINLINE bd::as_integer_t<T> operator()( bd::functor<bs::tag::ifix_> const&
+    BOOST_MAYBEINLINE bd::as_integer_t<T> operator()( bd::functor<bs::tag::ifix_> const&
                                                     , T const& a, T const& b ) const BOOST_NOEXCEPT
     {
       return saturated_(toint)(a/b);
@@ -61,7 +61,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<T>, X>
                           )
   {
-    BOOST_FORCEINLINE bd::as_integer_t<T> operator()( bd::functor<bs::tag::iceil_> const&
+    BOOST_MAYBEINLINE bd::as_integer_t<T> operator()( bd::functor<bs::tag::iceil_> const&
                                                     , T const& a, T const& b ) const BOOST_NOEXCEPT
     {
       return iceil(a/b);
@@ -77,7 +77,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<T>, X>
                           )
   {
-    BOOST_FORCEINLINE bd::as_integer_t<T> operator()( bd::functor<bs::tag::ifloor_> const&
+    BOOST_MAYBEINLINE bd::as_integer_t<T> operator()( bd::functor<bs::tag::ifloor_> const&
                                                     ,T const& a, T const& b) const BOOST_NOEXCEPT
     {
       return ifloor(a/b);
@@ -93,7 +93,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<T>, X>
                           )
   {
-    BOOST_FORCEINLINE  bd::as_integer_t<T>  operator()( bd::functor<bs::tag::iround_> const&
+    BOOST_MAYBEINLINE  bd::as_integer_t<T>  operator()( bd::functor<bs::tag::iround_> const&
                                                       ,T const& a, T const& b) const BOOST_NOEXCEPT
     {
       return iround(a/b);
@@ -109,7 +109,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<T>, X>
                           )
   {
-    BOOST_FORCEINLINE bd::as_integer_t<T> operator()( bd::functor<bs::tag::inearbyint_> const&
+    BOOST_MAYBEINLINE bd::as_integer_t<T> operator()( bd::functor<bs::tag::inearbyint_> const&
                                                     ,T const& a, T const& b) const BOOST_NOEXCEPT
     {
       return pedantic_(inearbyint)(a/b);
@@ -129,7 +129,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::integer_<T>, X>
                           )
   {
-    BOOST_FORCEINLINE T operator()( bd::functor<bs::tag::ifix_> const&
+    BOOST_MAYBEINLINE T operator()( bd::functor<bs::tag::ifix_> const&
                                                     , T const& a, T const& b ) const BOOST_NOEXCEPT
     {
       return  div(fix, a, b);
@@ -144,7 +144,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::integer_<T>, X>
                           )
   {
-    BOOST_FORCEINLINE T operator()( bd::functor<bs::tag::iceil_> const&
+    BOOST_MAYBEINLINE T operator()( bd::functor<bs::tag::iceil_> const&
                                                     , T const& a, T const& b ) const BOOST_NOEXCEPT
     {
       return div(ceil, a, b);
@@ -160,7 +160,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::integer_<T>, X>
                           )
   {
-    BOOST_FORCEINLINE T operator()( bd::functor<bs::tag::ifloor_> const&
+    BOOST_MAYBEINLINE T operator()( bd::functor<bs::tag::ifloor_> const&
                                                     ,T const& a, T const& b) const BOOST_NOEXCEPT
     {
       return  div(floor, a, b);
@@ -176,7 +176,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::integer_<T>, X>
                           )
   {
-    BOOST_FORCEINLINE T operator()( bd::functor<bs::tag::iround_> const&
+    BOOST_MAYBEINLINE T operator()( bd::functor<bs::tag::iround_> const&
                                                     ,T const& a, T const& b) const BOOST_NOEXCEPT
     {
       return div(round, a, b);
@@ -192,7 +192,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::integer_<T>, X>
                           )
   {
-    BOOST_FORCEINLINE T operator()( bd::functor<bs::tag::inearbyint_> const&
+    BOOST_MAYBEINLINE T operator()( bd::functor<bs::tag::inearbyint_> const&
                                   ,T const& a, T const& b) const BOOST_NOEXCEPT
     {
       return  div(nearbyint, a, b);
@@ -207,7 +207,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::arithmetic_<T>, X>
                           )
   {
-    BOOST_FORCEINLINE T operator()(T const& a, T const& b ) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE T operator()(T const& a, T const& b ) const BOOST_NOEXCEPT
     {
       return divides(a, b);
     }

--- a/include/boost/simd/arch/common/simd/function/divides.hpp
+++ b/include/boost/simd/arch/common/simd/function/divides.hpp
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()(const saturated_tag &
+      BOOST_MAYBEINLINE A0 operator()(const saturated_tag &
                                      , const A0& a0, const A0& a1) const BOOST_NOEXCEPT
       {
         return a0/a1;
@@ -56,7 +56,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::uint_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()(const saturated_tag &
+      BOOST_MAYBEINLINE A0 operator()(const saturated_tag &
                                      , const A0& a0, const A0& a1) const BOOST_NOEXCEPT
       {
         auto iseqza1 = is_eqz(a1);
@@ -74,7 +74,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::int_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()(const saturated_tag &
+      BOOST_MAYBEINLINE A0 operator()(const saturated_tag &
                                      , const A0& a0, const A0& a1) const BOOST_NOEXCEPT
       {
         using sA0 = bd::scalar_of_t<A0>;
@@ -98,7 +98,7 @@ namespace boost { namespace simd { namespace ext
                           ,  bd::generic_<bd::fundamental_<T>>
                           )
   {
-    BOOST_FORCEINLINE T operator()(const saturated_tag &, const T& a, const T& b) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE T operator()(const saturated_tag &, const T& a, const T& b) const BOOST_NOEXCEPT
     {
       return saturated_(divides)(a, b);
     }

--- a/include/boost/simd/arch/common/simd/function/exp.hpp
+++ b/include/boost/simd/arch/common/simd/function/exp.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace simd { namespace ext
                             , bs::pack_< bd::floating_<A0>, X>
                             )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::exponential<A0,bs::tag::exp_,tag::simd_type>::expa(a0);
     }

--- a/include/boost/simd/arch/common/simd/function/exp2.hpp
+++ b/include/boost/simd/arch/common/simd/function/exp2.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                             , bs::pack_<bd::floating_<A0>,X>
                             )
   {
-    BOOST_FORCEINLINE A0 operator()(A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator()(A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::exponential<A0,bs::tag::exp2_,tag::simd_type>::expa(a0);
     }

--- a/include/boost/simd/arch/common/simd/function/expm1.hpp
+++ b/include/boost/simd/arch/common/simd/function/expm1.hpp
@@ -33,7 +33,7 @@ namespace boost { namespace simd { namespace ext
                             , bs::pack_<bd::floating_<A0>,X>
                             )
   {
-    BOOST_FORCEINLINE A0 operator()(A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator()(A0 const& a0) const BOOST_NOEXCEPT
     {
       using sA0 = bd::scalar_of_t<A0>;
       return if_else(is_less(a0, Logeps<A0>()),

--- a/include/boost/simd/arch/common/simd/function/exprecneg.hpp
+++ b/include/boost/simd/arch/common/simd/function/exprecneg.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return exp(-rec(a0));
     }

--- a/include/boost/simd/arch/common/simd/function/exprecnegc.hpp
+++ b/include/boost/simd/arch/common/simd/function/exprecnegc.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return -expm1(-rec(a0));
     }

--- a/include/boost/simd/arch/common/simd/function/expx2.hpp
+++ b/include/boost/simd/arch/common/simd/function/expx2.hpp
@@ -44,7 +44,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-     BOOST_FORCEINLINE A0 operator()(const A0& a0) const
+     BOOST_MAYBEINLINE A0 operator()(const A0& a0) const
       {
         A0 x =  bs::abs(a0);
         // Represent x as an exact multiple of 1/32 plus a residual.
@@ -72,7 +72,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-     BOOST_FORCEINLINE A0 operator()(const A0& a0,  const A0 & s) const
+     BOOST_MAYBEINLINE A0 operator()(const A0& a0,  const A0 & s) const
       {
         A0 sgn =  signnz(s);
         A0 x =  a0*sgn;

--- a/include/boost/simd/arch/common/simd/function/fma.hpp
+++ b/include/boost/simd/arch/common/simd/function/fma.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::unspecified_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE
+    BOOST_MAYBEINLINE
     A0 operator() ( A0 const& a0, A0 const& a1, A0 const& a2) const BOOST_NOEXCEPT
     {
       return plus(multiplies(a0, a1), a2);

--- a/include/boost/simd/arch/common/simd/function/gamma.hpp
+++ b/include/boost/simd/arch/common/simd/function/gamma.hpp
@@ -67,7 +67,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_< bd::floating_<A0>, X>
                              )
   {
-    BOOST_FORCEINLINE A0 operator() (const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const A0& a0) const BOOST_NOEXCEPT
     {
       auto nan_result = logical_and(is_ltz(a0), is_flint(a0));
       #ifndef BOOST_SIMD_NO_INVALIDS

--- a/include/boost/simd/arch/common/simd/function/gammaln.hpp
+++ b/include/boost/simd/arch/common/simd/function/gammaln.hpp
@@ -198,7 +198,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_< bd::double_<A0>, X >
                              )
   {
-    BOOST_FORCEINLINE A0 operator() (const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const A0& a0) const BOOST_NOEXCEPT
     {
       auto inf_result = logical_and(is_lez(a0), is_flint(a0));
       A0 x = if_nan_else(inf_result, a0);

--- a/include/boost/simd/arch/common/simd/function/hypot.hpp
+++ b/include/boost/simd/arch/common/simd/function/hypot.hpp
@@ -50,7 +50,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()(const pedantic_tag &,
+      BOOST_MAYBEINLINE A0 operator()(const pedantic_tag &,
                                       const A0& a0, const A0& a1) const BOOST_NOEXCEPT
       {
         using iA0 = bd::as_integer_t<A0>;
@@ -81,7 +81,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
 
-    BOOST_FORCEINLINE A0 operator() (A0 const& a0, A0 const& a1
+    BOOST_MAYBEINLINE A0 operator() (A0 const& a0, A0 const& a1
                                     ) const BOOST_NOEXCEPT
     {
       return boost::simd::sqrt(bs::fma(a0, a0, sqr(a1)));

--- a/include/boost/simd/arch/common/simd/function/ilog2.hpp
+++ b/include/boost/simd/arch/common/simd/function/ilog2.hpp
@@ -34,7 +34,7 @@ namespace boost { namespace simd { namespace ext
                           )
    {
       using result = bd::as_integer_t<A0>;
-      BOOST_FORCEINLINE result operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE result operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         BOOST_ASSERT_MSG( assert_all(a0 > 0)
                         , "Logarithm is not defined for zero or negative values." );
@@ -50,7 +50,7 @@ namespace boost { namespace simd { namespace ext
                           )
    {
       using result = bd::as_integer_t<A0>;
-      BOOST_FORCEINLINE result operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE result operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         BOOST_ASSERT_MSG( assert_all(a0 > 0)
                         , "Logarithm is not defined for zero or negative values." );

--- a/include/boost/simd/arch/common/simd/function/ilogb.hpp
+++ b/include/boost/simd/arch/common/simd/function/ilogb.hpp
@@ -39,7 +39,7 @@ namespace boost { namespace simd { namespace ext
                             )
   {
     using result_t = bd::as_integer_t<A0>;
-    BOOST_FORCEINLINE result_t operator()( const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE result_t operator()( const A0& a0) const BOOST_NOEXCEPT
     {
       return if_else(is_inf(a0), Valmax<result_t>(), exponent(a0));
     }
@@ -53,7 +53,7 @@ namespace boost { namespace simd { namespace ext
                          )
   {
     using result_t = bd::as_integer_t<A0>;
-    BOOST_FORCEINLINE result_t operator()(const pedantic_tag &
+    BOOST_MAYBEINLINE result_t operator()(const pedantic_tag &
                                          ,  const A0& a0) const BOOST_NOEXCEPT
     {
       result_t fp_ilogbnan(FP_ILOGBNAN);
@@ -71,7 +71,7 @@ namespace boost { namespace simd { namespace ext
                             , bs::pack_<bd::integer_<A0>, X>
                             )
   {
-    BOOST_FORCEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
     {
       return bitwise_cast<A0>(ilogb(tofloat(a0)));
     }
@@ -84,7 +84,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_<bd::ints16_<A0>, X>
                              )
   {
-    BOOST_FORCEINLINE A0 operator() ( const A0 & a0)
+    BOOST_MAYBEINLINE A0 operator() ( const A0 & a0)
     {
       auto s0 = split(a0);
       return bitwise_cast<A0>(group(ilogb(s0[0]), ilogb(s0[1])));
@@ -99,7 +99,7 @@ namespace boost { namespace simd { namespace ext
                              )
   {
     using result = bd::as_integer_t<A0>;
-    BOOST_FORCEINLINE A0 operator() ( const A0 & a0)
+    BOOST_MAYBEINLINE A0 operator() ( const A0 & a0)
     {
       auto s0 = split(a0);
       return bitwise_cast<A0>(group(ilogb(s0[0]), ilogb(s0[1])));

--- a/include/boost/simd/arch/common/simd/function/ldexp.hpp
+++ b/include/boost/simd/arch/common/simd/function/ldexp.hpp
@@ -46,7 +46,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::integer_<A1>, X>
                           )
    {
-     BOOST_FORCEINLINE A0 operator()( const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
+     BOOST_MAYBEINLINE A0 operator()( const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
      {
        return rshl(a0, a1);
      }
@@ -59,7 +59,7 @@ namespace boost { namespace simd { namespace ext
                          , bd::scalar_<bd::integer_<A1>>
                          )
   {
-    BOOST_FORCEINLINE A0 operator()( const A0& a0, A1  a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator()( const A0& a0, A1  a1) const BOOST_NOEXCEPT
     {
       using sA0 = bd::scalar_of_t<A0>;
       using iA0 = bd::as_integer_t<sA0>;
@@ -76,7 +76,7 @@ namespace boost { namespace simd { namespace ext
                          , bs::pack_<bd::integer_<A1>, Y>
                          )
   {
-    BOOST_FORCEINLINE A0 operator()(const pedantic_tag &
+    BOOST_MAYBEINLINE A0 operator()(const pedantic_tag &
                                    ,  const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
     {
       using iA0 = bd::as_integer_t<A0>;
@@ -105,7 +105,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::integer_<A1>>
                           )
    {
-     BOOST_FORCEINLINE A0 operator()(const pedantic_tag &
+     BOOST_MAYBEINLINE A0 operator()(const pedantic_tag &
                                     ,  const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
      {
        using iA0 = bd::as_integer_t<A0>;
@@ -136,7 +136,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::integer_<A1>, Y>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const A0& a0, const A1& a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const A0& a0, const A1& a1) const BOOST_NOEXCEPT
     {
       using i_t = bd::as_integer_t<A0,signed>;
       using sA0 = bd::scalar_of_t<A0>;
@@ -153,7 +153,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::integer_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const A0& a0,  A1 a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const A0& a0,  A1 a1) const BOOST_NOEXCEPT
     {
       using iA0 = bd::as_integer_t<A0>;
       using sA0 =  bd::scalar_of_t<A0>;
@@ -171,7 +171,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( const A0& a0, const A0& a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( const A0& a0, const A0& a1) const BOOST_NOEXCEPT
     {
       BOOST_ASSERT_MSG(assert_all(is_flint(a1)||is_invalid(a1)), "parameter is not a flint nor invalid");
       return ldexp(a0, toint(a1));
@@ -186,7 +186,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( const pedantic_tag &
+    BOOST_MAYBEINLINE A0 operator() ( const pedantic_tag &
                                     , const A0& a0, const A0& a1) const BOOST_NOEXCEPT
     {
       BOOST_ASSERT_MSG(assert_all(is_flint(a1)||is_invalid(a1)), "parameter is not a flint nor invalid");
@@ -202,7 +202,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::single_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( const pedantic_tag &
+    BOOST_MAYBEINLINE A0 operator() ( const pedantic_tag &
                                     , const A0& a0, const A1& a1) const BOOST_NOEXCEPT
     {
       BOOST_ASSERT_MSG(assert_all(is_flint(a1)||is_invalid(a1)), "parameter is not a flint nor invalid");
@@ -218,7 +218,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::double_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( const pedantic_tag &
+    BOOST_MAYBEINLINE A0 operator() ( const pedantic_tag &
                                     , const A0& a0, const A1& a1) const BOOST_NOEXCEPT
     {
       BOOST_ASSERT_MSG(assert_all(is_flint(a1)||is_invalid(a1)), "parameter is not a flint nor invalid");

--- a/include/boost/simd/arch/common/simd/function/log.hpp
+++ b/include/boost/simd/arch/common/simd/function/log.hpp
@@ -68,7 +68,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::single_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 const & a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 const & a0) const BOOST_NOEXCEPT
     {
       return musl_(log)(a0);
     }
@@ -81,7 +81,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::double_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 const & a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 const & a0) const BOOST_NOEXCEPT
     {
       return musl_(log)(a0);
     }
@@ -94,7 +94,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::single_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const musl_tag &, const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const musl_tag &, const A0& a0) const BOOST_NOEXCEPT
     {
       using uiA0 = bd::as_integer_t<A0, unsigned>;
       using iA0 = bd::as_integer_t<A0,   signed>;
@@ -143,7 +143,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_< bd::double_<A0>, X>
                              )
   {
-    BOOST_FORCEINLINE A0 operator() (const musl_tag &, const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const musl_tag &, const A0& a0) const BOOST_NOEXCEPT
     {
       using uiA0 = bd::as_integer_t<A0, unsigned>;
       using iA0 = bd::as_integer_t<A0,   signed>;
@@ -202,7 +202,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::single_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const plain_tag &, const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const plain_tag &, const A0& a0) const BOOST_NOEXCEPT
     {
       A0 x =  a0;
       A0 dk = Zero<A0>();
@@ -245,7 +245,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_< bd::double_<A0>, X>
                              )
   {
-    BOOST_FORCEINLINE A0 operator() (const plain_tag &, const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const plain_tag &, const A0& a0) const BOOST_NOEXCEPT
     {
       A0 x =  a0;
       A0 dk = Zero<A0>();

--- a/include/boost/simd/arch/common/simd/function/log10.hpp
+++ b/include/boost/simd/arch/common/simd/function/log10.hpp
@@ -38,7 +38,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::single_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return musl_(log10)(a0);
     }
@@ -51,7 +51,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::double_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return musl_(log10)(a0);
     }
@@ -64,7 +64,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::single_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const musl_tag &, const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const musl_tag &, const A0& a0) const BOOST_NOEXCEPT
     {
       /* origin: FreeBSD /usr/src/lib/msun/src/e_log10f.c */
       /*
@@ -140,7 +140,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_< bd::double_<A0>, X>
                              )
   {
-    BOOST_FORCEINLINE A0 operator() (const musl_tag &, const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const musl_tag &, const A0& a0) const BOOST_NOEXCEPT
     {
       /* origin: FreeBSD /usr/src/lib/msun/src/e_log10f.c */
       /*
@@ -229,7 +229,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::single_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const plain_tag &, const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const plain_tag &, const A0& a0) const BOOST_NOEXCEPT
     {
       /* origin: FreeBSD /usr/src/lib/msun/src/e_log10f.c */
       /*
@@ -301,7 +301,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_< bd::double_<A0>, X>
                              )
   {
-    BOOST_FORCEINLINE A0 operator() (const plain_tag &, const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const plain_tag &, const A0& a0) const BOOST_NOEXCEPT
     {
       /* origin: FreeBSD /usr/src/lib/msun/src/e_log10f.c */
       /*

--- a/include/boost/simd/arch/common/simd/function/log1p.hpp
+++ b/include/boost/simd/arch/common/simd/function/log1p.hpp
@@ -47,7 +47,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_< bd::single_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator()( const A0& a0) BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator()( const A0& a0) BOOST_NOEXCEPT
     {
       return musl_(log1p)(a0);
     }
@@ -60,7 +60,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_< bd::double_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator()( const A0& a0) BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator()( const A0& a0) BOOST_NOEXCEPT
     {
       return plain_(log1p)(a0);
     }
@@ -74,7 +74,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::single_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const musl_tag &, const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const musl_tag &, const A0& a0) const BOOST_NOEXCEPT
     {
       using uiA0 = bd::as_integer_t<A0, unsigned>;
       using iA0 = bd::as_integer_t<A0,   signed>;
@@ -115,7 +115,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_< bd::double_<A0>, X>
                              )
   {
-    BOOST_FORCEINLINE A0 operator() (const musl_tag &, const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const musl_tag &, const A0& a0) const BOOST_NOEXCEPT
     {
       using uiA0 = bd::as_integer_t<A0, unsigned>;
       using iA0 = bd::as_integer_t<A0,   signed>;
@@ -160,7 +160,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::single_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const plain_tag &, const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const plain_tag &, const A0& a0) const BOOST_NOEXCEPT
     {
       const A0 uf =  inc(a0);
       auto isnez = is_nez(uf);
@@ -200,7 +200,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_< bd::double_<A0>, X>
                              )
   {
-    BOOST_FORCEINLINE A0 operator() (const plain_tag &, const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const plain_tag &, const A0& a0) const BOOST_NOEXCEPT
     {
 //      using iA0 = bd::as_integer_t<A0,   signed>;
       const A0 uf =  inc(a0);

--- a/include/boost/simd/arch/common/simd/function/log2.hpp
+++ b/include/boost/simd/arch/common/simd/function/log2.hpp
@@ -66,7 +66,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::single_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 const& a0) const BOOST_NOEXCEPT
     {
       return musl_(log2)(a0);
     }
@@ -78,7 +78,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::double_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 const& a0) const BOOST_NOEXCEPT
     {
       return musl_(log2)(a0);
     }
@@ -91,7 +91,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::arithmetic_<A0>, X >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (A0 const& a0) const BOOST_NOEXCEPT
     {
       return bitwise_cast<A0>(bs::ilog2(a0));
     }
@@ -116,7 +116,7 @@ namespace boost { namespace simd { namespace ext
      * is preserved.
      * ====================================================
      */
-    BOOST_FORCEINLINE A0 operator() (const musl_tag &, const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const musl_tag &, const A0& a0) const BOOST_NOEXCEPT
     {
       using uiA0 = bd::as_integer_t<A0, unsigned>;
       using iA0 = bd::as_integer_t<A0,   signed>;
@@ -175,7 +175,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_< bd::double_<A0>, X>
                              )
   {
-    BOOST_FORCEINLINE A0 operator() (const musl_tag &, const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const musl_tag &, const A0& a0) const BOOST_NOEXCEPT
     {
     /* origin: FreeBSD /usr/src/lib/msun/src/e_log2f.c */
     /*
@@ -292,7 +292,7 @@ namespace boost { namespace simd { namespace ext
      * is preserved.
      * ====================================================
      */
-    BOOST_FORCEINLINE A0 operator() (const plain_tag &, const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const plain_tag &, const A0& a0) const BOOST_NOEXCEPT
     {
       A0 x =  a0;
       A0 dk = Zero<A0>();
@@ -347,7 +347,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_< bd::double_<A0>, X>
                              )
   {
-    BOOST_FORCEINLINE A0 operator() (const plain_tag &, const A0& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const plain_tag &, const A0& a0) const BOOST_NOEXCEPT
     {
       /* origin: FreeBSD /usr/src/lib/msun/src/e_log2f.c */
       /*

--- a/include/boost/simd/arch/common/simd/function/nextafter.hpp
+++ b/include/boost/simd/arch/common/simd/function/nextafter.hpp
@@ -34,7 +34,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::arithmetic_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0, const A0& a1) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0, const A0& a1) const BOOST_NOEXCEPT
       {
         return  if_else(bs::is_equal(a0,a1),
                       a0,
@@ -50,7 +50,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0, const A0& a1) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0, const A0& a1) const BOOST_NOEXCEPT
       {
         return if_else(is_less(a0, a1), next(a0), if_else(is_equal(a0, a1),  a0, prev(a0)));
       }

--- a/include/boost/simd/arch/common/simd/function/nthroot.hpp
+++ b/include/boost/simd/arch/common/simd/function/nthroot.hpp
@@ -108,7 +108,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::integer_<A1>, X>
                           )
    {
-     BOOST_FORCEINLINE A0 operator()(const raw_tag &, const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
+     BOOST_MAYBEINLINE A0 operator()(const raw_tag &, const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
      {
        auto aa1 =  abs(a1);
        A0 aa0 = abs(a0);

--- a/include/boost/simd/arch/common/simd/function/pow.hpp
+++ b/include/boost/simd/arch/common/simd/function/pow.hpp
@@ -39,7 +39,7 @@ namespace boost { namespace simd { namespace ext
                            , bs::pack_<bd::floating_<A0>,X>
                            )
   {
-    BOOST_FORCEINLINE A0 operator()( const A0& a0, const A0& a1) BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator()( const A0& a0, const A0& a1) BOOST_NOEXCEPT
     {
       auto nega0 = is_negative(a0);
       A0 z = pow_abs(a0, a1);
@@ -58,7 +58,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::uint_<A1>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()(const A0& a0, const A1& a1 ) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()(const A0& a0, const A1& a1 ) const BOOST_NOEXCEPT
       {
         A0 base = a0;
         A1 exp = a1;
@@ -83,7 +83,7 @@ namespace boost { namespace simd { namespace ext
   {
     using result_type = A0;
 
-    BOOST_FORCEINLINE result_type operator() ( A0 const& a0, A1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE result_type operator() ( A0 const& a0, A1) const BOOST_NOEXCEPT
     {
       return pow_expander<A1::value>::call(a0);
     }
@@ -99,17 +99,17 @@ namespace boost { namespace simd { namespace ext
   {
     using result_type = A0;
 
-    BOOST_FORCEINLINE result_type operator() ( A0 const& a0, A1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE result_type operator() ( A0 const& a0, A1) const BOOST_NOEXCEPT
     {
       return eval(a0, boost::mpl::bool_<(A1::value >= 0)>());
     }
 
-    BOOST_FORCEINLINE result_type eval( A0 const& a0, boost::mpl::true_) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE result_type eval( A0 const& a0, boost::mpl::true_) const BOOST_NOEXCEPT
     {
       return pow_expander<A1::value>::call(a0);
     }
 
-    BOOST_FORCEINLINE result_type eval( A0 const& a0, boost::mpl::false_) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE result_type eval( A0 const& a0, boost::mpl::false_) const BOOST_NOEXCEPT
     {
       return pow_expander<-A1::value>::call(rec(a0));
     }
@@ -153,7 +153,7 @@ namespace boost { namespace simd { namespace ext
   {
     using result_type = A0;
 
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 const& a1) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0, A1 const& a1) const BOOST_NOEXCEPT
     {
       BOOST_ASSERT_MSG( boost::simd::assert_all(a1 >= 0), "integral pow with signed exponent" );
 
@@ -191,7 +191,7 @@ namespace boost { namespace simd { namespace ext
                             , bs::pack_<bd::floating_<A0>,X>
                            )
   {
-    BOOST_FORCEINLINE A0 operator()(const raw_tag &,
+    BOOST_MAYBEINLINE A0 operator()(const raw_tag &,
                                     const A0& a0, const A0& a1) BOOST_NOEXCEPT
     {
       auto nega0 = is_negative(a0);

--- a/include/boost/simd/arch/common/simd/function/predecessor.hpp
+++ b/include/boost/simd/arch/common/simd/function/predecessor.hpp
@@ -38,7 +38,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::arithmetic_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         return if_dec(is_not_equal(a0, Valmin<A0>()), a0);
       }
@@ -51,7 +51,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         return if_nan_else(is_nan(a0), bitfloating(saturated_(dec)(bitinteger(a0))));
       }
@@ -65,7 +65,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::integer_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0, const A0& a1) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0, const A0& a1) const BOOST_NOEXCEPT
       {
         BOOST_ASSERT_MSG(assert_all(is_gez(a1)), "predecessor rank must be non negative");
         return if_else(  is_greater(Valmin<A0>()+a1, a0), Valmin<A0>(), a0-a1);
@@ -80,7 +80,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::integer_<A1>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
       {
         BOOST_ASSERT_MSG(assert_all(is_gez(a1)), "predecessor rank must be non negative");
         return if_allbits_else(is_nan(a0), bitfloating(saturated_(minus)(bitinteger(a0), a1)));

--- a/include/boost/simd/arch/common/simd/function/rem.hpp
+++ b/include/boost/simd/arch/common/simd/function/rem.hpp
@@ -36,7 +36,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::int_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()(pedantic_tag const &
+      BOOST_MAYBEINLINE A0 operator()(pedantic_tag const &
                                      , const A0& a0, const A0& a1) const BOOST_NOEXCEPT
       {
         return if_minus(is_nez(a1), a0, div(fix,a0,a1)*a1);
@@ -52,7 +52,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()(pedantic_tag const &
+      BOOST_MAYBEINLINE A0 operator()(pedantic_tag const &
                                      ,  const A0& a0, const A0& a1) const BOOST_NOEXCEPT
       {
         auto z = is_nez(a1);
@@ -77,7 +77,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::int_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()(pedantic_tag const &
+      BOOST_MAYBEINLINE A0 operator()(pedantic_tag const &
                                      , bd::functor<bs::tag::fix_> const&
                                      , const A0& a0, const A0& a1) const BOOST_NOEXCEPT
       {
@@ -95,7 +95,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_<bd::floating_<A0>, X>
                              )
    {
-      BOOST_FORCEINLINE A0 operator()(pedantic_tag const &
+      BOOST_MAYBEINLINE A0 operator()(pedantic_tag const &
                                      , bd::functor<bs::tag::fix_> const&
                                      , const A0& a0, const A0& a1) const BOOST_NOEXCEPT
       {
@@ -112,7 +112,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( bd::functor<bs::tag::fix_> const&
+      BOOST_MAYBEINLINE A0 operator()( bd::functor<bs::tag::fix_> const&
                                      , const A0& a0, const A0& a1) const BOOST_NOEXCEPT
       {
         return  fnms(div(fix, a0,a1), a1, a0);
@@ -127,7 +127,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()(const A0& a0, const A0& a1) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()(const A0& a0, const A0& a1) const BOOST_NOEXCEPT
       {
         return  fnms(div(fix, a0,a1), a1, a0);
       }

--- a/include/boost/simd/arch/common/simd/function/rol.hpp
+++ b/include/boost/simd/arch/common/simd/function/rol.hpp
@@ -38,7 +38,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::unsigned_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 a1) const
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0, A1 a1) const
     {
       BOOST_ASSERT_MSG(assert_good_shift<A0>(a1), "rol : rotation is out of range");
 
@@ -56,7 +56,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::integer_<A1> >
   )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const&  a0, A1 a1 ) const
+    BOOST_MAYBEINLINE A0 operator() ( A0 const&  a0, A1 a1 ) const
     {
       using i_t  = bd::as_integer_t<A0, unsigned>;
       using is_t = bd::as_integer_t<i_t, unsigned>;
@@ -80,7 +80,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_< bd::unsigned_<A1>, X>
                              )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 const& a1 ) const
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0, A1 const& a1 ) const
     {
       using s_t = bd::scalar_of_t<A0>;
       BOOST_ASSERT_MSG(assert_good_shift<A0>(a1), "rol : rotation is out of range");
@@ -102,7 +102,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::integer_<A1>, X>
   )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 const& a1 ) const
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0, A1 const& a1 ) const
     {
       using i_t = bd::as_integer_t<A0, unsigned>;
       return bitwise_cast<A0>( rol ( bitwise_cast<i_t>(a0)

--- a/include/boost/simd/arch/common/simd/function/ror.hpp
+++ b/include/boost/simd/arch/common/simd/function/ror.hpp
@@ -36,7 +36,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::unsigned_<A1> >
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 a1) const
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0, A1 a1) const
     {
       BOOST_ASSERT_MSG(assert_good_shift<A0>(a1), "rol : rotation is out of range");
       using s_t = bd::scalar_of_t<A0>;
@@ -54,7 +54,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_< bd::integer_<A1> >
   )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const&  a0, A1 a1 ) const
+    BOOST_MAYBEINLINE A0 operator() ( A0 const&  a0, A1 a1 ) const
     {
       using i_t = bd::as_integer_t<A0, unsigned>;
       using is_t = bd::as_integer_t<i_t, unsigned>;
@@ -77,7 +77,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_< bd::unsigned_<A1>, X>
                              )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A0 const& a1) const
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0, A0 const& a1) const
     {
       using s_t = bd::scalar_of_t<A0>;
       BOOST_ASSERT_MSG(assert_good_shift<A0>(a1), "ror : rotation is out of range");
@@ -99,7 +99,7 @@ namespace boost { namespace simd { namespace ext
                                , bs::pack_< bd::integer_<A1>, X>
                                )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 const& a1) const
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0, A1 const& a1) const
     {
       using i_t = bd::as_integer_t<A0, unsigned>;
       return bitwise_cast<A0>( ror ( bitwise_cast<i_t>(a0)

--- a/include/boost/simd/arch/common/simd/function/round.hpp
+++ b/include/boost/simd/arch/common/simd/function/round.hpp
@@ -44,7 +44,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::integer_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         return a0;
       }
@@ -57,7 +57,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         const A0 v = bs::abs(a0);
         const A0 c = bs::ceil(v);
@@ -73,7 +73,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_<bd::integer_<A1>, X>
                              )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
       {
         A0 fac = tenpower(a1);
         A0 tmp1 = round(a0*fac)/fac;
@@ -88,7 +88,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::unsigned_<A1>>
                           )
    {
-     BOOST_FORCEINLINE A0 operator()(A0 const & a0,  A1 const & a1) const
+     BOOST_MAYBEINLINE A0 operator()(A0 const & a0,  A1 const & a1) const
       {
         using itype_t = bd::as_integer_t<A0, unsigned>;
         return round(a0, splat<itype_t>(a1));
@@ -102,7 +102,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::integer_<A1>>
                           )
    {
-     BOOST_FORCEINLINE A0 operator()(A0 const & a0,  A1 const & a1) const
+     BOOST_MAYBEINLINE A0 operator()(A0 const & a0,  A1 const & a1) const
       {
         using itype_t = bd::as_integer_t<A0>;
         return round(a0, splat<itype_t>(a1));

--- a/include/boost/simd/arch/common/simd/function/rrol.hpp
+++ b/include/boost/simd/arch/common/simd/function/rrol.hpp
@@ -37,7 +37,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::int_<A1>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
       {
         #ifndef NDEBUG
         return bitwise_cast<A0>( if_else ( is_gtz(a1)
@@ -67,7 +67,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::uint_<A1>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
       {
         return bitwise_cast<A0>( rol( bitwise_cast<A1>(a0), a1 ) );
       }

--- a/include/boost/simd/arch/common/simd/function/rror.hpp
+++ b/include/boost/simd/arch/common/simd/function/rror.hpp
@@ -37,7 +37,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_<bd::int_<A1>, X>
                              )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
       {
         #ifndef NDEBUG
         return bitwise_cast<A0>( if_else ( is_gtz(a1)
@@ -67,7 +67,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_<bd::uint_<A1>, X>
                              )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
       {
         return bitwise_cast<A0>( ror( bitwise_cast<A1>(a0), a1 ) );
       }

--- a/include/boost/simd/arch/common/simd/function/rsqrt.hpp
+++ b/include/boost/simd/arch/common/simd/function/rsqrt.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                             , bs::pack_< bd::floating_<A0>, X >
                             )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return bs::rec(bs::sqrt(a0));
     }
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace ext
                             , bs::pack_< bd::floating_<A0>, X >
                             )
   {
-    BOOST_FORCEINLINE A0 operator() (const raw_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const raw_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return bs::rec(bs::raw_(bs::sqrt)(a0));
     }

--- a/include/boost/simd/arch/common/simd/function/sec.hpp
+++ b/include/boost/simd/arch/common/simd/function/sec.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return sec(a0, tag::big_);
     }
@@ -40,7 +40,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 const&) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0, A1 const&) const BOOST_NOEXCEPT
     {
       return rec(cos(a0, A1()));
     }
@@ -53,7 +53,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return rec(restricted_(cos)(a0));
     }

--- a/include/boost/simd/arch/common/simd/function/secd.hpp
+++ b/include/boost/simd/arch/common/simd/function/secd.hpp
@@ -31,7 +31,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return secd(a0, tag::big_);
     }
@@ -43,7 +43,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 const&) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0, A1 const&) const BOOST_NOEXCEPT
     {
       return if_nan_else(is_flint((a0- Ratio<A0,90>())*Ratio<A0,1,180>())
                         , rec(cosd(a0,A1())));
@@ -57,7 +57,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return rec(restricted_(cosd)(a0));
     }

--- a/include/boost/simd/arch/common/simd/function/sech.hpp
+++ b/include/boost/simd/arch/common/simd/function/sech.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
     using result_t = A0;
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return bs::rec(bs::cosh(a0));
     }

--- a/include/boost/simd/arch/common/simd/function/secpi.hpp
+++ b/include/boost/simd/arch/common/simd/function/secpi.hpp
@@ -31,7 +31,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return secpi(a0, tag::big_);
     }
@@ -43,7 +43,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0, A1 const&) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0, A1 const&) const BOOST_NOEXCEPT
     {
       return if_nan_else(is_flint(a0-Half<A0>()), rec(cospi(a0, A1())));
     }
@@ -56,7 +56,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return rec(restricted_(cospi)(a0));
     }

--- a/include/boost/simd/arch/common/simd/function/significants.hpp
+++ b/include/boost/simd/arch/common/simd/function/significants.hpp
@@ -52,7 +52,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_< bd::integer_<A1>, X>
                              )
    {
-     BOOST_FORCEINLINE A0 operator()( const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
+     BOOST_MAYBEINLINE A0 operator()( const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
      {
        BOOST_ASSERT_MSG( assert_all(is_gtz(a1))
                        , "Number of significant digits must be positive"
@@ -78,7 +78,7 @@ namespace boost { namespace simd { namespace ext
                          )
   {
 
-    BOOST_FORCEINLINE A0 operator()( const A0& a0, A1 a1 ) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator()( const A0& a0, A1 a1 ) const BOOST_NOEXCEPT
     {
       using iA0 = bd::as_integer_t<A0>;
       return significants(a0, iA0(a1));

--- a/include/boost/simd/arch/common/simd/function/sin.hpp
+++ b/include/boost/simd/arch/common/simd/function/sin.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::radian_tag,tag::simd_type,tag::big_tag>::sina(a0);
     }
@@ -40,7 +40,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::radian_tag,tag::simd_type,A1>::sina(a0);
     }
@@ -53,7 +53,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::radian_tag,tag::simd_type,tag::clipped_pio4_tag>::sina(a0);
     }

--- a/include/boost/simd/arch/common/simd/function/sinc.hpp
+++ b/include/boost/simd/arch/common/simd/function/sinc.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         A0 r1 =  bs::sin(a0)/a0;
         #if !defined(BOOST_SIMD_NO_DENORMALS)

--- a/include/boost/simd/arch/common/simd/function/sincpi.hpp
+++ b/include/boost/simd/arch/common/simd/function/sincpi.hpp
@@ -42,7 +42,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         A0 r1 = bs::Invpi<A0>()*(bs::sinpi(a0)/a0);
         #if !defined(BOOST_SIMD_NO_DENORMALS)

--- a/include/boost/simd/arch/common/simd/function/sind.hpp
+++ b/include/boost/simd/arch/common/simd/function/sind.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::simd_type,tag::big_tag>::sina(a0);
     }
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::simd_type,tag::clipped_pio4_tag>::sina(a0);
     }
@@ -53,7 +53,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::simd_type,A1>::sina(a0);
     }

--- a/include/boost/simd/arch/common/simd/function/sinh.hpp
+++ b/include/boost/simd/arch/common/simd/function/sinh.hpp
@@ -43,7 +43,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         A0 x = bs::abs(a0);
         auto lt1= is_less(x, One<A0>());

--- a/include/boost/simd/arch/common/simd/function/sinhc.hpp
+++ b/include/boost/simd/arch/common/simd/function/sinhc.hpp
@@ -47,7 +47,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         //////////////////////////////////////////////////////////////////////////////
         // if x = abs(a0) is less than 1 sinhc is computed using a polynomial(float)

--- a/include/boost/simd/arch/common/simd/function/sinhcosh.hpp
+++ b/include/boost/simd/arch/common/simd/function/sinhcosh.hpp
@@ -46,7 +46,7 @@ namespace boost { namespace simd { namespace ext
                              )
   {
     using result_t = std::pair<A0, A0>;
-    BOOST_FORCEINLINE result_t operator() ( A0 const& a0) const
+    BOOST_MAYBEINLINE result_t operator() ( A0 const& a0) const
     {
       //////////////////////////////////////////////////////////////////////////////
       // if x = abs(a0) is less than 1 sinh is computed using a polynomial(float)

--- a/include/boost/simd/arch/common/simd/function/sinpi.hpp
+++ b/include/boost/simd/arch/common/simd/function/sinpi.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::simd_type,tag::big_tag>::sina(a0);
     }
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::simd_type,tag::clipped_pio4_tag>::sina(a0);
     }
@@ -53,7 +53,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::simd_type,tag::big_tag>::sina(a0);
     }

--- a/include/boost/simd/arch/common/simd/function/sqrt.hpp
+++ b/include/boost/simd/arch/common/simd/function/sqrt.hpp
@@ -34,7 +34,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const raw_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const raw_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       A0 r = if_else_zero(a0, a0 * raw_(rsqrt)(a0));
       #ifndef BOOST_SIMD_NO_INFINITIES
@@ -52,7 +52,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::integer_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const raw_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const raw_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       BOOST_ASSERT_MSG( bs::assert_all(is_positive(a0))
                       , "sqrt integer domain is restricted to positive integer."

--- a/include/boost/simd/arch/common/simd/function/stirling.hpp
+++ b/include/boost/simd/arch/common/simd/function/stirling.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace simd { namespace ext
                              , bs::pack_< bd::floating_<A0>, X>
                              )
   {
-    BOOST_FORCEINLINE A0 operator() (const A0& a00) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const A0& a00) const BOOST_NOEXCEPT
     {
       const A0 Stirlingsplitlim = Real<A0, 0X4061E083BA3443D4ULL, 0X41D628F6UL>();// 143.01608, 26.77f
       const A0 Stirlinglargelim = Real<A0, 0x4065800000000000ULL, 0X420C28F3UL>();// 172, 35.0399895f

--- a/include/boost/simd/arch/common/simd/function/successor.hpp
+++ b/include/boost/simd/arch/common/simd/function/successor.hpp
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::arithmetic_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         return if_plus(is_not_equal(a0, Valmax<A0>()), a0, One<A0>());
       }
@@ -54,7 +54,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         return if_allbits_else(is_nan(a0), bitfloating(saturated_(inc)(bitinteger(a0))));
       }
@@ -68,7 +68,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::integer_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0, const A0& a1) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0, const A0& a1) const BOOST_NOEXCEPT
       {
         BOOST_ASSERT_MSG(assert_all(is_gez(a1)), "successor rank must be non negative");
         return if_else( bs::is_greater(Valmax<A0>()-a1, a0),
@@ -85,7 +85,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::integer_<A1>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0, const  A1&  a1) const BOOST_NOEXCEPT
       {
         BOOST_ASSERT_MSG(assert_all(is_gez(a1)), "successor rank must be non negative");
         return if_allbits_else(is_nan(a0), bitfloating(saturated_(plus)(bitinteger(a0), a1)));

--- a/include/boost/simd/arch/common/simd/function/tan.hpp
+++ b/include/boost/simd/arch/common/simd/function/tan.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::radian_tag,tag::simd_type,tag::big_tag>::tana(a0);
     }
@@ -40,7 +40,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::radian_tag,tag::simd_type,A1>::tana(a0);
     }
@@ -53,7 +53,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::radian_tag,tag::simd_type,tag::clipped_pio4_tag>::tana(a0);
     }

--- a/include/boost/simd/arch/common/simd/function/tand.hpp
+++ b/include/boost/simd/arch/common/simd/function/tand.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::simd_type,tag::big_tag>::tana(a0);
     }
@@ -40,7 +40,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::simd_type,A1>::tana(a0);
     }
@@ -53,7 +53,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::degree_tag,tag::simd_type,tag::clipped_pio4_tag>::tana(a0);
     }

--- a/include/boost/simd/arch/common/simd/function/tanh.hpp
+++ b/include/boost/simd/arch/common/simd/function/tanh.hpp
@@ -42,7 +42,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         //////////////////////////////////////////////////////////////////////////////
         // if x = abs(a0) is less than 5/8 tanh is computed using a polynomial(float)

--- a/include/boost/simd/arch/common/simd/function/tanpi.hpp
+++ b/include/boost/simd/arch/common/simd/function/tanpi.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::simd_type,tag::big_tag>::tana(a0);
     }
@@ -40,7 +40,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_ < bd::unspecified_<A1>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( A0 const& a0,  A1 const &) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::simd_type,A1>::tana(a0);
     }
@@ -53,7 +53,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_< bd::floating_<A0>, X>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const restricted_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return detail::trig_base<A0,tag::pi_tag,tag::simd_type,tag::clipped_pio4_tag>::tana(a0);
     }

--- a/include/boost/simd/arch/common/simd/function/tenpower.hpp
+++ b/include/boost/simd/arch/common/simd/function/tenpower.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace simd { namespace ext
                              )
    {
       using result = bd::as_floating_t<A0>;
-      BOOST_FORCEINLINE result operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE result operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         result res = One<result>();
         result base = Ten<result>();
@@ -65,7 +65,7 @@ namespace boost { namespace simd { namespace ext
                              )
    {
       using result = bd::as_floating_t<A0>;
-      BOOST_FORCEINLINE result operator()( const A0& a0) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE result operator()( const A0& a0) const BOOST_NOEXCEPT
       {
         result res = One<result>();
         result base = Ten<result>();

--- a/include/boost/simd/arch/common/simd/function/toint.hpp
+++ b/include/boost/simd/arch/common/simd/function/toint.hpp
@@ -33,7 +33,7 @@ namespace boost { namespace simd { namespace ext
                           )
    {
       using result = bd::as_integer_t<A0, signed> ;
-      BOOST_FORCEINLINE result operator()(A0 const& a0) const
+      BOOST_MAYBEINLINE result operator()(A0 const& a0) const
       {
         return bitwise_cast<result>(a0);
       }
@@ -45,7 +45,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::int_<A0>, X>
                           )
    {
-     BOOST_FORCEINLINE A0 operator()(A0 const& a0) const
+     BOOST_MAYBEINLINE A0 operator()(A0 const& a0) const
      {
         return a0;
      }
@@ -60,7 +60,7 @@ namespace boost { namespace simd { namespace ext
                           )
    {
      using result = bd::as_integer_t<A0, signed> ;
-     BOOST_FORCEINLINE result operator()(pedantic_tag const &
+     BOOST_MAYBEINLINE result operator()(pedantic_tag const &
                                         , A0 const& a0) const
      {
        const int32_t Vim32 = Valmin<int32_t>();
@@ -84,7 +84,7 @@ namespace boost { namespace simd { namespace ext
                           )
    {
      using result = bd::as_integer_t<A0, signed> ;
-     BOOST_FORCEINLINE result operator()(pedantic_tag const &
+     BOOST_MAYBEINLINE result operator()(pedantic_tag const &
                                         , A0 const& a0) const
      {
        return toint(a0);

--- a/include/boost/simd/arch/common/simd/function/ulpdist.hpp
+++ b/include/boost/simd/arch/common/simd/function/ulpdist.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::floating_<A0>, X>
                           )
    {
-      BOOST_FORCEINLINE A0 operator()( const A0& a0, const A0& a1) const BOOST_NOEXCEPT
+      BOOST_MAYBEINLINE A0 operator()( const A0& a0, const A0& a1) const BOOST_NOEXCEPT
       {
         using itype = bd::as_integer_t<A0>;
         itype e1, e2;

--- a/include/boost/simd/arch/x86/sse1/scalar/function/rsqrt.hpp
+++ b/include/boost/simd/arch/x86/sse1/scalar/function/rsqrt.hpp
@@ -38,7 +38,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::single_<A0>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (raw_tag const&
+    BOOST_MAYBEINLINE A0 operator() (raw_tag const&
                                     , const A0 & a0) const BOOST_NOEXCEPT
     {
       float inv;
@@ -54,7 +54,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::double_<A0>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (raw_tag const&
+    BOOST_MAYBEINLINE A0 operator() (raw_tag const&
                                     , const A0 & a0) const BOOST_NOEXCEPT
     {
       float inv = a0;
@@ -69,7 +69,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::single_<A0>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const A0 & a00) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const A0 & a00) const BOOST_NOEXCEPT
     {
       if (is_eqz(a00)) return Inf<A0>();
       #ifndef BOOST_SIMD_NO_INFINITIES
@@ -88,7 +88,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::single_<A0>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (pedantic_tag const&
+    BOOST_MAYBEINLINE A0 operator() (pedantic_tag const&
                                     ,const A0 & a00) const BOOST_NOEXCEPT
     {
       if (is_eqz(a00)) return Inf<A0>();
@@ -115,7 +115,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::double_<A0>>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (pedantic_tag const&
+    BOOST_MAYBEINLINE A0 operator() (pedantic_tag const&
                                     ,const A0 & a00) const BOOST_NOEXCEPT
     {
       if (is_eqz(a00)) return Inf<A0>();

--- a/include/boost/simd/arch/x86/sse1/simd/function/divides.hpp
+++ b/include/boost/simd/arch/x86/sse1/simd/function/divides.hpp
@@ -29,7 +29,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::single_<A0>, bs::sse_>
                          )
   {
-    BOOST_FORCEINLINE A0 operator() ( const A0 & a0
+    BOOST_MAYBEINLINE A0 operator() ( const A0 & a0
                                     , const A0 & a1 ) const BOOST_NOEXCEPT
     {
       A0 const that = _mm_div_ps(a0,a1);

--- a/include/boost/simd/arch/x86/sse1/simd/function/rol.hpp
+++ b/include/boost/simd/arch/x86/sse1/simd/function/rol.hpp
@@ -24,7 +24,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::integer_<A1>>
                          )
   {
-    BOOST_FORCEINLINE A0 operator() ( const A0 & a0
+    BOOST_MAYBEINLINE A0 operator() ( const A0 & a0
                                     , const A1 & a1 ) const BOOST_NOEXCEPT
     {
       using iA0 = bd::as_integer_t<A0>;

--- a/include/boost/simd/arch/x86/sse1/simd/function/ror.hpp
+++ b/include/boost/simd/arch/x86/sse1/simd/function/ror.hpp
@@ -24,7 +24,7 @@ namespace boost { namespace simd { namespace ext
                           , bd::scalar_<bd::integer_<A1>>
                          )
   {
-    BOOST_FORCEINLINE A0 operator() ( const A0 & a0
+    BOOST_MAYBEINLINE A0 operator() ( const A0 & a0
                                     , const A1 & a1 ) const BOOST_NOEXCEPT
     {
       using iA0 = bd::as_integer_t<A0>;

--- a/include/boost/simd/arch/x86/sse1/simd/function/rsqrt.hpp
+++ b/include/boost/simd/arch/x86/sse1/simd/function/rsqrt.hpp
@@ -36,7 +36,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::single_<A0>, bs::sse_>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (raw_tag const&
+    BOOST_MAYBEINLINE A0 operator() (raw_tag const&
                                     , const A0 & a0) const BOOST_NOEXCEPT
     {
       return _mm_rsqrt_ps(a0);
@@ -49,7 +49,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::single_<A0>, bs::sse_>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const A0 & a00) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const A0 & a00) const BOOST_NOEXCEPT
     {
 //       A0 a0 = refine_rsqrt(a00, refine_rsqrt(a00, raw_(rsqrt)(a00)));
       A0 a0 =  raw_(rsqrt)(a00);
@@ -69,7 +69,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::single_<A0>, bs::sse_>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (pedantic_tag const&
+    BOOST_MAYBEINLINE A0 operator() (pedantic_tag const&
                                     ,const A0 & a00) const BOOST_NOEXCEPT
     {
       A0 a0 = a00;

--- a/include/boost/simd/arch/x86/sse1/simd/function/sqrt.hpp
+++ b/include/boost/simd/arch/x86/sse1/simd/function/sqrt.hpp
@@ -22,7 +22,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::single_<A0>, bs::sse_>
                          )
   {
-    BOOST_FORCEINLINE A0 operator() ( const A0 & a0 ) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( const A0 & a0 ) const BOOST_NOEXCEPT
     {
       return _mm_sqrt_ps(a0);
     }

--- a/include/boost/simd/arch/x86/sse2/simd/function/acos.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/acos.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
 
-    BOOST_FORCEINLINE A0 operator() (const pedantic_tag &,  A0 const& a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const pedantic_tag &,  A0 const& a0) const BOOST_NOEXCEPT
     {
       return A0(bs::pedantic_(bs::acos)(a0[0]), bs::pedantic_(bs::acos)(a0[1]));
     }

--- a/include/boost/simd/arch/x86/sse2/simd/function/divides.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/divides.hpp
@@ -29,7 +29,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::double_<A0>, bs::sse_>
                          )
   {
-    BOOST_FORCEINLINE A0 operator() ( const A0 & a0
+    BOOST_MAYBEINLINE A0 operator() ( const A0 & a0
                                     , const A0 & a1 ) const BOOST_NOEXCEPT
     {
 //      A0 const that = _mm_div_pd(a0,a1);

--- a/include/boost/simd/arch/x86/sse2/simd/function/gammaln.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/gammaln.hpp
@@ -21,7 +21,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::double_<A0>, bs::sse_>
                          )
   {
-    BOOST_FORCEINLINE A0 operator() ( const A0 & a0 ) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( const A0 & a0 ) const BOOST_NOEXCEPT
     {
       return {bs::gammaln(a0[0]), bs::gammaln(a0[1])};
 

--- a/include/boost/simd/arch/x86/sse2/simd/function/ilogb.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/ilogb.hpp
@@ -43,7 +43,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
 
-    BOOST_FORCEINLINE A0 operator() ( const A0 & a0)
+    BOOST_MAYBEINLINE A0 operator() ( const A0 & a0)
     {
       using ui16_t =  bd::upgrade_t<A0>;
       const A0 mask =  Constant<A0, 0x7f>();
@@ -73,7 +73,7 @@ namespace boost { namespace simd { namespace ext
                           )
   {
 
-    BOOST_FORCEINLINE A0 operator() ( const A0 & a0)
+    BOOST_MAYBEINLINE A0 operator() ( const A0 & a0)
     {
       using uA0 = bd::as_integer_t<A0, unsigned>;
       return bitwise_cast<A0>(ilogb(bitwise_cast<uA0>(saturated_(abs)(a0))));

--- a/include/boost/simd/arch/x86/sse2/simd/function/nthroot.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/nthroot.hpp
@@ -22,7 +22,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::ints64_<A1>, bs::sse_>
                          )
   {
-    BOOST_FORCEINLINE A0 operator() ( const A0 & a0
+    BOOST_MAYBEINLINE A0 operator() ( const A0 & a0
                                     , const A1 & a1 ) const BOOST_NOEXCEPT
     {
       return {nthroot(a0[0], a1[0]), nthroot(a0[1], a1[1])};
@@ -36,7 +36,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::ints64_<A1>, bs::sse_>
                          )
   {
-    BOOST_FORCEINLINE A0 operator() ( raw_tag const&,
+    BOOST_MAYBEINLINE A0 operator() ( raw_tag const&,
                                       const A0 & a0
                                     , const A1 & a1 ) const BOOST_NOEXCEPT
     {

--- a/include/boost/simd/arch/x86/sse2/simd/function/rsqrt.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/rsqrt.hpp
@@ -34,7 +34,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::double_<A0>, bs::sse_>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (raw_tag const&
+    BOOST_MAYBEINLINE A0 operator() (raw_tag const&
                                     , const A0 & a0) const BOOST_NOEXCEPT
     {
       return _mm_cvtps_pd(_mm_rsqrt_ps(_mm_cvtpd_ps(a0))); //The maximum error for this approximation is 1.5e-12
@@ -47,7 +47,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::double_<A0>, bs::sse_>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (const A0 & a00) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() (const A0 & a00) const BOOST_NOEXCEPT
     {
       // To obtain accuracy we need 3 Newton steps or one Halley step followed by one Newton from the raw estimate
       // the second method is a bit faster by half a cycle
@@ -69,7 +69,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::double_<A0>, bs::sse_>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() (pedantic_tag const&
+    BOOST_MAYBEINLINE A0 operator() (pedantic_tag const&
                                     ,const A0 & a00) const BOOST_NOEXCEPT
     {
       A0 a01 =  a00;

--- a/include/boost/simd/arch/x86/sse2/simd/function/sqrt.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/sqrt.hpp
@@ -43,7 +43,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::double_<A0>, bs::sse_>
                          )
   {
-    BOOST_FORCEINLINE A0 operator() ( const A0 & a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( const A0 & a0) const BOOST_NOEXCEPT
     {
        return _mm_sqrt_pd(a0);
     }
@@ -55,7 +55,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::int_<A0>, bs::sse_>
                          )
   {
-    BOOST_FORCEINLINE A0 operator() ( const A0 & a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( const A0 & a0) const BOOST_NOEXCEPT
     {
       using uint_type = bd::as_integer_t<A0,unsigned>;
       return simd::bitwise_cast<A0>(sqrt( simd::bitwise_cast<uint_type>(a0)));
@@ -68,7 +68,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::int64_<A0>, bs::sse_>
                          )
   {
-    BOOST_FORCEINLINE A0 operator() ( const A0 & a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( const A0 & a0) const BOOST_NOEXCEPT
     {
       return bs::toint(bs::sqrt(bs::tofloat(a0)));
     }
@@ -80,7 +80,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::uint8_<A0>, bs::sse_>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( const A0 & a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( const A0 & a0) const BOOST_NOEXCEPT
     {
       A0 n   = plus(shift_right(a0, 4), Four<A0>());
       A0 n1  = shift_right(n+a0/n, 1);
@@ -102,7 +102,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::uint16_<A0>, bs::sse_>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( const A0 & a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( const A0 & a0) const BOOST_NOEXCEPT
     {
       auto na = is_nez(a0);
       A0 const  z1 = plus(shift_right(a0, 6), Ratio<A0, 16>());
@@ -137,7 +137,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::uint32_<A0>, bs::sse_>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( const A0 & a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( const A0 & a0) const BOOST_NOEXCEPT
     {
       auto na = is_nez(a0);
       A0 const z1 = plus(shift_right(a0, 6),    Ratio<A0,16>());
@@ -183,7 +183,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::uint64_<A0>, bs::sse_>
                           )
   {
-    BOOST_FORCEINLINE A0 operator() ( const A0 & a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE A0 operator() ( const A0 & a0) const BOOST_NOEXCEPT
     {
       return bs::touint(bs::sqrt(bs::tofloat(a0)));
     }

--- a/include/boost/simd/arch/x86/sse2/simd/function/toint.hpp
+++ b/include/boost/simd/arch/x86/sse2/simd/function/toint.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::double_<A0>, bs::sse_>
                          )
   {
-    BOOST_FORCEINLINE  bd::as_integer_t<A0>  operator() (const A0 & a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE  bd::as_integer_t<A0>  operator() (const A0 & a0) const BOOST_NOEXCEPT
     {
       bd::downgrade_t<bd::as_integer_t<A0>> out = _mm_cvttpd_epi32(a0);
       return bs::split_low(out);
@@ -40,7 +40,7 @@ namespace boost { namespace simd { namespace ext
                           , bs::pack_<bd::single_<A0>, bs::sse_>
                          )
   {
-    BOOST_FORCEINLINE bd::as_integer_t<A0> operator() ( const A0 & a0) const BOOST_NOEXCEPT
+    BOOST_MAYBEINLINE bd::as_integer_t<A0> operator() ( const A0 & a0) const BOOST_NOEXCEPT
     {
       return _mm_cvttps_epi32(a0);
     }

--- a/include/boost/simd/config.hpp
+++ b/include/boost/simd/config.hpp
@@ -24,6 +24,21 @@
 #  include <boost/simd/detail/dispatch/hierarchy/default_site.hpp>
 #endif
 
+// Conditionnal BOOST_FORCEINLINE. Some compilers (like MSVC...) does not handle properly
+// forceinlining on big functions such as `acos` or `asin` which leads to crazy
+// compilation/linking time. In that case, using a simple inline get rid of that crazyness.
+// On other compilers such as gcc/clang, forceinlining works well.
+#if defined(_MSC_VER)
+#  define BOOST_MAYBEINLINE inline
+#else
+#  define BOOST_MAYBEINLINE BOOST_FORCEINLINE
+#endif
+
+// If BOOST_SIMD_NO_MAYBEINLINE is defined, then just re-use FORCEILINE
+#if defined(BOOST_SIMD_NO_MAYBEINLINE)
+  #define BOOST_MAYBEINLINE BOOST_FORCEINLINE
+#endif
+
 // noexcept((expr))
 #define BOOST_NOEXCEPT_IF_EXPR(expr) BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT_EXPR(expr))
 


### PR DESCRIPTION
This fixes the crazy compilation/linking time for some tests with MSVC. The forceinline has been
replaced by a simple inline. This should not really impact performances because most of those
functions have a big computation time. Also, this is not possible to live with that as it takes
more than 20min to compile/link some tests... You can still force MAYBEINLINE to be used as
FORCEINLINE with BOOST_SIMD_NO_MAYBEINLINE but you will get back to those crazy times...

Close #479.