### PR TITLE
include: don't include missing header

### DIFF
--- a/include/boost/simd.hpp
+++ b/include/boost/simd.hpp
@@ -19,7 +19,6 @@
 #include <boost/simd/as.hpp>
 #include <boost/simd/meta/cardinal_of.hpp>
 #include <boost/simd/logical.hpp>
-#include <boost/simd/detail/math.hpp>
 #include <boost/simd/pack.hpp>
 
 /// Main Boost namespace


### PR DESCRIPTION
small compile fix